### PR TITLE
Improve TinyMCE and ACF editor sanitization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- `Helpers::sanitizeEditorContent()` to strip TinyMCE artifacts such as bookmark spans and bogus line breaks from editor content
+- `Helpers::getEditorAllowedHtml()` shared allow-list for ACF WYSIWYG content, permitting common editorial markup including `<span class="…">` but excluding inline styles and embedded `<script>` / `<iframe>`
+- `Helpers::isEditorContentEmpty()` to detect visually empty editor content (handles non-breaking spaces, zero-width and bidi control characters)
+- `acf/update_value/type=wysiwyg` wired to `StarterBase::sanitize_acf_editor_value()` — sanitize content on save via `wp_kses()` with the shared allow-list
+- Client-side TinyMCE sanitization on `BeforeSetContent`, `PastePreProcess`, and `GetContent` events plus `verify_html`, `invalid_elements=script,iframe`, and `paste_webkit_styles=none` in `tiny_mce_before_init`
+
+### Changed
+- `Helpers::fieldFormatter()` now strips TinyMCE artifacts from rendered `wysiwyg` values, not just during the emptiness check, while avoiding editor-specific sanitization for `textarea` to prevent destructive cleanup. Tag and attribute filtering for saved WYSIWYG content is enforced via `wp_kses()`
+
 ## [1.1.0] - 2026-04-13
 
 ### Added

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -487,6 +487,144 @@ class Helpers {
 	}
 
 	/**
+	 * Sanitize HTML content coming from an editor.
+	 *
+	 * Removes TinyMCE artifacts such as bookmark spans and bogus line breaks.
+	 * Security-sensitive tag and attribute filtering is intentionally left to
+	 * `wp_kses()` with {@see getEditorAllowedHtml()}, rather than broad regex
+	 * stripping that could corrupt visible editor content.
+	 *
+	 * @param mixed $value Raw editor value.
+	 * @return mixed Sanitized editor value.
+	 */
+	public static function sanitizeEditorContent( $value ) {
+
+		if ( ! is_string( $value ) ) {
+			return $value;
+		}
+
+		$without_bookmarks = preg_replace( '/<span[^>]*data-mce-type=(["\'])bookmark\1[^>]*>[\s\S]*?<\/span>/iu', '', $value );
+		if ( null !== $without_bookmarks ) {
+			$value = $without_bookmarks;
+		}
+		$without_bogus_breaks = preg_replace( '/<br[^>]*data-mce-bogus=(["\'])1\1[^>]*>/iu', '', $value );
+		if ( null !== $without_bogus_breaks ) {
+			$value = $without_bogus_breaks;
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Get the allowed HTML map for editor content sanitized via wp_kses().
+	 *
+	 * Keeps common editorial markup and selected attributes such as `class`,
+	 * while excluding inline styles and risky embedded content.
+	 *
+	 * @return array<string, array<string, bool>>
+	 */
+	public static function getEditorAllowedHtml() {
+		return [
+			'p' => [ 'class' => true ],
+			'br' => [],
+			'strong' => [ 'class' => true ],
+			'b' => [ 'class' => true ],
+			'em' => [ 'class' => true ],
+			'i' => [ 'class' => true ],
+			'u' => [ 'class' => true ],
+			's' => [ 'class' => true ],
+			'sub' => [ 'class' => true ],
+			'sup' => [ 'class' => true ],
+			'ul' => [ 'class' => true ],
+			'ol' => [ 'class' => true ],
+			'li' => [ 'class' => true ],
+			'h1' => [ 'class' => true ],
+			'h2' => [ 'class' => true ],
+			'h3' => [ 'class' => true ],
+			'h4' => [ 'class' => true ],
+			'h5' => [ 'class' => true ],
+			'h6' => [ 'class' => true ],
+			'blockquote' => [ 'class' => true, 'cite' => true ],
+			'hr' => [ 'class' => true ],
+			'span' => [ 'class' => true ],
+			'a' => [ 'class' => true, 'href' => true, 'rel' => true, 'title' => true ],
+			'img' => [ 'class' => true, 'src' => true, 'alt' => true, 'width' => true, 'height' => true, 'srcset' => true, 'sizes' => true, 'loading' => true ],
+			'figure' => [ 'class' => true ],
+			'figcaption' => [ 'class' => true ],
+			'code' => [ 'class' => true ],
+			'pre' => [ 'class' => true ],
+		];
+	}
+
+	/**
+	 * Check whether HTML content from an editor is visually empty.
+	 *
+	 * TinyMCE / ACF WYSIWYG may save invisible artifacts such as bookmark spans,
+	 * bogus line breaks, non-breaking spaces, or zero-width characters. This
+	 * helper removes those before performing an emptiness check.
+	 *
+	 * @param mixed $value Raw editor value.
+	 * @param bool  $is_sanitized True when TinyMCE artifacts were already removed by the caller.
+	 * @return bool True when the content is visually empty.
+	 */
+	public static function isEditorContentEmpty( $value, bool $is_sanitized = false ) {
+
+		if ( ! is_string( $value ) ) {
+			return empty( $value );
+		}
+
+		if ( ! $is_sanitized ) {
+			$value = self::sanitizeEditorContent( $value );
+		}
+
+		if ( preg_match( '/<(img|hr|video|audio|svg|canvas)\b/i', $value ) ) {
+			return false;
+		}
+
+		$plain = function_exists( 'wp_strip_all_tags' ) ? wp_strip_all_tags( $value ) : strip_tags( $value );
+		$plain = html_entity_decode( $plain, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+		$stripped_plain = preg_replace( '/[\x{00A0}\x{00AD}\x{034F}\x{061C}\x{180E}\x{200B}-\x{200F}\x{2028}-\x{202E}\x{2060}\x{2066}-\x{2069}\x{FEFF}\s]+/u', '', $plain );
+		if ( null !== $stripped_plain ) {
+			$plain = $stripped_plain;
+		}
+
+		return $plain === '';
+	}
+
+	/**
+	 * Check whether textarea-like content is visually empty without applying
+	 * editor-specific artifact sanitization.
+	 *
+	 * This only treats whitespace, non-breaking spaces, `<br>` tags, and empty
+	 * paragraph wrappers as empty. Arbitrary HTML/code examples remain intact.
+	 *
+	 * @param mixed $value Raw textarea value.
+	 * @return bool True when the content is visually empty.
+	 */
+	public static function isTextareaContentEmpty( $value ) {
+
+		if ( ! is_string( $value ) ) {
+			return empty( $value );
+		}
+
+		$normalized = html_entity_decode( $value, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+		$without_breaks = preg_replace( '/<br\s*\/?>/iu', '', $normalized );
+		if ( null !== $without_breaks ) {
+			$normalized = $without_breaks;
+		}
+		$without_empty_paragraphs = preg_replace( '/<p\b[^>]*>(?:[\x{00A0}\x{200B}-\x{200F}\x{FEFF}\s]|&nbsp;|&#160;|<br\s*\/?>)*<\/p>/iu', '', $normalized );
+		if ( null !== $without_empty_paragraphs ) {
+			$normalized = $without_empty_paragraphs;
+		}
+		$stripped_normalized = preg_replace( '/[\x{00A0}\x{200B}-\x{200F}\x{FEFF}\s]+/u', '', $normalized );
+		if ( null !== $stripped_normalized ) {
+			$normalized = $stripped_normalized;
+		}
+
+		return $normalized === '';
+	}
+
+	/**
 	 * Retrieve and format all ACF fields attached to a post, term, or options page.
 	 *
 	 * Resolves the post ID from a WP_Post / Timber post object, a term object,
@@ -536,6 +674,7 @@ class Helpers {
 		if ( ! empty( $fields ) ) {
 			foreach ( $fields as $key => $field ) {
 				$value = self::fieldFormatter( $field, $post_id, $is_preview );
+
 				if ( ! empty( $value ) ) {
 					$content[ $key ] = $value;
 				}
@@ -550,7 +689,8 @@ class Helpers {
 	 *
 	 * Dispatches to type-specific formatting logic:
 	 * - `link` → {@see formatLink()}
-	 * - `wysiwyg` / `textarea` → shortcodes expanded, bogus markup stripped
+	 * - `wysiwyg` → TinyMCE artifact cleanup, visually-empty detection, shortcodes expanded
+	 * - `textarea` → shortcodes expanded without editor-specific sanitization
 	 * - `image` → {@see formatImage()}
 	 * - `gallery` → each item formatted by type (image / file / video)
 	 * - `file` → {@see formatFile()}
@@ -584,14 +724,23 @@ class Helpers {
 
 			$field['value'] = self::formatLink( $field['value'], $post_id, $field );
 
-		} elseif ( in_array( $field['type'], [ 'wysiwyg', 'textarea' ] ) ) {
+		} elseif ( $field['type'] === 'wysiwyg' ) {
 
-			// we need to check wysiwyg fields for <br data-mce-bogus="1"> to properly check if empty
-			if ( is_string( $field['value'] ) && empty( trim( preg_replace( '/\s\s+/', ' ', strip_tags( $field['value'] ) ) ) ) ) {
+			$field['value'] = self::sanitizeEditorContent( $field['value'] );
+
+			if ( self::isEditorContentEmpty( $field['value'], true ) ) {
 				$field['value'] = '';
 			}
 
 			$field['value'] = do_shortcode( $field['value'] );
+
+		} elseif ( $field['type'] === 'textarea' ) {
+
+			if ( self::isTextareaContentEmpty( $field['value'] ) ) {
+				$field['value'] = '';
+			} else {
+				$field['value'] = do_shortcode( $field['value'] );
+			}
 
 		} elseif ( $field['type'] === 'image' ) {
 

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -192,6 +192,7 @@ class StarterBase extends Site {
 		add_action( 'admin_head', array( $this, 'hide_core_update_notifications' ), 1 );
 		add_action( 'acf/input/admin_footer', array( $this, 'acf_input_admin_footer' ) );
 		add_filter( 'tiny_mce_before_init', array( $this, 'tiny_mce_before_init' ) );
+		add_filter( 'acf/update_value/type=wysiwyg', array( $this, 'sanitize_acf_editor_value' ), 10, 1 );
 		add_filter( 'wp_get_attachment_image_attributes', array( $this, 'wp_get_attachment_image_attributes' ), 10, 2 );
 		add_filter( 'jpeg_quality', array( $this, 'jpeg_quality' ) );
 		add_filter( 'wp_editor_set_quality', array( $this, 'wp_editor_set_quality' ) );
@@ -902,6 +903,29 @@ class StarterBase extends Site {
 			</style>
 			<script>
 			(function($) {
+				function sanitizeTinyMceContent(content) {
+					if (typeof content !== 'string' || content === '') {
+						return content;
+					}
+
+					content = content.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, '');
+					content = content.replace(/<iframe\b[^>]*>[\s\S]*?<\/iframe>/gi, '');
+
+					if (typeof document === 'undefined' || !document.createElement) {
+						return content;
+					}
+
+					var template = document.createElement('template');
+					template.innerHTML = content;
+					template.content.querySelectorAll('[style]').forEach(function(element) {
+						element.removeAttribute('style');
+					});
+
+					content = template.innerHTML;
+
+					return content;
+				}
+
 				// reduce placeholder textarea height to match tinymce settings (when using delay-setting)
 				$('.acf-editor-wrap.delay textarea').css('height', '60px');
 				// (filter called before the tinyMCE instance is created)
@@ -916,6 +940,13 @@ class StarterBase extends Site {
 				ed.settings.autoresize_min_height = 60;
 				// reduce iframe's 'height' style to match tinymce settings
 				$('.acf-editor-wrap iframe').css('height', '60px');
+				['BeforeSetContent', 'PastePreProcess', 'GetContent'].forEach(function(eventName) {
+					ed.on(eventName, function(e) {
+						if (e && typeof e.content === 'string') {
+							e.content = sanitizeTinyMceContent(e.content);
+						}
+					});
+				});
 				});
 				// Compatibility with Alpine.js and Gutenberg preview
 				// https://discourse.roots.io/t/alpine-js-and-blade-acf-composer/23756/12
@@ -941,7 +972,37 @@ class StarterBase extends Site {
 		} else {
 			$mceInit['content_style'] = $styles . ' ';
 		}
+
+		$mceInit['verify_html'] = true;
+		$mceInit['invalid_elements'] = 'script,iframe';
+		$mceInit['paste_webkit_styles'] = 'none';
+
 		return $mceInit;
+	}
+
+	/**
+	 * Sanitize ACF editor values before saving them to the database.
+	 *
+	 * Hooked to `acf/update_value/type=wysiwyg`.
+	 *
+	 * @param mixed $value Raw ACF field value.
+	 * @return mixed Sanitized value, or empty string when visually empty.
+	 */
+	public function sanitize_acf_editor_value( $value ) {
+		$value = Helpers::sanitizeEditorContent( $value );
+
+		if ( ! is_string( $value ) ) {
+			return ( null === $value || false === $value ) ? '' : $value;
+		}
+
+		$allowed_html = Helpers::getEditorAllowedHtml();
+		$value = wp_kses( $value, $allowed_html );
+
+		if ( Helpers::isEditorContentEmpty( $value, true ) ) {
+			return '';
+		}
+
+		return $value;
 	}
 
 	/**

--- a/tests/Unit/Helpers/FieldFormatterTest.php
+++ b/tests/Unit/Helpers/FieldFormatterTest.php
@@ -235,6 +235,157 @@ class FieldFormatterTest extends HelpersTestCase {
 		$this->assertSame( 'Some text content', $result );
 	}
 
+	public function test_textarea_does_not_apply_editor_artifact_sanitization(): void {
+		Functions\when( 'do_shortcode' )->alias( function ( $content ) {
+			return $content;
+		} );
+
+		$field = [
+			'type'  => 'textarea',
+			'value' => '<span data-mce-type="bookmark">&#xfeff;</span><br data-mce-bogus="1">',
+		];
+
+		$result = Helpers::fieldFormatter( $field );
+
+		$this->assertSame( $field['value'], $result );
+	}
+
+	public function test_textarea_with_only_breaks_and_spaces_is_treated_as_empty(): void {
+		Functions\when( 'do_shortcode' )->alias( function ( $content ) {
+			return $content;
+		} );
+
+		$field = [
+			'type'  => 'textarea',
+			'value' => "<p>\n&nbsp;<br></p>",
+		];
+
+		$result = Helpers::fieldFormatter( $field );
+
+		$this->assertSame( '', $result );
+	}
+
+	public function test_textarea_with_empty_paragraph_attributes_is_treated_as_empty(): void {
+		Functions\when( 'do_shortcode' )->alias( function ( $content ) {
+			return $content;
+		} );
+
+		$field = [
+			'type'  => 'textarea',
+			'value' => '<p class="foo">&nbsp;<br></p>',
+		];
+
+		$result = Helpers::fieldFormatter( $field );
+
+		$this->assertSame( '', $result );
+	}
+
+	public function test_wysiwyg_with_tinymce_artifacts_is_treated_as_empty(): void {
+		Functions\when( 'do_shortcode' )->alias( function ( $content ) {
+			return $content;
+		} );
+
+		$field = [
+			'type'  => 'wysiwyg',
+			'value' => '<p><span data-mce-type="bookmark" style="overflow:hidden;line-height:0px">&#xfeff;</span><br data-mce-bogus="1"></p>',
+		];
+
+		$result = Helpers::fieldFormatter( $field );
+
+		$this->assertSame( '', $result );
+	}
+
+	public function test_wysiwyg_with_multiline_tinymce_bookmark_is_treated_as_empty(): void {
+		Functions\when( 'do_shortcode' )->alias( function ( $content ) {
+			return $content;
+		} );
+
+		$field = [
+			'type'  => 'wysiwyg',
+			'value' => "<p><span data-mce-type=\"bookmark\">\n&#xfeff;\n</span><br data-mce-bogus=\"1\"></p>",
+		];
+
+		$result = Helpers::fieldFormatter( $field );
+
+		$this->assertSame( '', $result );
+	}
+
+	public function test_wysiwyg_with_only_spaces_and_zero_width_chars_is_treated_as_empty(): void {
+		Functions\when( 'do_shortcode' )->alias( function ( $content ) {
+			return $content;
+		} );
+
+		$field = [
+			'type'  => 'wysiwyg',
+			'value' => '<p>&nbsp;' . html_entity_decode( '&#x200B;', ENT_QUOTES | ENT_HTML5, 'UTF-8' ) . '</p>',
+		];
+
+		$result = Helpers::fieldFormatter( $field );
+
+		$this->assertSame( '', $result );
+	}
+
+	public function test_wysiwyg_with_visible_text_is_not_treated_as_empty(): void {
+		Functions\when( 'do_shortcode' )->alias( function ( $content ) {
+			return $content;
+		} );
+
+		$field = [
+			'type'  => 'wysiwyg',
+			'value' => '<p>&nbsp;Ahoj</p>',
+		];
+
+		$result = Helpers::fieldFormatter( $field );
+
+		$this->assertSame( '<p>&nbsp;Ahoj</p>', $result );
+	}
+
+	public function test_wysiwyg_with_image_only_content_is_not_treated_as_empty(): void {
+		Functions\when( 'do_shortcode' )->alias( function ( $content ) {
+			return $content;
+		} );
+
+		$field = [
+			'type'  => 'wysiwyg',
+			'value' => '<figure><img src="https://example.com/a.jpg" alt=""></figure>',
+		];
+
+		$result = Helpers::fieldFormatter( $field );
+
+		$this->assertSame( $field['value'], $result );
+	}
+
+	public function test_wysiwyg_keeps_literal_style_text_in_visible_content(): void {
+		Functions\when( 'do_shortcode' )->alias( function ( $content ) {
+			return $content;
+		} );
+
+		$field = [
+			'type'  => 'wysiwyg',
+			'value' => '<p>Use <code>style="color:red"</code> in this example</p>',
+		];
+
+		$result = Helpers::fieldFormatter( $field );
+
+		$this->assertSame( $field['value'], $result );
+	}
+
+	public function test_wysiwyg_with_invalid_utf8_does_not_fail_empty_check(): void {
+		Functions\when( 'do_shortcode' )->alias( function ( $content ) {
+			return $content;
+		} );
+
+		$invalid_utf8 = "<p>\xC3\x28</p>";
+		$field = [
+			'type'  => 'wysiwyg',
+			'value' => $invalid_utf8,
+		];
+
+		$result = Helpers::fieldFormatter( $field );
+
+		$this->assertSame( $invalid_utf8, $result );
+	}
+
 	// --- Post Object ---
 
 	public function test_post_object_cf7_render(): void {

--- a/tests/Unit/Helpers/FormatFieldsTest.php
+++ b/tests/Unit/Helpers/FormatFieldsTest.php
@@ -139,6 +139,74 @@ class FormatFieldsTest extends HelpersTestCase {
 		$this->assertArrayNotHasKey( 'empty', $result );
 	}
 
+	public function test_wysiwyg_tinymce_artifacts_excluded_automatically(): void {
+		Functions\when( 'do_shortcode' )->alias( function ( $content ) {
+			return $content;
+		} );
+		Functions\when( 'get_field_objects' )->justReturn( [
+			'perex' => [
+				'type'  => 'wysiwyg',
+				'value' => '<p><span data-mce-type="bookmark">&#xfeff;</span><br data-mce-bogus="1"></p>',
+			],
+			'title' => [ 'type' => 'text', 'value' => 'Present' ],
+		] );
+
+		$result = Helpers::formatFields( (object) [ 'ID' => 1 ] );
+
+		$this->assertArrayHasKey( 'title', $result );
+		$this->assertArrayNotHasKey( 'perex', $result );
+	}
+
+	public function test_textarea_artifact_like_content_is_not_excluded_automatically(): void {
+		Functions\when( 'do_shortcode' )->alias( function ( $content ) {
+			return $content;
+		} );
+		Functions\when( 'get_field_objects' )->justReturn( [
+			'code_sample' => [
+				'type'  => 'textarea',
+				'value' => '<span data-mce-type="bookmark">&#xfeff;</span><br data-mce-bogus="1">',
+			],
+		] );
+
+		$result = Helpers::formatFields( (object) [ 'ID' => 1 ] );
+
+		$this->assertArrayHasKey( 'code_sample', $result );
+		$this->assertSame( '<span data-mce-type="bookmark">&#xfeff;</span><br data-mce-bogus="1">', $result['code_sample'] );
+	}
+
+	public function test_textarea_with_only_breaks_and_spaces_is_excluded(): void {
+		Functions\when( 'do_shortcode' )->alias( function ( $content ) {
+			return $content;
+		} );
+		Functions\when( 'get_field_objects' )->justReturn( [
+			'notes' => [
+				'type'  => 'textarea',
+				'value' => "<p>\n&nbsp;<br></p>",
+			],
+		] );
+
+		$result = Helpers::formatFields( (object) [ 'ID' => 1 ] );
+
+		$this->assertArrayNotHasKey( 'notes', $result );
+	}
+
+	public function test_wysiwyg_shortcode_markup_output_is_not_excluded(): void {
+		Functions\when( 'do_shortcode' )->alias( function ( $content ) {
+			return str_replace( '[image-only]', '<img src="https://example.com/a.jpg" alt="">', $content );
+		} );
+		Functions\when( 'get_field_objects' )->justReturn( [
+			'gallery' => [
+				'type'  => 'wysiwyg',
+				'value' => '[image-only]',
+			],
+		] );
+
+		$result = Helpers::formatFields( (object) [ 'ID' => 1 ] );
+
+		$this->assertArrayHasKey( 'gallery', $result );
+		$this->assertSame( '<img src="https://example.com/a.jpg" alt="">', $result['gallery'] );
+	}
+
 	public function test_with_string_option_singular(): void {
 		Functions\when( 'get_field_objects' )->alias( function ( $id ) {
 			if ( $id === 'option' ) {

--- a/tests/Unit/StarterBase/SimpleReturnValuesTest.php
+++ b/tests/Unit/StarterBase/SimpleReturnValuesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\StarterBase;
 
+use Brain\Monkey\Functions;
 use Tests\Unit\StarterBaseTestCase;
 
 class SimpleReturnValuesTest extends StarterBaseTestCase {
@@ -52,5 +53,140 @@ class SimpleReturnValuesTest extends StarterBaseTestCase {
 	public function test_theme_page_templates_passes_through(): void {
 		$templates = [ 'template-full.php' => 'Full Width' ];
 		$this->assertSame( $templates, $this->base->theme_page_templates( $templates ) );
+	}
+
+	public function test_tiny_mce_before_init_adds_mild_cleanup_rules(): void {
+		$result = $this->base->tiny_mce_before_init( [] );
+
+		$this->assertStringContainsString( 'body.mce-content-body', $result['content_style'] );
+		$this->assertTrue( $result['verify_html'] );
+		$this->assertSame( 'script,iframe', $result['invalid_elements'] );
+		$this->assertSame( 'none', $result['paste_webkit_styles'] );
+		$this->assertArrayNotHasKey( 'paste_remove_spans', $result );
+		$this->assertArrayNotHasKey( 'valid_elements', $result );
+	}
+
+	public function test_acf_input_admin_footer_prints_tinymce_sanitization_script(): void {
+		ob_start();
+		$this->base->acf_input_admin_footer();
+		$output = (string) ob_get_clean();
+
+		$this->assertStringContainsString( 'sanitizeTinyMceContent', $output );
+		$this->assertStringContainsString( 'BeforeSetContent', $output );
+		$this->assertStringContainsString( 'PastePreProcess', $output );
+		$this->assertStringContainsString( 'GetContent', $output );
+		$this->assertStringContainsString( '<script', $output );
+		$this->assertStringContainsString( '<iframe', $output );
+		$this->assertStringContainsString( 'style', $output );
+		// spans are intentionally allowed in editor output, so the JS must not strip them
+		$this->assertStringNotContainsString( 'span\\b', $output );
+		$this->assertStringNotContainsString( 'class=', $output );
+	}
+
+	public function test_sanitize_acf_editor_value_removes_unwanted_markup_before_save(): void {
+		$captured_allowed = null;
+		Functions\when( 'wp_kses' )->alias( function ( $value, $allowed_html ) use ( &$captured_allowed ) {
+			$captured_allowed = $allowed_html;
+			// Simulate wp_kses: strip disallowed tags entirely. This verifies the
+			// pipeline relies on wp_kses for security, not a broad regex pre-pass.
+			$value = preg_replace( '/<script\b[^>]*>[\s\S]*?<\/script>/i', '', $value );
+			$value = preg_replace( '/<iframe\b[^>]*>[\s\S]*?<\/iframe>/i', '', $value );
+			$value = preg_replace( '/\sstyle=(["\']).*?\1/i', '', $value );
+			return $value;
+		} );
+
+		$value = '<p class="lead"><span class="x" style="color:red">Text</span><script>alert(1)</script><iframe src="https://example.com"></iframe></p>';
+
+		$result = $this->base->sanitize_acf_editor_value( $value );
+
+		// Allow-list shape: span is permitted with class, script/iframe are not,
+		// inline style is not a permitted attribute on any element.
+		$this->assertIsArray( $captured_allowed );
+		$this->assertArrayHasKey( 'p', $captured_allowed );
+		$this->assertSame( [ 'class' => true ], $captured_allowed['p'] );
+		$this->assertArrayHasKey( 'a', $captured_allowed );
+		$this->assertArrayHasKey( 'img', $captured_allowed );
+		$this->assertArrayHasKey( 'span', $captured_allowed );
+		$this->assertSame( [ 'class' => true ], $captured_allowed['span'] );
+		$this->assertArrayNotHasKey( 'target', $captured_allowed['a'] );
+		$this->assertArrayNotHasKey( 'iframe', $captured_allowed );
+		$this->assertArrayNotHasKey( 'script', $captured_allowed );
+		$this->assertArrayNotHasKey( 'style', $captured_allowed['p'] );
+
+		// The stubbed wp_kses strips disallowed tags and style attributes.
+		// Legitimate <span class="..."> is preserved end-to-end.
+		$this->assertSame( '<p class="lead"><span class="x">Text</span></p>', $result );
+	}
+
+	public function test_sanitize_acf_editor_value_keeps_literal_style_text(): void {
+		Functions\when( 'wp_kses' )->alias( function ( $value, $allowed_html ) {
+			return $value;
+		} );
+
+		$value = '<p>Use <code>style="color:red"</code> in this example</p>';
+
+		$result = $this->base->sanitize_acf_editor_value( $value );
+
+		$this->assertSame( $value, $result );
+	}
+
+	public function test_sanitize_acf_editor_value_returns_empty_string_for_visually_empty_content(): void {
+		Functions\when( 'wp_kses' )->alias( function ( $value, $allowed_html ) {
+			return $value;
+		} );
+
+		$value = '<p><span data-mce-type="bookmark">&#xfeff;</span><br data-mce-bogus="1">&nbsp;</p>';
+
+		$result = $this->base->sanitize_acf_editor_value( $value );
+
+		$this->assertSame( '', $result );
+	}
+
+	public function test_sanitize_acf_editor_value_keeps_allowed_markup_and_class(): void {
+		Functions\when( 'wp_kses' )->alias( function ( $value, $allowed_html ) {
+			return $value;
+		} );
+
+		$value = '<p class="lead"><a class="btn" href="https://example.com" rel="noopener">Link</a> <strong class="accent">Text</strong></p>';
+
+		$result = $this->base->sanitize_acf_editor_value( $value );
+
+		$this->assertSame( $value, $result );
+	}
+
+	public function test_sanitize_acf_editor_value_keeps_image_only_content(): void {
+		Functions\when( 'wp_kses' )->alias( function ( $value, $allowed_html ) {
+			return $value;
+		} );
+
+		$value = '<figure><img src="https://example.com/a.jpg" alt=""></figure>';
+
+		$result = $this->base->sanitize_acf_editor_value( $value );
+
+		$this->assertSame( $value, $result );
+	}
+
+	public function test_sanitize_acf_editor_value_preserves_spans_with_class(): void {
+		// Regression test: legitimate <span class="..."> from editors must survive
+		// both the regex pre-pass and the wp_kses allow-list.
+		Functions\when( 'wp_kses' )->alias( function ( $value, $allowed_html ) {
+			return $value;
+		} );
+
+		$value = '<p>Text with <span class="highlight">highlighted</span> word.</p>';
+
+		$result = $this->base->sanitize_acf_editor_value( $value );
+
+		$this->assertSame( $value, $result );
+	}
+
+	public function test_sanitize_acf_editor_value_returns_empty_string_for_null_and_false(): void {
+		$this->assertSame( '', $this->base->sanitize_acf_editor_value( null ) );
+		$this->assertSame( '', $this->base->sanitize_acf_editor_value( false ) );
+	}
+
+	public function test_sanitize_acf_editor_value_returns_non_string_values_as_is(): void {
+		$this->assertSame( [ 'x' => 1 ], $this->base->sanitize_acf_editor_value( [ 'x' => 1 ] ) );
+		$this->assertSame( 123, $this->base->sanitize_acf_editor_value( 123 ) );
 	}
 }


### PR DESCRIPTION
## Summary
- add TinyMCE-side cleanup for unwanted editor markup and inline styles
- sanitize saved WYSIWYG content with a shared helper plus a WordPress allowlist via wp_kses
- keep render-time empty-content detection for TinyMCE artifacts while avoiding destructive sanitization for generic textarea fields

## Testing
- vendor/bin/phpunit tests/Unit/StarterBase/SimpleReturnValuesTest.php tests/Unit/Helpers/FormatFieldsTest.php tests/Unit/Helpers/FieldFormatterTest.php