### PR TITLE
feat: add |resizer_aspect Twig filter for orientation-aware cropping (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- `|resizer_aspect` Twig filter — aspect-aware sibling of `|resizer` that classifies a source image's orientation (`landscape` / `portrait` / `square`, ±10 % tolerance around 1:1) and routes to a per-orientation tuple set. Caller passes one map `{landscape: [...], portrait: [...], square: [...]}` instead of branching on `image.width >= image.height` in Twig. Missing-metadata, non-numeric, or zero-dimension sources fall back to `landscape`. Source-element selection mirrors `|resizer` — the last entry of the image list wins. Backed by `Parisek\TimberKit\Resizer::resizerAspect()` (instance method, the filter callback) and `Resizer::classifyAspect()` (static utility, public for callers needing the bucket without resizing). When the matched orientation bucket has no tuples the helper falls through to `orientations.landscape`; if that's also empty / absent the source is returned unchanged. Implements parisek/timber-kit#16.
+- `timber_kit_resizer_aspect_tolerance` WordPress filter — overrides the 0.1 default tolerance band used by `Resizer::classifyAspect()`. Returning a smaller value (e.g. `0.05`) tightens the square band, returning a larger value (e.g. `0.2`) loosens it.
+
 ## [1.5.0] - 2026-05-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,7 +31,20 @@ Static methods for formatting ACF data into clean arrays for Twig templates:
 
 ### Resizer
 
-Image resizing via [Spatie/Image](https://github.com/spatie/image). AVIF output, responsive variants with breakpoints, crop positions, and cache management. Used as a Twig filter.
+Image resizing via [Spatie/Image](https://github.com/spatie/image). AVIF output, responsive variants with breakpoints, crop positions, and cache management. Exposed as two Twig filters:
+
+- `|resizer( ...$variants )` — caller passes the variant tuples directly.
+- `|resizer_aspect({ landscape, portrait, square })` — orientation-aware sibling. Classifies the source image's aspect (`landscape` / `portrait` / `square`, ±10 % tolerance around 1:1, overridable via the `timber_kit_resizer_aspect_tolerance` WP filter) and dispatches to the matching tuple set. Missing-metadata / zero-dimension sources fall back to `landscape`; an empty matched bucket falls through to the `landscape` tuples.
+
+  ```twig
+  {{ component_picture({
+      image: item.image|resizer_aspect({
+          landscape: [['960', '720', '1280', 'crop'], ['480', '360', '', 'crop']],
+          portrait:  [['720', '960', '1280', 'crop'], ['360', '480', '', 'crop']],
+          square:    [['800', '800', '1280', 'crop'], ['400', '400', '', 'crop']],
+      }),
+  }) }}
+  ```
 
 ### DevMediaProxy
 
@@ -200,6 +213,7 @@ Available hooks:
 - `timber_kit_resizer_probe_remote_variants` — enable/disable remote variant probing, default `true`
 - `timber_kit_resizer_remote_variant_probe_timeout` — HTTP timeout for variant probes, default `2.0`
 - `timber_kit_resizer_remote_variant_probe_limit` — max remote variant probes per request, default `50`
+- `timber_kit_resizer_aspect_tolerance` — tolerance band around 1:1 used by `Resizer::classifyAspect()` to decide whether a source qualifies as `square`, default `0.1`. Returning a smaller value (e.g. `0.05`) tightens the square band; returning a larger value (e.g. `0.2`) loosens it.
 
 ### WPForms Config Bridge
 

--- a/src/Resizer.php
+++ b/src/Resizer.php
@@ -751,7 +751,14 @@ class Resizer {
 	 */
 	public function resizerAspect( $image, array $orientations ): array {
 		$bucket = self::classifyAspect( $image );
-		$tuples = $orientations[ $bucket ] ?? $orientations['landscape'] ?? [];
+
+		// Pick the matched bucket's tuples when present AND non-empty;
+		// otherwise fall through to 'landscape'. `??` alone would treat
+		// `portrait => []` as "set" and skip the fallback — the caller's
+		// intent for an empty list is "I haven't filled this bucket yet",
+		// same semantic as a missing key.
+		$matched = $orientations[ $bucket ] ?? null;
+		$tuples = ( is_array( $matched ) && ! empty( $matched ) ) ? $matched : ( $orientations['landscape'] ?? [] );
 
 		if ( empty( $tuples ) || ! is_array( $tuples ) ) {
 			return is_array( $image ) ? $image : [];

--- a/src/Resizer.php
+++ b/src/Resizer.php
@@ -700,13 +700,16 @@ class Resizer {
 		}
 
 		$tolerance = (float) apply_filters( 'timber_kit_resizer_aspect_tolerance', self::DEFAULT_ASPECT_TOLERANCE );
-		$aspect = $width / $height;
 
-		if ( abs( $aspect - 1.0 ) <= $tolerance ) {
+		// Compare in dimension space instead of `abs($width/$height - 1.0) <= $tol`:
+		// the division-based form trips IEEE-754 representation noise at the
+		// inclusive boundary (1100×1000 → 1.1000...0001, which fails `<= 0.1`).
+		// Algebraically equivalent for positive dimensions, boundary-stable here.
+		if ( abs( $width - $height ) <= $tolerance * $height ) {
 			return 'square';
 		}
 
-		return $aspect > 1.0 ? 'landscape' : 'portrait';
+		return $width > $height ? 'landscape' : 'portrait';
 	}
 
 	/**

--- a/src/Resizer.php
+++ b/src/Resizer.php
@@ -22,10 +22,19 @@ use Spatie\Image\Enums\Fit;
  * suitable for `<picture>` / `<img>` markup. Supports standard positional
  * cropping via Spatie/Image and entropy-based smart cropping via GD/Imagick.
  *
- * All defaults (format, quality, cache path, force-regenerate) are
- * overridable through WordPress filters prefixed with `timber_kit_resizer_`.
+ * All defaults (format, quality, cache path, force-regenerate, aspect-classification
+ * tolerance) are overridable through WordPress filters prefixed with `timber_kit_resizer_`.
  */
 class Resizer {
+
+	/**
+	 * Default tolerance band for square aspect classification.
+	 *
+	 * A source image whose `width / height` ratio falls within `[1 - TOL, 1 + TOL]`
+	 * is classified as 'square'. The 0.1 default covers most editor uploads that
+	 * are intended to be square but have minor fuzz (1020×1000, 1050×950, etc.).
+	 */
+	private const float DEFAULT_ASPECT_TOLERANCE = 0.1;
 
 	/**
 	 * Default image quality (0-100)
@@ -632,5 +641,122 @@ class Resizer {
 		$images[] = $default_image;
 
 		return $images;
+	}
+
+	/**
+	 * Classify a source image's aspect orientation.
+	 *
+	 * Returns one of three buckets based on the `width / height` ratio of the
+	 * source image, with a tolerance band around 1:1 controlling the 'square'
+	 * classification:
+	 *
+	 *   - `aspect > 1 + tolerance` → 'landscape'
+	 *   - `aspect < 1 - tolerance` → 'portrait'
+	 *   - within ± tolerance        → 'square'
+	 *
+	 * Missing or non-numeric width/height in the image metadata falls back to
+	 * 'landscape' so legacy uploads (pre-ACF imports, SVG without intrinsic
+	 * dimensions) preserve the kit's historical wide-crop default — components
+	 * that adopt `resizerAspect()` don't silently shift their rendering for
+	 * legacy assets.
+	 *
+	 * The source element is picked the same way `resizer()` picks its source:
+	 * the LAST entry of a multi-image array (per `Helpers::formatImage`'s
+	 * convention that the last item is the original / largest variant). This
+	 * keeps classification aligned with what the cropping pipeline will
+	 * actually operate on.
+	 *
+	 * WordPress filter:
+	 *
+	 *   - `timber_kit_resizer_aspect_tolerance` — float, default 0.1.
+	 *     Tighten with `add_filter( 'timber_kit_resizer_aspect_tolerance', fn() => 0.05 );`
+	 *     for design-sensitive components that shouldn't classify near-square
+	 *     sources as 'square'.
+	 *
+	 * @param array|mixed $image Image data — array from Helpers::formatImage()
+	 *                           (multiple variants, last is the original) or a
+	 *                           single image dict.
+	 * @return string One of 'landscape', 'portrait', 'square'.
+	 */
+	public static function classifyAspect( $image ): string {
+		if ( ! is_array( $image ) || empty( $image ) ) {
+			return 'landscape';
+		}
+
+		// Mirror resizer()'s source selection — the last entry of a multi-
+		// variant array is the original. Falls through to treating the input
+		// as a single image dict when there's no integer-indexed 0 key.
+		$source = isset( $image[0] ) ? end( $image ) : $image;
+
+		if ( ! is_array( $source ) ) {
+			return 'landscape';
+		}
+
+		$width = (float) ( $source['width'] ?? 0 );
+		$height = (float) ( $source['height'] ?? 0 );
+
+		if ( $width <= 0 || $height <= 0 ) {
+			return 'landscape';
+		}
+
+		$tolerance = (float) apply_filters( 'timber_kit_resizer_aspect_tolerance', self::DEFAULT_ASPECT_TOLERANCE );
+		$aspect = $width / $height;
+
+		if ( abs( $aspect - 1.0 ) <= $tolerance ) {
+			return 'square';
+		}
+
+		return $aspect > 1.0 ? 'landscape' : 'portrait';
+	}
+
+	/**
+	 * Aspect-aware variant of `resizer()`.
+	 *
+	 * Classifies the source image's orientation (via `classifyAspect()`),
+	 * picks the matching tuple set from `$orientations`, and delegates to
+	 * `resizer()`. Callers pass three named tuple sets keyed by orientation:
+	 *
+	 * ```twig
+	 * item.image|resizer_aspect({
+	 *     landscape: [['960', '720', '1280', 'crop'], …],
+	 *     portrait:  [['720', '960', '1280', 'crop'], …],
+	 *     square:    [['800', '800', '1280', 'crop'], …],
+	 * })
+	 * ```
+	 *
+	 * When the classified bucket's tuples are missing, falls back to the
+	 * 'landscape' tuples — same fallback policy as `classifyAspect()` itself.
+	 * If 'landscape' is also missing (no usable tuple set at all), returns
+	 * the image array unchanged so the caller still has something to render
+	 * rather than crashing with an empty `<picture>`.
+	 *
+	 * Composes naturally with `merge_resizer()` for art-direction layers —
+	 * each layer's source is classified independently:
+	 *
+	 * ```twig
+	 * merge_resizer(
+	 *     item.image|resizer_aspect({ landscape: […], portrait: […], square: […] }),
+	 *     item.image_mobile|resizer_aspect({ landscape: […], portrait: […], square: […] }),
+	 * )
+	 * ```
+	 *
+	 * @param array|mixed $image        Image data (same shape as `resizer()`).
+	 * @param array       $orientations Map keyed by 'landscape' / 'portrait' /
+	 *                                   'square'. Each value is a list of
+	 *                                   variant spec arrays (`[w, h, media,
+	 *                                   image_style, quality]`) — the same
+	 *                                   tuple shape `resizer()` consumes.
+	 * @return array Processed image variants matching the source orientation,
+	 *               or the original image array if no usable tuples were found.
+	 */
+	public function resizerAspect( $image, array $orientations ): array {
+		$bucket = self::classifyAspect( $image );
+		$tuples = $orientations[ $bucket ] ?? $orientations['landscape'] ?? [];
+
+		if ( empty( $tuples ) || ! is_array( $tuples ) ) {
+			return is_array( $image ) ? $image : [];
+		}
+
+		return $this->resizer( $image, $tuples );
 	}
 }

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -627,6 +627,15 @@ class StarterBase extends Site {
 			$resizer = new Resizer();
 			return $resizer->resizer( $image, $variants );
 		} ) );
+		// Aspect-aware sibling of `|resizer`. Classifies source orientation
+		// (landscape / portrait / square with ±10 % tolerance, overridable
+		// via the `timber_kit_resizer_aspect_tolerance` filter) and dispatches
+		// the matching tuple set from the orientation map. See Resizer::classifyAspect
+		// and Resizer::resizerAspect for the full contract.
+		$twig->addFilter( new TwigFilter( 'resizer_aspect', function ( $image, array $orientations ) {
+			$resizer = new Resizer();
+			return $resizer->resizerAspect( $image, $orientations );
+		} ) );
 		$twig->addFunction( new TwigFunction( 'component_*', function ( Environment $env, $context, $template_name, $content = [] ) {
 			try {
 				$template_name = str_replace( '_', '-', $template_name );

--- a/tests/Unit/Resizer/ClassifyAspectTest.php
+++ b/tests/Unit/Resizer/ClassifyAspectTest.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Resizer;
+
+use Brain\Monkey\Functions;
+use Parisek\TimberKit\Resizer;
+use Tests\Unit\ResizerTestCase;
+
+/**
+ * Coverage for `Resizer::classifyAspect()` and `Resizer::resizerAspect()` —
+ * orientation classification (landscape / portrait / square) with tolerance,
+ * missing-metadata fallback, and dispatch into the right tuple set.
+ *
+ * Lives in its own file to keep the existing `ResizerPublicApiTest` focused
+ * on the pre-existing `resizer()` API surface.
+ */
+class ClassifyAspectTest extends ResizerTestCase {
+
+	/**
+	 * Mock `apply_filters` to either return the default (most tests) or override
+	 * a specific filter name. Keeps each test's setup self-contained — no
+	 * cross-test state leakage via Brain Monkey's global filter registry.
+	 *
+	 * @param array<string, mixed> $overrides Filter name → forced return value.
+	 */
+	private function mockFilters( array $overrides = [] ): void {
+		Functions\when( 'apply_filters' )->alias( function ( $filter, $default, ...$args ) use ( $overrides ) {
+			unset( $args );
+			return $overrides[ $filter ] ?? $default;
+		} );
+	}
+
+	// ------------------------------------------------------------------
+	// Landscape classification
+	// ------------------------------------------------------------------
+
+	public function test_classifies_16_9_as_landscape(): void {
+		$this->mockFilters();
+		$image = [ [ 'src' => '/x.jpg', 'width' => 1920, 'height' => 1080 ] ];
+		$this->assertSame( 'landscape', Resizer::classifyAspect( $image ) );
+	}
+
+	public function test_classifies_4_3_as_landscape(): void {
+		$this->mockFilters();
+		$image = [ [ 'src' => '/x.jpg', 'width' => 1200, 'height' => 900 ] ];
+		$this->assertSame( 'landscape', Resizer::classifyAspect( $image ) );
+	}
+
+	public function test_classifies_just_outside_square_band_as_landscape(): void {
+		// Aspect = 1.11 → above 1 + 0.1 tolerance band → landscape
+		$this->mockFilters();
+		$image = [ [ 'src' => '/x.jpg', 'width' => 1110, 'height' => 1000 ] ];
+		$this->assertSame( 'landscape', Resizer::classifyAspect( $image ) );
+	}
+
+	// ------------------------------------------------------------------
+	// Portrait classification
+	// ------------------------------------------------------------------
+
+	public function test_classifies_9_16_as_portrait(): void {
+		$this->mockFilters();
+		$image = [ [ 'src' => '/x.jpg', 'width' => 1080, 'height' => 1920 ] ];
+		$this->assertSame( 'portrait', Resizer::classifyAspect( $image ) );
+	}
+
+	public function test_classifies_3_4_as_portrait(): void {
+		$this->mockFilters();
+		$image = [ [ 'src' => '/x.jpg', 'width' => 900, 'height' => 1200 ] ];
+		$this->assertSame( 'portrait', Resizer::classifyAspect( $image ) );
+	}
+
+	public function test_classifies_just_outside_square_band_as_portrait(): void {
+		// Aspect = 0.892 → distance 0.108 > 0.1 tolerance → portrait
+		// (At 1000×1110 the distance is 0.0991, still inside the band; pick a
+		// pair clearly past 10 % to avoid floating-point boundary noise.)
+		$this->mockFilters();
+		$image = [ [ 'src' => '/x.jpg', 'width' => 1000, 'height' => 1120 ] ];
+		$this->assertSame( 'portrait', Resizer::classifyAspect( $image ) );
+	}
+
+	// ------------------------------------------------------------------
+	// Square classification (within ±10 % tolerance)
+	// ------------------------------------------------------------------
+
+	public function test_classifies_exact_square_as_square(): void {
+		$this->mockFilters();
+		$image = [ [ 'src' => '/x.jpg', 'width' => 1000, 'height' => 1000 ] ];
+		$this->assertSame( 'square', Resizer::classifyAspect( $image ) );
+	}
+
+	public function test_classifies_slightly_wide_as_square(): void {
+		// Aspect = 1.05 → inside tolerance band → square
+		$this->mockFilters();
+		$image = [ [ 'src' => '/x.jpg', 'width' => 1050, 'height' => 1000 ] ];
+		$this->assertSame( 'square', Resizer::classifyAspect( $image ) );
+	}
+
+	public function test_classifies_slightly_tall_as_square(): void {
+		// Aspect = 0.952 → inside tolerance band → square
+		$this->mockFilters();
+		$image = [ [ 'src' => '/x.jpg', 'width' => 1000, 'height' => 1050 ] ];
+		$this->assertSame( 'square', Resizer::classifyAspect( $image ) );
+	}
+
+	public function test_classifies_upper_boundary_as_square(): void {
+		// Aspect = 1.099 → clearly inside the 0.1 tolerance band → square.
+		// (Exact 1100×1000 = 1.1 lands on the boundary where IEEE-754 noise
+		// makes `abs(1.1 - 1.0) <= 0.1` flip false; pick a fixture inside.)
+		$this->mockFilters();
+		$image = [ [ 'src' => '/x.jpg', 'width' => 1099, 'height' => 1000 ] ];
+		$this->assertSame( 'square', Resizer::classifyAspect( $image ) );
+	}
+
+	// ------------------------------------------------------------------
+	// Tolerance filter override
+	// ------------------------------------------------------------------
+
+	public function test_tolerance_filter_can_tighten_square_band(): void {
+		// With tolerance 0.05, aspect 1.07 falls OUTSIDE the band → landscape.
+		// (Same image at the default 0.1 tolerance would classify as square.)
+		$this->mockFilters( [ 'timber_kit_resizer_aspect_tolerance' => 0.05 ] );
+		$image = [ [ 'src' => '/x.jpg', 'width' => 1070, 'height' => 1000 ] ];
+		$this->assertSame( 'landscape', Resizer::classifyAspect( $image ) );
+	}
+
+	public function test_tolerance_filter_can_loosen_square_band(): void {
+		// With tolerance 0.2, aspect 1.15 falls INSIDE the band → square.
+		// (Same image at the default 0.1 tolerance would classify as landscape.)
+		$this->mockFilters( [ 'timber_kit_resizer_aspect_tolerance' => 0.2 ] );
+		$image = [ [ 'src' => '/x.jpg', 'width' => 1150, 'height' => 1000 ] ];
+		$this->assertSame( 'square', Resizer::classifyAspect( $image ) );
+	}
+
+	// ------------------------------------------------------------------
+	// Missing-metadata fallback → landscape
+	// ------------------------------------------------------------------
+
+	public function test_empty_array_falls_back_to_landscape(): void {
+		$this->mockFilters();
+		$this->assertSame( 'landscape', Resizer::classifyAspect( [] ) );
+	}
+
+	public function test_non_array_input_falls_back_to_landscape(): void {
+		$this->mockFilters();
+		$this->assertSame( 'landscape', Resizer::classifyAspect( null ) );
+		$this->assertSame( 'landscape', Resizer::classifyAspect( 'string-not-array' ) );
+	}
+
+	public function test_missing_width_falls_back_to_landscape(): void {
+		$this->mockFilters();
+		$image = [ [ 'src' => '/x.jpg', 'height' => 1000 ] ];
+		$this->assertSame( 'landscape', Resizer::classifyAspect( $image ) );
+	}
+
+	public function test_missing_height_falls_back_to_landscape(): void {
+		$this->mockFilters();
+		$image = [ [ 'src' => '/x.jpg', 'width' => 1000 ] ];
+		$this->assertSame( 'landscape', Resizer::classifyAspect( $image ) );
+	}
+
+	public function test_zero_dimensions_fall_back_to_landscape(): void {
+		$this->mockFilters();
+		$image = [ [ 'src' => '/x.jpg', 'width' => 0, 'height' => 0 ] ];
+		$this->assertSame( 'landscape', Resizer::classifyAspect( $image ) );
+	}
+
+	public function test_non_numeric_dimensions_fall_back_to_landscape(): void {
+		// (float) cast of a non-numeric string is 0.0, which trips the
+		// $width <= 0 || $height <= 0 guard → landscape.
+		$this->mockFilters();
+		$image = [ [ 'src' => '/x.jpg', 'width' => 'invalid', 'height' => 'invalid' ] ];
+		$this->assertSame( 'landscape', Resizer::classifyAspect( $image ) );
+	}
+
+	// ------------------------------------------------------------------
+	// Source-element selection — last entry wins (mirrors `resizer()`)
+	// ------------------------------------------------------------------
+
+	public function test_uses_last_entry_when_array_has_multiple_variants(): void {
+		// First entry is a portrait thumbnail, last is the landscape original —
+		// classification should pick the original (last), matching how
+		// `resizer()` picks its source via `end($image)`.
+		$this->mockFilters();
+		$image = [
+			[ 'src' => '/thumb.jpg', 'width' => 100, 'height' => 200 ],   // portrait thumbnail
+			[ 'src' => '/full.jpg', 'width' => 1920, 'height' => 1080 ], // landscape original
+		];
+		$this->assertSame( 'landscape', Resizer::classifyAspect( $image ) );
+	}
+
+	public function test_accepts_single_image_dict_as_input(): void {
+		// Defensive — some callers may pass a single image dict instead of
+		// the formatImage()-style array of dicts. classifyAspect should
+		// handle both shapes.
+		$this->mockFilters();
+		$image = [ 'src' => '/x.jpg', 'width' => 1080, 'height' => 1920 ];
+		// Note: the function detects array-of-dicts by `isset($image[0])`.
+		// A single dict has no [0] index, so it falls through the else branch
+		// and uses the dict directly.
+		$this->assertSame( 'portrait', Resizer::classifyAspect( $image ) );
+	}
+
+	// ------------------------------------------------------------------
+	// resizerAspect() dispatch — bucket → tuples
+	// ------------------------------------------------------------------
+
+	public function test_resizer_aspect_returns_image_when_orientations_empty(): void {
+		$this->mockFilters();
+		$resizer = $this->createResizer();
+		$image = [ [ 'src' => '/x.jpg', 'width' => 1920, 'height' => 1080 ] ];
+		$result = $resizer->resizerAspect( $image, [] );
+		$this->assertSame( $image, $result );
+	}
+
+	public function test_resizer_aspect_returns_empty_array_when_image_is_non_array(): void {
+		$this->mockFilters();
+		$resizer = $this->createResizer();
+		$result = $resizer->resizerAspect( null, [ 'landscape' => [ [ '960', '720', '', 'crop' ] ] ] );
+		$this->assertSame( [], $result );
+	}
+
+	public function test_resizer_aspect_returns_image_when_matched_bucket_is_empty(): void {
+		// Portrait source classifies as 'portrait'; the orientations map
+		// provides an empty 'portrait' list and no 'landscape' fallback.
+		// Both branches yield empty tuples, so the helper short-circuits
+		// before hitting the real resizer() (which would touch the filesystem).
+		$this->mockFilters();
+		$resizer = $this->createResizer();
+		$image = [ [ 'src' => '/x.jpg', 'width' => 1080, 'height' => 1920 ] ];
+		$result = $resizer->resizerAspect( $image, [ 'portrait' => [] ] );
+		$this->assertSame( $image, $result );
+	}
+
+	public function test_resizer_aspect_returns_image_when_only_other_bucket_is_empty(): void {
+		// Landscape source classifies as 'landscape'; orientations map only
+		// holds an empty 'landscape' entry. Bucket matches but tuples are
+		// empty → passthrough without hitting resizer().
+		$this->mockFilters();
+		$resizer = $this->createResizer();
+		$image = [ [ 'src' => '/x.jpg', 'width' => 1920, 'height' => 1080 ] ];
+		$result = $resizer->resizerAspect( $image, [ 'landscape' => [] ] );
+		$this->assertSame( $image, $result );
+	}
+}

--- a/tests/Unit/Resizer/ClassifyAspectTest.php
+++ b/tests/Unit/Resizer/ClassifyAspectTest.php
@@ -243,4 +243,32 @@ class ClassifyAspectTest extends ResizerTestCase {
 		$result = $resizer->resizerAspect( $image, [ 'landscape' => [] ] );
 		$this->assertSame( $image, $result );
 	}
+
+	public function test_resizer_aspect_falls_back_to_landscape_when_matched_bucket_is_empty_array(): void {
+		// Regression for the `??`-vs-empty bug: portrait source classifies
+		// as 'portrait', the orientations map has `portrait => []` (key
+		// present but value empty) AND a populated 'landscape' fallback.
+		// Naive `??` would treat the empty array as "set" and return the
+		// source image; the helper should instead fall through to
+		// 'landscape' tuples and delegate to resizer().
+		//
+		// We assert by recording the tuples resizer() was actually invoked
+		// with via an anonymous subclass — this stays purely in dispatch
+		// territory, no filesystem reads.
+		$this->mockFilters();
+		$resizer = new class extends Resizer {
+			public ?array $invokedWith = null;
+			public function resizer( $image, array $variants ): array {
+				$this->invokedWith = $variants;
+				return [ [ 'src' => '/stubbed-by-spy.jpg' ] ];
+			}
+		};
+		$image = [ [ 'src' => '/x.jpg', 'width' => 1080, 'height' => 1920 ] ];
+		$landscape_tuples = [ [ '960', '720', '', 'crop' ] ];
+		$resizer->resizerAspect( $image, [
+			'portrait' => [],
+			'landscape' => $landscape_tuples,
+		] );
+		$this->assertSame( $landscape_tuples, $resizer->invokedWith );
+	}
 }

--- a/tests/Unit/Resizer/ClassifyAspectTest.php
+++ b/tests/Unit/Resizer/ClassifyAspectTest.php
@@ -105,11 +105,14 @@ class ClassifyAspectTest extends ResizerTestCase {
 	}
 
 	public function test_classifies_upper_boundary_as_square(): void {
-		// Aspect = 1.099 → clearly inside the 0.1 tolerance band → square.
-		// (Exact 1100×1000 = 1.1 lands on the boundary where IEEE-754 noise
-		// makes `abs(1.1 - 1.0) <= 0.1` flip false; pick a fixture inside.)
+		// Aspect = 1.10 EXACTLY — inclusive upper boundary of the 0.1 band → square.
+		// Locks in the contract Copilot called out: with the dimension-space
+		// comparison `abs($width - $height) <= $tolerance * $height`, the
+		// boundary case `|1100 - 1000| = 100 <= 0.1 * 1000 = 100` is exact
+		// (no IEEE-754 noise). Regression-cover for the division-based form
+		// that previously failed at this exact ratio.
 		$this->mockFilters();
-		$image = [ [ 'src' => '/x.jpg', 'width' => 1099, 'height' => 1000 ] ];
+		$image = [ [ 'src' => '/x.jpg', 'width' => 1100, 'height' => 1000 ] ];
 		$this->assertSame( 'square', Resizer::classifyAspect( $image ) );
 	}
 


### PR DESCRIPTION
## Summary
- Implements parisek/timber-kit#16 — new `|resizer_aspect` Twig filter that classifies a source image's orientation (landscape / portrait / square, ±10 % tolerance around 1:1) and routes to a per-orientation tuple set, so consuming components can drop the inline `image.width >= image.height` branch.
- Backed by `Resizer::classifyAspect()` (static, public — also usable outside the Twig filter for callers needing the bucket without resizing) and `Resizer::resizerAspect()` (instance, the filter callback that dispatches to the existing `resizer()` pipeline).
- Tolerance is hardcoded at 0.1 but overridable via the `timber_kit_resizer_aspect_tolerance` WP filter — keeps the common path one-line at the call site while leaving an escape hatch for design-sensitive components.
- Missing-metadata / non-numeric / zero-dimension sources fall back to `landscape` so legacy assets (pre-ACF imports, SVG without intrinsic dimensions) keep the kit's historical wide-crop default. Components adopting the new filter don't silently shift their rendering for legacy assets.

## Usage

```twig
{{ component_picture({
    image: item.image|resizer_aspect({
        landscape: [['960', '720', '1280', 'crop'], ['480', '360', '', 'crop']],
        portrait:  [['720', '960', '1280', 'crop'], ['360', '480', '', 'crop']],
        square:    [['800', '800', '1280', 'crop'], ['400', '400', '', 'crop']],
    }),
}) }}
```

When the matched orientation bucket has no tuples the helper falls through to `orientations.landscape`; if that's also empty / absent the source is returned unchanged.

## Test plan
- [x] PHPUnit suite — 538 / 538 pass (24 new tests cover landscape / portrait / square classifications, square-band boundaries inside / outside the ±10 % band, tolerance filter overrides — tighten + loosen, missing-metadata fallbacks, source-element selection — last entry wins, and `resizerAspect()` dispatch decisions: empty orientations passthrough, non-array → empty array, matched-but-empty bucket passthrough).
- [x] PHPStan analyse — clean.
- [ ] Manual smoke test in a downstream consumer (pm-a's article-gallery component will swap its inline `is_landscape` branch for `|resizer_aspect` once this lands).

## Follow-ups (out of scope here, tracked separately)
- Styleguide-side parity in `parisek/styleguide` (styleguide-side sub-issue) — registers a parallel filter on the styleguide's bundled-helpers block so demos can show orientation-aware crops without the WordPress runtime.
- Drupal-side parity (Drupal sub-issue) — venue decision (per-project module vs. shared CMS-agnostic package) deferred until at least one active Drupal project hits the pain point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)