### PR TITLE
feat: Breadcrumb class + StarterBase auto-context (next release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+
+- **`Parisek\TimberKit\Breadcrumb` class** — strategy dispatcher producing typed item arrays (`[{type, url, title, …extras}]`) for the current WordPress query state. Covers 404, search, date archives, author archives, post type archives, taxonomy (with hierarchical ancestors), singular pages/posts/CPTs (menu-trail + post_parent fallback + list_page_map injection), and pagination.
+- **`StarterBase` properties** for breadcrumb configuration: `$breadcrumb_menu_name`, `$breadcrumb_list_page_map`, `$breadcrumb_menu_trail_post_types`, `$breadcrumb_include_pagination`, `$breadcrumb_labels`. Child `Base::__construct()` overrides these before calling `parent::__construct()`.
+- **`StarterBase::timber_context()` auto-populates `$context['breadcrumb']`** — unless the project still ships a global `\Breadcrumb` class (legacy compatibility guard via `class_exists('\Breadcrumb', false)`).
+- **Filter API**: `timber_kit_breadcrumb_items`, `timber_kit_breadcrumb_labels`, `timber_kit_breadcrumb_skip`, `timber_kit_breadcrumb_menu_trail`.
 - `StarterBase` now bundles the behaviour previously provided by the standalone [Speculation Rules](https://wordpress.org/plugins/speculation-rules/) plugin so downstream projects can `wp plugin deactivate speculation-rules && wp plugin delete speculation-rules` after upgrading. Two new properties drive it:
 
   - `$speculation_rules` (`?array`, default `['mode' => 'prerender', 'eagerness' => 'moderate', 'authentication' => 'logged_out']`) — registers `configure_speculation_rules()` on the WordPress 6.8+ `wp_speculation_rules_configuration` filter. Defaults mirror the plugin's defaults: meaningfully faster than WP core's `prefetch` / `conservative`, but rules are emitted only for logged-out visitors (`is_user_logged_in()` short-circuits to `null`) so admin previews and editor sessions don't trigger `prerender`-driven double-firing of GA / GTM / Productive page-view events. Set to `null` to fall back to WP core defaults entirely; set `authentication` to `'any'` to emit rules for logged-in users too. Partial overrides are supported — supply only the keys you want to change (e.g. `['mode' => 'prefetch']`), the remaining keys fall back to the defaults declared in `StarterBase::SPECULATION_RULES_DEFAULTS`.
   - `$warn_speculation_rules_plugin_redundant` (`bool`, default `true`) — registers a Site Health test (`Tools > Site Health`) named `timber_kit_speculation_rules_redundant`. Returns `status: 'good'` when the standalone plugin is inactive; returns `status: 'recommended'` with a "Manage plugin" link when both code paths are active and would duplicate the `wp_speculation_rules_configuration` filter. Passive signal only — no `admin_notices` banner, no auto-deactivation; the conflict is discovered during routine Site Health audits.
 
   Hooks are wired through a new `registerPerformanceHooks()` private method invoked from the constructor's declarative orchestrator, matching the concern-per-method shape of `registerSecurityHardeningHooks()` and `registerCommentDisablingHooks()`. The `wp_speculation_rules_href_exclude_paths` filter is intentionally **not** re-exposed: WP 6.8+ core already excludes `/wp-login.php`, `/wp-admin/*`, `*action=*` etc., and the standalone plugin only re-emits the legacy `plsr_…` filter for backwards compatibility — no downstream project under `wordpress-base` hooked the legacy name, so dropping it is safe. See [#23](https://github.com/parisek/timber-kit/pull/23).
+
+### Migration note for downstream consumers (breadcrumb)
+
+If your project still uses the global `\Breadcrumb` class (typical pre-migration `wordpress-base` setup), **no action is required for the upcoming release** — the legacy compatibility guard auto-detects your class and skips the new auto-populate. Your existing `new \Breadcrumb()` call sites keep working.
+
+To activate the new auto-populate:
+
+1. Delete your project's `classes/Breadcrumb.php` (and its tests).
+2. Remove the manual `$breadcrumbs = new \Breadcrumb(); $context['breadcrumb'] = $breadcrumbs->get();` block from your `Base::timber_context()`.
+3. Override `$breadcrumb_*` properties in your `Base::__construct()` (provide `_x()`-translated `$breadcrumb_labels` matching your text domain).
+4. `$context['breadcrumb']` is now populated by `parent::timber_context()` automatically.
+
+The items shape `[{type, url, title}]` is backward-compatible with the previous `[{url, title}]` — `type` is an additive key. No Twig component changes required.
 
 ## [1.6.0] - 2026-05-24
 

--- a/docs/adr/2026-05-24-breadcrumb-design.md
+++ b/docs/adr/2026-05-24-breadcrumb-design.md
@@ -1,0 +1,429 @@
+# Breadcrumb refactor — migration to `parisek/timber-kit`
+
+**Status:** Draft (awaiting user approval)
+**Date:** 2026-05-24
+**Author:** Petr Parimucha + Claude
+**Triggered from:** `wordpress-base` audit of WordPress 7.0 vs. existing `\Breadcrumb` class
+
+---
+
+## 1. Goal
+
+Move the project-local `\Breadcrumb` class (`wp-content/themes/starter_theme/classes/Breadcrumb.php`) **upstream into `parisek/timber-kit`** so every downstream WordPress project gets:
+
+- Strategy-based coverage (404, search, date, author, post-type-archive, taxonomy hierarchy, pagination) the current class misses.
+- Defensive guards (`WP_Error` from `get_term_link`, ACF Pro absence, WPML normalization in menu trail).
+- A `tk`-style configuration surface that mirrors the existing `StarterBase` property idiom (`$menus`, `$article_post_types`, …).
+- A filter API (`timber_kit_breadcrumb_*`) for per-project extensions without forking the class.
+
+The project's `classes/Breadcrumb.php` is **deleted entirely**. `wordpress-base` is a create-project template (canonical source new projects clone from), not a long-running site — there are no historical `new \Breadcrumb()` call sites that need a graceful migration path. The class moves upstream cleanly. (See §9 for the rationale and the one-line `Base::timber_context()` migration.)
+
+---
+
+## 2. Scope
+
+| Repo | Changes | Version |
+|---|---|---|
+| **`parisek/timber-kit`** | `src/Breadcrumb.php` (new), `src/StarterBase.php` (+5 properties + auto-context behind legacy-class guard), `tests/Unit/BreadcrumbTest.php` (~35 brain/monkey tests), `CHANGELOG.md` | 1.6.0 (minor, additive) |
+| **`wordpress-base`** | `classes/Base.php` (use `$breadcrumb_*` properties), **delete** `classes/Breadcrumb.php`, **delete** `tests/unit/BreadcrumbTest.php`, `.claude/rules/wordpress/timber-kit.md` (new property rows) | n/a |
+| **`tailwind-base`** | **None.** Items shape stays backward-compatible (`type` key is additive) | n/a |
+
+---
+
+## 3. Items shape — typed structured data + hydrated `title`
+
+The class produces an array of items, each carrying a `type` discriminator. Hydration (resolving `title` from labels + structured fields) happens **inside the class** before return — so the consumer (Twig) sees the existing `[{url, title}]` shape with `type` as an extra key.
+
+### Discriminators
+
+| `type` | Extra keys | Hydrated `title` |
+|---|---|---|
+| `home` | `url` | `$labels['home']` |
+| `item` | `url`, `title` (raw from DB) | unchanged |
+| `404` | — | `$labels['404']` |
+| `search` | `query`, `url` | `sprintf($labels['search'], $query)` |
+| `pagination` | `page`, `url` | `sprintf($labels['pagination'], $page)` |
+| `author` | `display_name`, `url` | `sprintf($labels['author'], $display_name)` |
+| `date_year` | `year`, `url` (linked when month follows, else null) | `(string) $year` |
+| `date_month` | `year`, `month`, `url` (linked when day follows, else null) | `wp_date('F', mktime(0,0,0,$month,1,$year))` |
+| `date_day` | `year`, `month`, `day` (always leaf, no `url`) | `(string) $day` |
+
+After hydration, every item has `type`, `url` (or `null`), and `title` — Twig reads `item.url` and `item.title` exactly as today.
+
+### Backward-compat invariant
+
+Items shape stays `[{url, title}, …]` *with* extra `type` key. Existing Twig component `breadcrumb.twig` reads `item.url` + `item.title` and ignores `type` — **no template change needed**. Hide rule (`items|length <= 2`) keeps working because Home is now an explicit item in the array (not auto-prepended in view).
+
+---
+
+## 4. `StarterBase` configuration surface
+
+Five new `protected` properties in `Parisek\TimberKit\StarterBase`, mirroring the existing `$menus` / `$article_post_types` idiom:
+
+```php
+/** @var string Nav menu location for breadcrumb menu-trail strategy */
+protected string $breadcrumb_menu_name = 'main-menu';
+
+/** @var array<string,string> Post type → ACF option key for "listing page" injection */
+protected array $breadcrumb_list_page_map = [];
+
+/** @var ?array Post types eligible for menu-trail; null = auto-detect hierarchical */
+protected ?array $breadcrumb_menu_trail_post_types = null;
+
+/** @var bool Whether to add "Page N" item on paginated views */
+protected bool $breadcrumb_include_pagination = false;
+
+/** @var array<string,string> Default English labels (project overrides via _x() in __construct()) */
+protected array $breadcrumb_labels = [
+    'home'       => 'Home',
+    '404'        => 'Page not found',
+    'search'     => 'Search: %s',
+    'pagination' => 'Page %d',
+    'author'     => 'Author: %s',
+];
+```
+
+`StarterBase::timber_context()` automatically instantiates `Breadcrumb` and populates `$context['breadcrumb']` — **unless** the project still ships a global `\Breadcrumb` class (legacy convention from pre-migration `wordpress-base` versions). See §4.1 *Legacy compatibility guard* below.
+
+Downstream Base.php overrides properties — never instantiates `Breadcrumb` directly:
+
+```php
+// downstream Base.php
+class Base extends StarterBase {
+    public function __construct() {
+        // ... other property overrides ...
+        $this->breadcrumb_list_page_map = [ 'post' => 'article_list' ];
+        $this->breadcrumb_labels = [
+            'home'       => _x('Home', 'starter_theme', 'starter_theme'),
+            '404'        => _x('Page not found', 'starter_theme', 'starter_theme'),
+            'search'     => _x('Search: %s', 'starter_theme', 'starter_theme'),
+            'pagination' => _x('Page %d', 'starter_theme', 'starter_theme'),
+            'author'     => _x('Author: %s', 'starter_theme', 'starter_theme'),
+        ];
+        parent::__construct();
+    }
+}
+```
+
+**No breadcrumb-related code in `Base::timber_context()`** — the parent populates `$context['breadcrumb']` automatically. This is the "full TimberKit" architecture user requested.
+
+`wordpress-base` is a **create-project template** (canonical source new projects clone from), not a running site with historical call sites. Therefore the project drops `classes/Breadcrumb.php` and `tests/unit/BreadcrumbTest.php` **entirely** — no deprecated shim, no shim tests. See §9.
+
+### 4.1 Legacy compatibility guard
+
+To avoid double-computation in projects that consume TimberKit 1.6.0 but haven't yet migrated their `Base.php` away from `new \Breadcrumb()`, the auto-populate is gated on a class-existence check:
+
+```php
+public function timber_context( $context ) {
+    // ... existing context population ...
+
+    // Populate $context['breadcrumb'] automatically — unless the project
+    // still ships a global \Breadcrumb class (legacy convention from
+    // wordpress-base versions before this migration). Projects that haven't
+    // yet migrated keep their own manual `new \Breadcrumb()` call site
+    // in Base::timber_context(); skipping here avoids wasted compute when
+    // child::timber_context() overwrites anyway.
+    if ( ! class_exists( '\Breadcrumb', false ) ) {
+        $bc = new Breadcrumb([
+            'menu_name'             => $this->breadcrumb_menu_name,
+            'list_page_map'         => $this->breadcrumb_list_page_map,
+            'menu_trail_post_types' => $this->breadcrumb_menu_trail_post_types,
+            'include_pagination'    => $this->breadcrumb_include_pagination,
+            'labels'                => $this->breadcrumb_labels,
+        ]);
+        $context['breadcrumb'] = $bc->get();
+    }
+
+    return $context;
+}
+```
+
+**`class_exists( '\Breadcrumb', false )`** — the second argument `false` disables the autoloader so the check is a plain class-map lookup, not a filesystem probe. If the project autoloads its own `classes/Breadcrumb.php` (typical Composer classmap setup), the class is already loaded by the time `timber_context()` fires (Base.php constructor runs first), so the check finds it without triggering I/O.
+
+### Behavior matrix
+
+| Project | `\Breadcrumb` defined? | Auto-populate | Outcome |
+|---|---|---|---|
+| New (post-migration template clone) | ❌ | runs | `$context['breadcrumb']` ready, project just overrides properties |
+| Legacy, unmigrated (composer update only) | ✅ | skipped | Child's manual `new \Breadcrumb()` line keeps working; no wasted compute |
+| Mid-migration (class deleted, properties not set) | ❌ | runs with English defaults | Functional, slightly unpolished — fix during migration |
+| Power user with non-`\Breadcrumb` custom class | ❌ (different namespace) | runs | Child override in `timber_context()` wins; small wasted compute. If common enough later, add opt-out property `$breadcrumb_auto_populate` |
+
+### Rationale: class existence over opt-out property
+
+A `protected bool $breadcrumb_auto_populate = true` opt-out was considered and rejected. Legacy unmigrated projects can't explicitly set the property without touching Base.php — which defeats the "composer update is safe" guarantee. The class-existence check **auto-opts out** for projects shipping the legacy convention, requiring zero code change.
+
+The corollary: if a future use case demands explicit opt-out (e.g., custom non-`\Breadcrumb` class names), add the property then. Start with minimal complexity.
+
+### English defaults rationale
+
+TimberKit ships English raw strings (`'Home'`, `'Page not found'`) as defaults — **not** `_x()` calls. Reason: TimberKit doesn't know the project's text domain. Projects translate by replacing the labels array in their own `__construct()` with `_x()` calls using their own domain. The English defaults guarantee the class never returns `null` titles even if a project forgets to configure labels (graceful degradation).
+
+---
+
+## 5. `Breadcrumb` class — internal architecture
+
+### Public API
+
+```php
+namespace Parisek\TimberKit;
+
+class Breadcrumb {
+    public function __construct( array $config = [] );
+    public function get(): array;
+}
+```
+
+Constructor accepts a config array with keys matching the property names (`menu_name`, `list_page_map`, `menu_trail_post_types`, `include_pagination`, `labels`). Unknown keys ignored.
+
+### Strategy dispatcher
+
+`get()` is a thin dispatcher; per-query-state logic lives in `protected` methods so each is unit-testable in isolation:
+
+```php
+public function get(): array {
+    if ( apply_filters( 'timber_kit_breadcrumb_skip', false, $GLOBALS['wp_query'] ?? null ) ) {
+        return [];
+    }
+    if ( is_front_page() && ! is_paged() ) {
+        return [];
+    }
+
+    $home  = $this->build_home_item();
+    $items = match ( true ) {
+        is_404()                              => $this->build_for_404(),
+        is_search()                           => $this->build_for_search(),
+        is_date()                             => $this->build_for_date_archive(),
+        is_author()                           => $this->build_for_author_archive(),
+        is_post_type_archive()                => $this->build_for_post_type_archive(),
+        is_tax() || is_category() || is_tag() => $this->build_for_taxonomy(),
+        is_singular()                         => $this->build_for_singular(),
+        default                               => [],
+    };
+
+    if ( $this->include_pagination && is_paged() ) {
+        $items[] = $this->build_pagination_item();
+    }
+
+    $all = array_merge( [ $home ], $items );
+    $all = apply_filters( 'timber_kit_breadcrumb_items', $all, $this );
+
+    return $this->hydrate( $all );
+}
+```
+
+### Per-strategy responsibility table
+
+| Method | Returns items for | Notes |
+|---|---|---|
+| `build_home_item()` | `[{type: 'home', url}]` | Always returned first |
+| `build_for_404()` | `[{type: '404'}]` | No URL |
+| `build_for_search()` | `[{type: 'search', query, url}]` | Query from `get_search_query()` |
+| `build_for_date_archive()` | year/month/day chain | Year linked when month present; month linked when day present |
+| `build_for_author_archive()` | `[{type: 'author', display_name, url}]` | |
+| `build_for_post_type_archive()` | `[{type: 'item', title, url}]` | Title from `post_type_object->labels->archives` |
+| `build_for_taxonomy()` | ancestor terms + current term | Hierarchical ancestors via `get_ancestors()`; `is_string()` guard on `get_term_link()` for `WP_Error` |
+| `build_for_singular()` | dispatch by post type | `page` → menu-trail OR ancestors; `post` (or post type in `list_page_map`) → list-page + title; hierarchical CPT → menu-trail OR ancestors; flat CPT → CPT archive label + title |
+| `build_pagination_item()` | `[{type: 'pagination', page, url}]` | `url` = page-1 link via `get_pagenum_link(1)` |
+
+### Hydrate
+
+```php
+protected function hydrate( array $items ): array {
+    $labels = apply_filters( 'timber_kit_breadcrumb_labels', $this->labels, $items );
+    foreach ( $items as &$item ) {
+        $item['title'] = match ( $item['type'] ?? 'item' ) {
+            'home'       => $labels['home']       ?? 'Home',
+            '404'        => $labels['404']        ?? 'Page not found',
+            'search'     => sprintf( $labels['search']     ?? '%s', $item['query']        ?? '' ),
+            'pagination' => sprintf( $labels['pagination'] ?? '%d', $item['page']         ?? 1  ),
+            'author'     => sprintf( $labels['author']     ?? '%s', $item['display_name'] ?? '' ),
+            'date_year'  => (string) ( $item['year'] ?? '' ),
+            'date_month' => wp_date( 'F', mktime( 0, 0, 0, $item['month'] ?? 1, 1, $item['year'] ?? (int) date( 'Y' ) ) ),
+            'date_day'   => (string) ( $item['day']  ?? '' ),
+            default      => $item['title'] ?? '',  // 'item' carries title from DB
+        };
+    }
+    return $items;
+}
+```
+
+### Helpers (ported from existing class)
+
+| Helper | Role |
+|---|---|
+| `by_menu_trail( string $menu_name )` | Walks the named WP nav menu for the parent chain. `apply_filters('wpml_object_id', $queried_id, 'page')` added vs. current implementation |
+| `get_menu_item( string $field, mixed $object_id, array $items )` | Pure helper; type-normalization for `wp_get_nav_menu_items` string/int mismatch — unchanged from current class |
+| `get_global_links()` | Reads ACF option for `list_page_map` resolution. `function_exists('get_field')` guard added |
+
+---
+
+## 6. Filter API
+
+| Filter | Args | When | Use case |
+|---|---|---|---|
+| `timber_kit_breadcrumb_items` | `(array $items, Breadcrumb $self)` | After strategy dispatch, before hydrate | Modify the structured item array (add/remove items, transform types) |
+| `timber_kit_breadcrumb_labels` | `(array $labels, array $items)` | Inside hydrate, before match | Per-request label override (WPML language-aware, per-page customization) |
+| `timber_kit_breadcrumb_skip` | `(bool $skip, ?\WP_Query $query)` | First check in `get()` | Suppress breadcrumb on landing pages |
+| `timber_kit_breadcrumb_menu_trail` | `(array $items, string $menu_name)` | After `by_menu_trail()` returns | Customize menu-derived chain |
+
+Naming matches existing `timber_kit_<feature>_<concern>` pattern from `Resizer`, `Helpers::*`, `DevMediaProxy` (14:1 majority vs. the slash-style used by `BlockRenderer`).
+
+---
+
+## 7. Defensive guards (vs. current class)
+
+| Issue (current class) | Location | Fix |
+|---|---|---|
+| `get()` returns `null` on front_page, `array` otherwise | `get():22` | Sjednotit na `array` return type + `: array` annotation |
+| `get_term_link()` returning `WP_Error` not filtered out | `get():60-62` | `is_string($url)` guard before append |
+| `get_global_links()` runs always, used only for `post` | `get():25` | Lazy: call inside `case 'post'` branch only |
+| Hard ACF dependency (`get_field` fatal if ACF deactivated) | `get_global_links():154` | `function_exists('get_field')` guard |
+| `by_menu_trail` doesn't normalize queried object via WPML | `by_menu_trail():97` | `apply_filters('wpml_object_id', $queried_id, 'page')` |
+| Hardcoded `'main-menu'` menu name | `by_menu_trail():81` | Configurable via `$menu_name` property |
+| No filter hook for downstream override | n/a | Four `timber_kit_breadcrumb_*` filters (§6) |
+| Hardcoded translation domain | constructor | Removed — TimberKit ships English defaults, project overrides via `_x()` in own domain |
+| `isset()` + `is_countable()` redundancy | `get_global_links():156` | Drop `isset()` — `is_countable(null)` is `false` |
+| `array_unshift` in loop (O(n²)) | `by_menu_trail():108` | Append + `array_reverse()` at end (academic, low priority) |
+
+---
+
+## 8. Twig component contract — unchanged
+
+`tailwind-base/static/templates/component/breadcrumb/breadcrumb.twig` consumes `[{url, title}, …]`. The new shape `[{type, url, title}, …]` adds a key Twig doesn't read. **Zero changes to the component.**
+
+The existing hide rule `items|length <= 2 ? 'hidden' : ''` keeps working: Home is now an explicit item (was auto-seeded by the constructor before), so "Home + 1 = 2 items = hide" matches today's behavior.
+
+`aria-label="{{ _x('Breadcrumb', 'tailwind-base', 'tailwind-base') }}"` stays in the template (template-owned translation in `tailwind-base` text domain).
+
+---
+
+## 9. Project: delete `theme/classes/Breadcrumb.php` entirely
+
+After TimberKit 1.6.0 release, the project's `Breadcrumb.php` is **removed** — no deprecated shim, no compatibility bridge.
+
+**Rationale**: `wordpress-base` is the canonical create-project template. New projects clone from it; there are no long-running downstream sites with their own `new \Breadcrumb()` call sites that need a migration period. The only consumer of the class is `Base::timber_context()`, which is updated in the same PR to use property overrides.
+
+**Migration in `Base::timber_context()`**:
+
+```diff
+-// breadcrumb
+-$breadcrumbs           = new \Breadcrumb();
+-$context['breadcrumb'] = $breadcrumbs->get();
++// $context['breadcrumb'] is auto-populated by parent via $breadcrumb_* properties
+```
+
+**Files deleted** in PR #2:
+
+- `wp-content/themes/starter_theme/classes/Breadcrumb.php`
+- `wp-content/themes/starter_theme/tests/unit/BreadcrumbTest.php`
+
+**Optional check at PR time**: `git grep -n "new \\\\Breadcrumb\|new Breadcrumb" wp-content/themes/starter_theme/` to confirm no other call sites exist. Expected: only `classes/Base.php:88` (the line being removed in the same PR).
+
+---
+
+## 10. Test plan
+
+### TimberKit `tests/Unit/BreadcrumbTest.php` (~35 tests, brain/monkey)
+
+| Group | Count | Coverage |
+|---|---|---|
+| Helper methods (ported) | 8 | `get_menu_item` (4), `by_menu_trail` (2), `get_global_links` (2) |
+| Strategy dispatchers | 15 | Each `build_for_*` gets 1-3 tests covering its known branches (see §5 table) |
+| Configuration | 3 | constructor with config, defaults, partial override |
+| Filters | 4 | `_items`, `_labels`, `_skip`, `_menu_trail` |
+| Edge cases | 5 | `WP_Error` from `get_term_link`, ACF unavailable, WPML object_id normalization, pagination, flat CPT fallthrough |
+
+**Mocking**: `brain/monkey` (TimberKit convention) replaces `WP_Mock` (current project convention). `Functions\when()` for stubs, `Functions\expect()` for assertions, `Filters\expectApplied()` for filter integration.
+
+### Project `tests/unit/BreadcrumbTest.php` — **deleted entirely**
+
+No shim, no shim tests. All 8 existing helper tests are deleted from the project; equivalent functional coverage is in TimberKit's `tests/Unit/BreadcrumbTest.php` (rewritten via brain/monkey).
+
+If a future need arises to assert that `Base` correctly wires `$breadcrumb_*` properties (e.g., specific list_page_map value), that becomes an integration test under a different name — out of scope here.
+
+---
+
+## 11. Migration mechanics — PR sequencing
+
+### PR #1 — `parisek/timber-kit` (draft, assignee parisek)
+
+- `src/Breadcrumb.php` (new)
+- `src/StarterBase.php` (+5 properties + auto-populate in `timber_context()`)
+- `tests/Unit/BreadcrumbTest.php` (~35 brain/monkey tests)
+- `CHANGELOG.md` entry with migration note for downstream consumers
+- **Git tag `v1.6.0`** at merge time. (Library `composer.json` doesn't carry a `version` field — Composer reads tags. Setting `version` in `composer.json` for a library is an anti-pattern.)
+
+Draft + assignee per `tailwind-base`-style doctrine (chat-first → draft → owner review). User merges + tags `v1.6.0` when satisfied.
+
+### PR #2 — `wordpress-base` project (after #1 merged + tagged)
+
+- `composer.json`: `parisek/timber-kit: ^1.6`
+- `composer update parisek/timber-kit`
+- `classes/Base.php`:
+  - Add `$this->breadcrumb_list_page_map` + `$this->breadcrumb_labels` overrides in `__construct()`
+  - Remove `$breadcrumbs = new \Breadcrumb(); $context['breadcrumb'] = $breadcrumbs->get();` from `timber_context()`
+- **Delete** `classes/Breadcrumb.php` (no shim — see §9 rationale)
+- **Delete** `tests/unit/BreadcrumbTest.php` (helpers moved upstream)
+- `.claude/rules/wordpress/timber-kit.md`: add 5 new property rows to the "Base.php configurable properties" table
+
+Pre-flight check: `git grep "new \\\\Breadcrumb\|new Breadcrumb" wp-content/themes/starter_theme/` should return only the `classes/Base.php` line being removed in the same PR.
+
+### PR #3 — `tailwind-base` Twig component
+
+**Not needed.** No changes per §8.
+
+---
+
+## 12. Risks & open questions
+
+### Risks
+
+| Risk | Mitigation |
+|---|---|
+| Other downstream projects depend on items shape *not* containing `type` key (e.g. JSON-encode for JS) | Additive key is non-breaking for `json_encode()` — extra field. No known consumer reads via `array_keys()` strict check. Spot-check at sync time. |
+| `wp_date` not available pre-WP-5.3 | Project targets WP 7.0; non-issue. TimberKit's existing code already uses modern WP APIs (PHP 8.3+, Timber 2.0+). |
+| `is_singular()` for paginated singles double-counts pagination | Pagination is appended only when `include_pagination` is `true` (default `false`) — opt-in keeps default safe. |
+| `breadcrumb_labels` left as English defaults in a non-EN project | Class never returns `null` title; falls back to English. Visible but graceful. CHANGELOG migration note flags this for review. |
+| Two filter prefixes co-exist (`tk_*` rejected → `timber_kit_*`) | Confirmed during brainstorming: `timber_kit_` matches existing 14:1 majority in TimberKit. Single style going forward. |
+| Legacy unmigrated project composer-updates TimberKit, doubles compute on breadcrumb | Class-existence guard (`class_exists('\Breadcrumb', false)`) skips auto-populate when legacy convention detected. See §4.1. |
+
+### Open questions (deferred to PR #1 implementation)
+
+| Question | Default if unanswered |
+|---|---|
+| TimberKit repo URL (GitHub org/name) | Determine from `composer show -s parisek/timber-kit` or ask user before cloning |
+| Should `Breadcrumb` register a Twig function (e.g. `{{ breadcrumb_items() }}` in pages without `$context`) | Out of scope for 1.6.0 — Twig context wiring is StarterBase's job |
+| Should TimberKit ship a default `breadcrumb.twig` component? | No — view layer lives in `tailwind-base`. TimberKit is PHP runtime, not template provider. |
+
+---
+
+## 13. Decisions made during brainstorming
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Where does the class live? | `parisek/timber-kit` only; project copy deleted entirely | Matches "upstream first" doctrine; `wordpress-base` is a create-project template with no legacy call sites to preserve |
+| Items shape | `[{type, url, title, …extras}]` | `type` discriminator is additive (no Twig change); structured extras allow view-agnostic data flow |
+| Translation strategy | Class accepts label dict in config; project provides `_x()`-translated dict | TimberKit translation-free; project owns text domain |
+| Filter prefix | `timber_kit_breadcrumb_*` | Match existing `timber_kit_*` convention in Resizer / Helpers / DevMediaProxy (14:1 majority) |
+| Where do project-level labels live? | `$breadcrumb_labels` property on Base (override in `__construct`) | Matches existing `$menus` / `$article_post_types` property idiom |
+| Where does StarterBase populate `$context['breadcrumb']`? | Inside `timber_context()`, no Base.php call needed | "Full TimberKit" — project just configures properties |
+| Twig component change | None | Items shape is shape-compatible; component reads `url` + `title`, ignores `type` |
+| Test framework in TimberKit | `brain/monkey` | TimberKit convention; project's WP_Mock tests get rewritten, not ported |
+| Version bump | `v1.6.0` git tag (minor, additive) | Class is new in TimberKit; StarterBase additions are property-additive; no existing API breaks. Library `composer.json` doesn't carry `version` — Composer reads git tags. |
+| PR sequencing | TimberKit first → tag → project follows | Standard upstream-first; project's `composer require ^1.6` needs the tag to exist |
+| Project-side deprecated shim | **None** — class deleted outright | `wordpress-base` is a create-project template, not a long-running site; no historical call sites to preserve. Trades graceful migration for cleaner skeleton. |
+| Legacy projects on composer-only update | `class_exists('\Breadcrumb', false)` guard in `StarterBase::timber_context()` | Legacy convention auto-opt-out; no Base.php change required for safety. Migrated projects (where class is deleted) get auto-populate. See §4.1. |
+
+---
+
+## 14. References
+
+- `wp-content/themes/starter_theme/classes/Breadcrumb.php` — current implementation
+- `wp-content/themes/starter_theme/tests/unit/BreadcrumbTest.php` — current 8 WP_Mock helper tests
+- `wp-content/themes/starter_theme/vendor/parisek/timber-kit/src/StarterBase.php` — property idiom + `timber_context()` host
+- `wp-content/themes/starter_theme/vendor/parisek/timber-kit/src/Helpers.php` — existing `timber_kit_*` filter naming
+- `wp-includes/blocks/breadcrumbs.php` — WP 7.0 native block (reviewed during brainstorming; rejected as data source due to HTML-only render contract)
+- `.claude/rules/wordpress/timber-kit.md` — `Base.php` configurable properties doctrine
+- `.claude/rules/meta/changelog.md` — CHANGELOG entry format for refs/footer
+- `AGENTS.md` § Rules upstream-first doctrine — applies in spirit (TimberKit is a separate package but same upstream concept)

--- a/docs/adr/2026-05-24-breadcrumb-design.md
+++ b/docs/adr/2026-05-24-breadcrumb-design.md
@@ -24,7 +24,7 @@ The project's `classes/Breadcrumb.php` is **deleted entirely**. `wordpress-base`
 
 | Repo | Changes | Version |
 |---|---|---|
-| **`parisek/timber-kit`** | `src/Breadcrumb.php` (new), `src/StarterBase.php` (+5 properties + auto-context behind legacy-class guard), `tests/Unit/BreadcrumbTest.php` (~35 brain/monkey tests), `CHANGELOG.md` | 1.6.0 (minor, additive) |
+| **`parisek/timber-kit`** | `src/Breadcrumb.php` (new), `src/StarterBase.php` (+5 properties + auto-context behind legacy-class guard), `tests/Unit/BreadcrumbTest.php` (~35 brain/monkey tests), `CHANGELOG.md` | Unreleased (minor, additive) |
 | **`wordpress-base`** | `classes/Base.php` (use `$breadcrumb_*` properties), **delete** `classes/Breadcrumb.php`, **delete** `tests/unit/BreadcrumbTest.php`, `.claude/rules/wordpress/timber-kit.md` (new property rows) | n/a |
 | **`tailwind-base`** | **None.** Items shape stays backward-compatible (`type` key is additive) | n/a |
 
@@ -111,7 +111,7 @@ class Base extends StarterBase {
 
 ### 4.1 Legacy compatibility guard
 
-To avoid double-computation in projects that consume TimberKit 1.6.0 but haven't yet migrated their `Base.php` away from `new \Breadcrumb()`, the auto-populate is gated on a class-existence check:
+To avoid double-computation in projects that consume the next TimberKit release but haven't yet migrated their `Base.php` away from `new \Breadcrumb()`, the auto-populate is gated on a class-existence check:
 
 ```php
 public function timber_context( $context ) {
@@ -223,7 +223,7 @@ public function get(): array {
 | `build_for_author_archive()` | `[{type: 'author', display_name, url}]` | |
 | `build_for_post_type_archive()` | `[{type: 'item', title, url}]` | Title from `post_type_object->labels->archives` |
 | `build_for_taxonomy()` | ancestor terms + current term | Hierarchical ancestors via `get_ancestors()`; `is_string()` guard on `get_term_link()` for `WP_Error` |
-| `build_for_singular()` | dispatch by post type | `page` → menu-trail OR ancestors; `post` (or post type in `list_page_map`) → list-page + title; hierarchical CPT → menu-trail OR ancestors; flat CPT → CPT archive label + title |
+| `build_for_singular()` | dispatch by post type | `page` → menu-trail OR ancestors; `post` (or post type in `list_page_map`) → list-page + title; hierarchical CPT → menu-trail OR ancestors; flat CPT without `list_page_map` entry → current title only |
 | `build_pagination_item()` | `[{type: 'pagination', page, url}]` | `url` = page-1 link via `get_pagenum_link(1)` |
 
 ### Hydrate
@@ -300,7 +300,7 @@ The existing hide rule `items|length <= 2 ? 'hidden' : ''` keeps working: Home i
 
 ## 9. Project: delete `theme/classes/Breadcrumb.php` entirely
 
-After TimberKit 1.6.0 release, the project's `Breadcrumb.php` is **removed** — no deprecated shim, no compatibility bridge.
+After the next TimberKit release (Unreleased), the project's `Breadcrumb.php` is **removed** — no deprecated shim, no compatibility bridge.
 
 **Rationale**: `wordpress-base` is the canonical create-project template. New projects clone from it; there are no long-running downstream sites with their own `new \Breadcrumb()` call sites that need a migration period. The only consumer of the class is `Base::timber_context()`, which is updated in the same PR to use property overrides.
 
@@ -352,13 +352,13 @@ If a future need arises to assert that `Base` correctly wires `$breadcrumb_*` pr
 - `src/StarterBase.php` (+5 properties + auto-populate in `timber_context()`)
 - `tests/Unit/BreadcrumbTest.php` (~35 brain/monkey tests)
 - `CHANGELOG.md` entry with migration note for downstream consumers
-- **Git tag `v1.6.0`** at merge time. (Library `composer.json` doesn't carry a `version` field — Composer reads tags. Setting `version` in `composer.json` for a library is an anti-pattern.)
+- **Git tag** (next minor version) at merge time. (Library `composer.json` doesn't carry a `version` field — Composer reads tags. Setting `version` in `composer.json` for a library is an anti-pattern.)
 
-Draft + assignee per `tailwind-base`-style doctrine (chat-first → draft → owner review). User merges + tags `v1.6.0` when satisfied.
+Draft + assignee per `tailwind-base`-style doctrine (chat-first → draft → owner review). User merges + tags when satisfied.
 
 ### PR #2 — `wordpress-base` project (after #1 merged + tagged)
 
-- `composer.json`: `parisek/timber-kit: ^1.6`
+- `composer.json`: `parisek/timber-kit` bumped to the new tag
 - `composer update parisek/timber-kit`
 - `classes/Base.php`:
   - Add `$this->breadcrumb_list_page_map` + `$this->breadcrumb_labels` overrides in `__construct()`
@@ -393,7 +393,7 @@ Pre-flight check: `git grep "new \\\\Breadcrumb\|new Breadcrumb" wp-content/them
 | Question | Default if unanswered |
 |---|---|
 | TimberKit repo URL (GitHub org/name) | Determine from `composer show -s parisek/timber-kit` or ask user before cloning |
-| Should `Breadcrumb` register a Twig function (e.g. `{{ breadcrumb_items() }}` in pages without `$context`) | Out of scope for 1.6.0 — Twig context wiring is StarterBase's job |
+| Should `Breadcrumb` register a Twig function (e.g. `{{ breadcrumb_items() }}` in pages without `$context`) | Out of scope for this release — Twig context wiring is StarterBase's job |
 | Should TimberKit ship a default `breadcrumb.twig` component? | No — view layer lives in `tailwind-base`. TimberKit is PHP runtime, not template provider. |
 
 ---
@@ -410,8 +410,8 @@ Pre-flight check: `git grep "new \\\\Breadcrumb\|new Breadcrumb" wp-content/them
 | Where does StarterBase populate `$context['breadcrumb']`? | Inside `timber_context()`, no Base.php call needed | "Full TimberKit" — project just configures properties |
 | Twig component change | None | Items shape is shape-compatible; component reads `url` + `title`, ignores `type` |
 | Test framework in TimberKit | `brain/monkey` | TimberKit convention; project's WP_Mock tests get rewritten, not ported |
-| Version bump | `v1.6.0` git tag (minor, additive) | Class is new in TimberKit; StarterBase additions are property-additive; no existing API breaks. Library `composer.json` doesn't carry `version` — Composer reads git tags. |
-| PR sequencing | TimberKit first → tag → project follows | Standard upstream-first; project's `composer require ^1.6` needs the tag to exist |
+| Version bump | Next minor git tag (Unreleased) | Class is new in TimberKit; StarterBase additions are property-additive; no existing API breaks. Library `composer.json` doesn't carry `version` — Composer reads git tags. |
+| PR sequencing | TimberKit first → tag → project follows | Standard upstream-first; project's `composer require` constraint bump needs the tag to exist |
 | Project-side deprecated shim | **None** — class deleted outright | `wordpress-base` is a create-project template, not a long-running site; no historical call sites to preserve. Trades graceful migration for cleaner skeleton. |
 | Legacy projects on composer-only update | `class_exists('\Breadcrumb', false)` guard in `StarterBase::timber_context()` | Legacy convention auto-opt-out; no Base.php change required for safety. Migrated projects (where class is deleted) get auto-populate. See §4.1. |
 

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -376,15 +376,13 @@ class Breadcrumb {
 	}
 
 	/**
-	 * Build a chain of items from a post's `post_parent` ancestors.
+	 * Build a chain of items from the current post's `post_parent` ancestors.
 	 *
-	 * Returns items in root-to-leaf order, excluding the post itself.
+	 * Returns items in root-to-leaf order, excluding the current post itself.
 	 *
-	 * @param object $post Post object (unused arg; method uses get_post() globals).
 	 * @return array<int, array{type: string, title: string, url: string}>
 	 */
-	protected function build_ancestors_chain( object $post ): array {
-		unset( $post );
+	protected function build_ancestors_chain(): array {
 		$current_post = get_post();
 		$ancestors = get_post_ancestors( $current_post );
 		$ancestors = array_reverse( $ancestors );
@@ -478,7 +476,7 @@ class Breadcrumb {
 		if ( 'page' === $post_type ) {
 			$items = $this->by_menu_trail();
 			if ( empty( $items ) ) {
-				$items = $this->build_ancestors_chain( $post );
+				$items = $this->build_ancestors_chain();
 			}
 		} elseif ( isset( $this->list_page_map[ $post_type ] ) ) {
 			$links = $this->get_global_links();
@@ -500,7 +498,7 @@ class Breadcrumb {
 			if ( $menu_trail_eligible ) {
 				$items = $this->by_menu_trail();
 				if ( empty( $items ) && $is_hierarchical ) {
-					$items = $this->build_ancestors_chain( $post );
+					$items = $this->build_ancestors_chain();
 				}
 			}
 		}

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -191,4 +191,37 @@ class Breadcrumb {
 
 		return $items;
 	}
+
+	/**
+	 * Build breadcrumb items for a post type archive page.
+	 *
+	 * @return array<int, array{type: string, title: string, url: string}>
+	 */
+	protected function build_for_post_type_archive(): array {
+		$post_type = get_query_var( 'post_type' );
+		if ( is_array( $post_type ) ) {
+			$post_type = reset( $post_type );
+		}
+		if ( ! $post_type || ! is_string( $post_type ) ) {
+			return [];
+		}
+
+		$cpt = get_post_type_object( $post_type );
+		if ( ! $cpt || ! isset( $cpt->labels->archives ) ) {
+			return [];
+		}
+
+		$url = get_post_type_archive_link( $post_type );
+		if ( ! is_string( $url ) ) {
+			return [];
+		}
+
+		return [
+			[
+				'type'  => 'item',
+				'title' => (string) $cpt->labels->archives,
+				'url'   => $url,
+			],
+		];
+	}
 }

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -89,4 +89,13 @@ class Breadcrumb {
 			'url'  => home_url( '/' ),
 		];
 	}
+
+	/**
+	 * Build breadcrumb items for a 404 page.
+	 *
+	 * @return array<int, array{type: string}>
+	 */
+	protected function build_for_404(): array {
+		return [ [ 'type' => '404' ] ];
+	}
 }

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -470,6 +470,21 @@ class Breadcrumb {
 	}
 
 	/**
+	 * Build a pagination item for paged archive views.
+	 *
+	 * URL points to page 1 of the same archive (allows "back to first page").
+	 *
+	 * @return array{type: string, page: int, url: string}
+	 */
+	protected function build_pagination_item(): array {
+		return [
+			'type' => 'pagination',
+			'page' => (int) get_query_var( 'paged' ),
+			'url'  => get_pagenum_link( 1 ),
+		];
+	}
+
+	/**
 	 * Find a menu item in an array of items by field-value match.
 	 *
 	 * Normalizes numeric values to int before strict comparison.

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -224,4 +224,48 @@ class Breadcrumb {
 			],
 		];
 	}
+
+	/**
+	 * Build breadcrumb items for a taxonomy term archive page.
+	 *
+	 * For hierarchical taxonomies, prepends ancestor terms (root to leaf).
+	 * `get_term_link()` returning `WP_Error` is guarded — item still added
+	 * with `url => null` (the leaf term is the current page anyway).
+	 *
+	 * @return array<int, array{type: string, title: string, url: string|null}>
+	 */
+	protected function build_for_taxonomy(): array {
+		$term = get_queried_object();
+		if ( ! $term || ! isset( $term->term_id, $term->name, $term->taxonomy ) ) {
+			return [];
+		}
+
+		$items = [];
+
+		if ( is_taxonomy_hierarchical( $term->taxonomy ) ) {
+			$ancestor_ids = get_ancestors( (int) $term->term_id, $term->taxonomy, 'taxonomy' );
+			$ancestor_ids = array_reverse( $ancestor_ids );
+			foreach ( $ancestor_ids as $ancestor_id ) {
+				$ancestor = get_term( $ancestor_id, $term->taxonomy );
+				if ( ! $ancestor || is_wp_error( $ancestor ) ) {
+					continue;
+				}
+				$ancestor_url = get_term_link( $ancestor );
+				$items[] = [
+					'type'  => 'item',
+					'title' => (string) $ancestor->name,
+					'url'   => is_string( $ancestor_url ) ? $ancestor_url : null,
+				];
+			}
+		}
+
+		$term_url = get_term_link( $term );
+		$items[] = [
+			'type'  => 'item',
+			'title' => (string) $term->name,
+			'url'   => is_string( $term_url ) ? $term_url : null,
+		];
+
+		return $items;
+	}
 }

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -331,6 +331,59 @@ class Breadcrumb {
 	}
 
 	/**
+	 * Resolve the ACF `links` option for list_page_map injection.
+	 *
+	 * Returns a normalized dict where each entry has `{id, title, url}`.
+	 * Defensive against ACF being absent — returns `[]` without fatal.
+	 * URLs are resolved through `wpml_object_id` so a Czech site rendering
+	 * the English breadcrumb gets the English article-list page link.
+	 *
+	 * @return array<string, array{id: int, title: string, url: string}>
+	 */
+	protected function get_global_links(): array {
+		if ( ! function_exists( 'get_field' ) ) {
+			return [];
+		}
+
+		$data = [];
+		$links = get_field( 'links', 'option' );
+
+		if ( ! is_countable( $links ) ) {
+			return $data;
+		}
+
+		foreach ( $links as $key => $item ) {
+			if ( is_string( $item ) && ! empty( $item ) ) {
+				$post_id = url_to_postid( $item );
+				if ( $post_id ) {
+					$translated_id = (int) apply_filters( 'wpml_object_id', $post_id, 'page' );
+					$data[ $key ] = [
+						'id'    => $translated_id,
+						'title' => '',
+						'url'   => get_permalink( $translated_id ),
+					];
+				}
+			} elseif ( is_array( $item ) && isset( $item['url'] ) ) {
+				$post_id = url_to_postid( $item['url'] );
+				if ( $post_id ) {
+					$translated_id = (int) apply_filters( 'wpml_object_id', $post_id, 'page' );
+					$url = get_permalink( $translated_id );
+				} else {
+					$translated_id = 0;
+					$url = $item['url'];
+				}
+				$data[ $key ] = [
+					'id'    => $translated_id,
+					'title' => $item['title'] ?? '',
+					'url'   => $url,
+				];
+			}
+		}
+
+		return $data;
+	}
+
+	/**
 	 * Find a menu item in an array of items by field-value match.
 	 *
 	 * Normalizes numeric values to int before strict comparison.

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -270,6 +270,67 @@ class Breadcrumb {
 	}
 
 	/**
+	 * Walk the configured nav menu for the queried page's parent chain.
+	 *
+	 * Returns items in root-to-leaf order, excluding the current page (the
+	 * caller appends current as a separate item). Each item has shape
+	 * `{type: 'item', title, url}`.
+	 *
+	 * WPML-aware: the queried object id is normalized via the `wpml_object_id`
+	 * filter before menu lookup, so the chain is built from the menu items
+	 * in the *active language* rather than the default language.
+	 *
+	 * @return array<int, array{type: string, title: string, url: string}>
+	 */
+	protected function by_menu_trail(): array {
+		$menu_name = $this->menu_name;
+		$breadcrumb_items = [];
+
+		$locations = get_nav_menu_locations();
+		if ( isset( $locations[ $menu_name ] ) ) {
+			$menu_name = $locations[ $menu_name ];
+		}
+
+		$items = wp_get_nav_menu_items( $menu_name );
+		if ( false === $items ) {
+			return $breadcrumb_items;
+		}
+
+		$queried_id = (int) apply_filters( 'wpml_object_id', get_queried_object_id(), 'page' );
+
+		$item = $this->get_menu_item( 'object_id', $queried_id, $items );
+		if ( false === $item ) {
+			return $breadcrumb_items;
+		}
+
+		$menu_item_objects = [ $item ];
+		while ( 0 !== (int) $item->menu_item_parent ) {
+			$item = $this->get_menu_item( 'ID', $item->menu_item_parent, $items );
+			if ( false === $item ) {
+				break;
+			}
+			$menu_item_objects[] = $item;
+		}
+		$menu_item_objects = array_reverse( $menu_item_objects );
+
+		foreach ( $menu_item_objects as $menu_item ) {
+			if ( ! isset( $menu_item->url ) || empty( $menu_item->url ) || '#' === $menu_item->url ) {
+				continue;
+			}
+			if ( $menu_item->url === get_permalink() ) {
+				continue;
+			}
+			$breadcrumb_items[] = [
+				'type'  => 'item',
+				'title' => (string) $menu_item->title,
+				'url'   => (string) $menu_item->url,
+			];
+		}
+
+		return $breadcrumb_items;
+	}
+
+	/**
 	 * Find a menu item in an array of items by field-value match.
 	 *
 	 * Normalizes numeric values to int before strict comparison.

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -113,4 +113,23 @@ class Breadcrumb {
 			],
 		];
 	}
+
+	/**
+	 * Build breadcrumb items for an author archive page.
+	 *
+	 * @return array<int, array{type: string, display_name: string, url: string}>
+	 */
+	protected function build_for_author_archive(): array {
+		$author = get_queried_object();
+		if ( ! $author || ! isset( $author->display_name, $author->ID ) ) {
+			return [];
+		}
+		return [
+			[
+				'type'         => 'author',
+				'display_name' => (string) $author->display_name,
+				'url'          => get_author_posts_url( (int) $author->ID ),
+			],
+		];
+	}
 }

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -132,4 +132,63 @@ class Breadcrumb {
 			],
 		];
 	}
+
+	/**
+	 * Build breadcrumb items for a date archive (year / month / day).
+	 *
+	 * Year linked when month follows; month linked when day follows; day is
+	 * always the leaf (no url). Each item carries the date components needed
+	 * for hydrate() to format the title.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	protected function build_for_date_archive(): array {
+		$year  = (int) get_query_var( 'year' );
+		$month = (int) get_query_var( 'monthnum' );
+		$day   = (int) get_query_var( 'day' );
+
+		if ( $year <= 0 ) {
+			return [];
+		}
+
+		$items = [];
+
+		if ( $month > 0 ) {
+			$items[] = [
+				'type' => 'date_year',
+				'year' => $year,
+				'url'  => get_year_link( $year ),
+			];
+
+			if ( $day > 0 ) {
+				$items[] = [
+					'type'  => 'date_month',
+					'year'  => $year,
+					'month' => $month,
+					'url'   => get_month_link( $year, $month ),
+				];
+				$items[] = [
+					'type'  => 'date_day',
+					'year'  => $year,
+					'month' => $month,
+					'day'   => $day,
+				];
+			} else {
+				$items[] = [
+					'type'  => 'date_month',
+					'year'  => $year,
+					'month' => $month,
+					'url'   => null,
+				];
+			}
+		} else {
+			$items[] = [
+				'type' => 'date_year',
+				'year' => $year,
+				'url'  => null,
+			];
+		}
+
+		return $items;
+	}
 }

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -384,6 +384,41 @@ class Breadcrumb {
 	}
 
 	/**
+	 * Build breadcrumb items for a singular page/post/CPT.
+	 *
+	 * Branches by post type:
+	 * - `page`: menu-trail via configured nav menu, fallback to post_parent ancestors.
+	 * - `post` (or post type in `list_page_map`): listing page + current title.
+	 * - hierarchical CPT: menu-trail (if enabled) or post_parent ancestors.
+	 * - flat CPT: just current title.
+	 *
+	 * All branches append the current post title as the leaf (no url).
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	protected function build_for_singular(): array {
+		$post = get_queried_object();
+		if ( ! $post || ! isset( $post->ID, $post->post_title ) ) {
+			return [];
+		}
+
+		$post_type = get_post_type();
+		$items = [];
+
+		if ( 'page' === $post_type ) {
+			$items = $this->by_menu_trail();
+		}
+
+		$items[] = [
+			'type'  => 'item',
+			'title' => (string) $post->post_title,
+			'url'   => null,
+		];
+
+		return $items;
+	}
+
+	/**
 	 * Find a menu item in an array of items by field-value match.
 	 *
 	 * Normalizes numeric values to int before strict comparison.

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -485,6 +485,42 @@ class Breadcrumb {
 	}
 
 	/**
+	 * Resolve `title` on every item using the configured labels.
+	 *
+	 * Each item's `type` discriminator selects the label template; structured
+	 * extras (`query`, `page`, `year`, etc.) feed `sprintf()` placeholders.
+	 * Items already carrying a `title` (type 'item') pass through unchanged.
+	 *
+	 * Labels are filterable via `timber_kit_breadcrumb_labels` for per-request
+	 * customization (WPML language-aware overrides, per-page brand changes).
+	 *
+	 * @param array<int, array<string, mixed>> $items
+	 * @return array<int, array<string, mixed>>
+	 */
+	protected function hydrate( array $items ): array {
+		/** @var array<string, string> $labels */
+		$labels = apply_filters( 'timber_kit_breadcrumb_labels', $this->labels, $items );
+
+		foreach ( $items as &$item ) {
+			$type = $item['type'] ?? 'item';
+			$item['title'] = match ( $type ) {
+				'home'       => $labels['home']       ?? 'Home',
+				'404'        => $labels['404']        ?? 'Page not found',
+				'search'     => sprintf( $labels['search']     ?? '%s', $item['query']        ?? '' ),
+				'pagination' => sprintf( $labels['pagination'] ?? '%d', $item['page']         ?? 1  ),
+				'author'     => sprintf( $labels['author']     ?? '%s', $item['display_name'] ?? '' ),
+				'date_year'  => (string) ( $item['year'] ?? '' ),
+				'date_month' => wp_date( 'F', mktime( 0, 0, 0, $item['month'] ?? 1, 1, $item['year'] ?? (int) date( 'Y' ) ) ),
+				'date_day'   => (string) ( $item['day']  ?? '' ),
+				default      => $item['title'] ?? '',
+			};
+		}
+		unset( $item );
+
+		return $items;
+	}
+
+	/**
 	 * Find a menu item in an array of items by field-value match.
 	 *
 	 * Normalizes numeric values to int before strict comparison.

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -321,15 +321,15 @@ class Breadcrumb {
 	 * @return array<int, array{type: string, title: string, url: string}>
 	 */
 	protected function by_menu_trail(): array {
-		$menu_name = $this->menu_name;
+		$resolved_menu = $this->menu_name;
 		$breadcrumb_items = [];
 
 		$locations = get_nav_menu_locations();
-		if ( isset( $locations[ $menu_name ] ) ) {
-			$menu_name = $locations[ $menu_name ];
+		if ( isset( $locations[ $resolved_menu ] ) ) {
+			$resolved_menu = $locations[ $resolved_menu ];
 		}
 
-		$items = wp_get_nav_menu_items( $menu_name );
+		$items = wp_get_nav_menu_items( $resolved_menu );
 		if ( false === $items ) {
 			return $breadcrumb_items;
 		}
@@ -369,7 +369,7 @@ class Breadcrumb {
 		$breadcrumb_items = apply_filters(
 			'timber_kit_breadcrumb_menu_trail',
 			$breadcrumb_items,
-			$menu_name
+			$this->menu_name
 		);
 
 		return $breadcrumb_items;

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -445,6 +445,19 @@ class Breadcrumb {
 					'url'   => (string) $links[ $list_key ]['url'],
 				];
 			}
+		} else {
+			// CPT branch — hierarchical uses ancestors; flat uses only the title
+			$is_hierarchical = is_post_type_hierarchical( $post_type );
+			$menu_trail_eligible = null === $this->menu_trail_post_types
+				? $is_hierarchical
+				: in_array( $post_type, $this->menu_trail_post_types, true );
+
+			if ( $menu_trail_eligible ) {
+				$items = $this->by_menu_trail();
+				if ( empty( $items ) && $is_hierarchical ) {
+					$items = $this->build_ancestors_chain( $post );
+				}
+			}
 		}
 
 		$items[] = [

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -98,4 +98,19 @@ class Breadcrumb {
 	protected function build_for_404(): array {
 		return [ [ 'type' => '404' ] ];
 	}
+
+	/**
+	 * Build breadcrumb items for a search results page.
+	 *
+	 * @return array<int, array{type: string, query: string, url: string}>
+	 */
+	protected function build_for_search(): array {
+		return [
+			[
+				'type'  => 'search',
+				'query' => get_search_query(),
+				'url'   => get_search_link(),
+			],
+		];
+	}
 }

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -72,10 +72,48 @@ class Breadcrumb {
 	/**
 	 * Build the breadcrumb item array for the current WordPress query state.
 	 *
+	 * Routing order:
+	 * 1. `timber_kit_breadcrumb_skip` filter — return [] immediately if true.
+	 * 2. Front page (non-paged) — return [].
+	 * 3. Dispatch to the matching strategy via match(true).
+	 * 4. Optionally append a pagination item when include_pagination is set.
+	 * 5. `timber_kit_breadcrumb_items` filter — modify the structured item array.
+	 * 6. hydrate() — resolve titles and apply `timber_kit_breadcrumb_labels`.
+	 *
 	 * @return array<int, array<string, mixed>> Typed items with hydrated titles.
 	 */
 	public function get(): array {
-		return [];
+		if ( apply_filters( 'timber_kit_breadcrumb_skip', false, $GLOBALS['wp_query'] ?? null ) ) {
+			return [];
+		}
+
+		if ( is_front_page() && ! is_paged() ) {
+			return [];
+		}
+
+		$home = $this->build_home_item();
+
+		$items = match ( true ) {
+			is_404()                              => $this->build_for_404(),
+			is_search()                           => $this->build_for_search(),
+			is_date()                             => $this->build_for_date_archive(),
+			is_author()                           => $this->build_for_author_archive(),
+			is_post_type_archive()                => $this->build_for_post_type_archive(),
+			is_tax() || is_category() || is_tag() => $this->build_for_taxonomy(),
+			is_singular()                         => $this->build_for_singular(),
+			default                               => [],
+		};
+
+		if ( $this->include_pagination && is_paged() ) {
+			$items[] = $this->build_pagination_item();
+		}
+
+		$all = array_values( array_merge( [ $home ], $items ) );
+
+		/** @var array<int, array<string, mixed>> $all */
+		$all = apply_filters( 'timber_kit_breadcrumb_items', $all, $this );
+
+		return $this->hydrate( $all );
 	}
 
 	/**

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -77,4 +77,16 @@ class Breadcrumb {
 	public function get(): array {
 		return [];
 	}
+
+	/**
+	 * Build the home breadcrumb item. Always the first item in the trail.
+	 *
+	 * @return array{type: string, url: string}
+	 */
+	protected function build_home_item(): array {
+		return [
+			'type' => 'home',
+			'url'  => home_url( '/' ),
+		];
+	}
 }

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -268,4 +268,30 @@ class Breadcrumb {
 
 		return $items;
 	}
+
+	/**
+	 * Find a menu item in an array of items by field-value match.
+	 *
+	 * Normalizes numeric values to int before strict comparison.
+	 * `wp_get_nav_menu_items()` returns `object_id` and `menu_item_parent`
+	 * as strings (post_meta is always stringified) while `ID` is int
+	 * (from wp_posts) and `get_queried_object_id()` also returns int.
+	 * Without this normalization `'42' === 42` is false and the menu
+	 * lookup silently fails — breaking breadcrumbs for normal nav menus.
+	 *
+	 * @param string             $field     Property name to compare.
+	 * @param mixed              $object_id Needle value.
+	 * @param array<int, object> $items     Haystack of menu-item objects.
+	 * @return object|false Matching item, or false if not found.
+	 */
+	protected function get_menu_item( string $field, mixed $object_id, array $items ): object|false {
+		$needle = is_numeric( $object_id ) ? (int) $object_id : $object_id;
+		foreach ( $items as $item ) {
+			$haystack = is_numeric( $item->$field ) ? (int) $item->$field : $item->$field;
+			if ( $haystack === $needle ) {
+				return $item;
+			}
+		}
+		return false;
+	}
 }

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+namespace Parisek\TimberKit;
+
+/**
+ * Builds breadcrumb data for the current WordPress query state.
+ *
+ * Returns an array of typed items `[{type, url, title, …extras}]`, with
+ * `type` discriminating which strategy produced the item ('home', 'item',
+ * '404', 'search', 'date_year', 'date_month', 'date_day', 'author',
+ * 'pagination'). After `hydrate()`, every item has a populated `title`
+ * suitable for direct Twig consumption.
+ *
+ * Configure via constructor:
+ * ```
+ * $bc = new Breadcrumb([
+ *     'menu_name'             => 'main-menu',
+ *     'list_page_map'         => ['post' => 'article_list'],
+ *     'menu_trail_post_types' => null,
+ *     'include_pagination'    => false,
+ *     'labels'                => [
+ *         'home'       => _x('Home', 'theme', 'theme'),
+ *         '404'        => _x('Page not found', 'theme', 'theme'),
+ *         'search'     => _x('Search: %s', 'theme', 'theme'),
+ *         'pagination' => _x('Page %d', 'theme', 'theme'),
+ *         'author'     => _x('Author: %s', 'theme', 'theme'),
+ *     ],
+ * ]);
+ * $items = $bc->get();
+ * ```
+ *
+ * Translation strategy: this class is text-domain agnostic. The `labels`
+ * array carries pre-translated strings supplied by the calling project.
+ * Defaults are English raw strings — graceful degradation when a project
+ * forgets to configure labels.
+ */
+class Breadcrumb {
+
+	/** @var string Nav menu location for menu-trail strategy */
+	protected string $menu_name = 'main-menu';
+
+	/** @var array<string, string> Post type → ACF option key for "listing page" injection */
+	protected array $list_page_map = [];
+
+	/** @var array<int, string>|null Post types eligible for menu-trail; null = auto-detect hierarchical */
+	protected ?array $menu_trail_post_types = null;
+
+	/** @var bool Whether to add "Page N" item on paginated views */
+	protected bool $include_pagination = false;
+
+	/** @var array{'home': string, '404': string, 'search': string, 'pagination': string, 'author': string} Label dict; pre-translated by the caller */
+	protected array $labels = [
+		'home'       => 'Home',
+		'404'        => 'Page not found',
+		'search'     => 'Search: %s',
+		'pagination' => 'Page %d',
+		'author'     => 'Author: %s',
+	];
+
+	/**
+	 * @param array<string, mixed> $config Optional config overriding default property values.
+	 */
+	public function __construct( array $config = [] ) {
+		foreach ( $config as $key => $value ) {
+			if ( property_exists( $this, $key ) ) {
+				$this->$key = $value;
+			}
+		}
+	}
+
+	/**
+	 * Build the breadcrumb item array for the current WordPress query state.
+	 *
+	 * @return array<int, array<string, mixed>> Typed items with hydrated titles.
+	 */
+	public function get(): array {
+		return [];
+	}
+}

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -435,6 +435,16 @@ class Breadcrumb {
 			if ( empty( $items ) ) {
 				$items = $this->build_ancestors_chain( $post );
 			}
+		} elseif ( isset( $this->list_page_map[ $post_type ] ) ) {
+			$links = $this->get_global_links();
+			$list_key = $this->list_page_map[ $post_type ];
+			if ( isset( $links[ $list_key ]['url'], $links[ $list_key ]['title'] ) ) {
+				$items[] = [
+					'type'  => 'item',
+					'title' => (string) $links[ $list_key ]['title'],
+					'url'   => (string) $links[ $list_key ]['url'],
+				];
+			}
 		}
 
 		$items[] = [

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -331,6 +331,31 @@ class Breadcrumb {
 	}
 
 	/**
+	 * Build a chain of items from a post's `post_parent` ancestors.
+	 *
+	 * Returns items in root-to-leaf order, excluding the post itself.
+	 *
+	 * @param object $post Post object (unused arg; method uses get_post() globals).
+	 * @return array<int, array{type: string, title: string, url: string}>
+	 */
+	protected function build_ancestors_chain( object $post ): array {
+		unset( $post );
+		$current_post = get_post();
+		$ancestors = get_post_ancestors( $current_post );
+		$ancestors = array_reverse( $ancestors );
+
+		$items = [];
+		foreach ( $ancestors as $ancestor_id ) {
+			$items[] = [
+				'type'  => 'item',
+				'title' => (string) get_the_title( $ancestor_id ),
+				'url'   => (string) get_permalink( $ancestor_id ),
+			];
+		}
+		return $items;
+	}
+
+	/**
 	 * Resolve the ACF `links` option for list_page_map injection.
 	 *
 	 * Returns a normalized dict where each entry has `{id, title, url}`.
@@ -407,6 +432,9 @@ class Breadcrumb {
 
 		if ( 'page' === $post_type ) {
 			$items = $this->by_menu_trail();
+			if ( empty( $items ) ) {
+				$items = $this->build_ancestors_chain( $post );
+			}
 		}
 
 		$items[] = [

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -365,6 +365,13 @@ class Breadcrumb {
 			];
 		}
 
+		/** @var array<int, array<string, string>> $breadcrumb_items */
+		$breadcrumb_items = apply_filters(
+			'timber_kit_breadcrumb_menu_trail',
+			$breadcrumb_items,
+			$menu_name
+		);
+
 		return $breadcrumb_items;
 	}
 

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -615,15 +615,15 @@ class StarterBase extends Site {
 
 		// Auto-populate $context['breadcrumb'] — unless the project still ships
 		// a global \Breadcrumb class (legacy convention from wordpress-base
-		// versions before 1.6.0). The class_exists check (with autoload=false)
-		// is a plain class-map lookup, not a filesystem probe; if the project
-		// autoloads classes/Breadcrumb.php via Composer, Base.php's constructor
-		// has already loaded it by the time timber_context() fires.
+		// versions before 1.6.0). class_exists triggers Composer's classmap
+		// autoload when the class is registered (cheap; one map lookup), so
+		// the guard reliably detects the legacy class even before the project
+		// instantiates it.
 		//
-		// Skipping when legacy class exists avoids wasted compute — the
-		// project's Base::timber_context() overwrites $context['breadcrumb']
-		// anyway via its own `new \Breadcrumb()` call.
-		if ( ! class_exists( '\Breadcrumb', false ) ) {
+		// Skipping when legacy class exists avoids double computation — the
+		// project's Base::timber_context() overrides $context['breadcrumb']
+		// later anyway via its own `new \Breadcrumb()` call.
+		if ( ! class_exists( '\Breadcrumb' ) ) {
 			$bc = new Breadcrumb( [
 				'menu_name'             => $this->breadcrumb_menu_name,
 				'list_page_map'         => $this->breadcrumb_list_page_map,

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -613,6 +613,27 @@ class StarterBase extends Site {
 		}
 		$context['search_query'] = get_search_query();
 
+		// Auto-populate $context['breadcrumb'] — unless the project still ships
+		// a global \Breadcrumb class (legacy convention from wordpress-base
+		// versions before 1.6.0). The class_exists check (with autoload=false)
+		// is a plain class-map lookup, not a filesystem probe; if the project
+		// autoloads classes/Breadcrumb.php via Composer, Base.php's constructor
+		// has already loaded it by the time timber_context() fires.
+		//
+		// Skipping when legacy class exists avoids wasted compute — the
+		// project's Base::timber_context() overwrites $context['breadcrumb']
+		// anyway via its own `new \Breadcrumb()` call.
+		if ( ! class_exists( '\Breadcrumb', false ) ) {
+			$bc = new Breadcrumb( [
+				'menu_name'             => $this->breadcrumb_menu_name,
+				'list_page_map'         => $this->breadcrumb_list_page_map,
+				'menu_trail_post_types' => $this->breadcrumb_menu_trail_post_types,
+				'include_pagination'    => $this->breadcrumb_include_pagination,
+				'labels'                => $this->breadcrumb_labels,
+			] );
+			$context['breadcrumb'] = $bc->get();
+		}
+
 		return $context;
 	}
 

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -87,6 +87,27 @@ class StarterBase extends Site {
 	/** @var string Twig template used to wrap core Gutenberg blocks on non-article pages. */
 	protected string $block_wrapper_template = '@component/content/content.twig';
 
+	/** @var string Nav menu location for breadcrumb menu-trail strategy */
+	protected string $breadcrumb_menu_name = 'main-menu';
+
+	/** @var array<string, string> Post type → ACF option key for "listing page" injection */
+	protected array $breadcrumb_list_page_map = [];
+
+	/** @var array<int, string>|null Post types eligible for menu-trail; null = auto-detect hierarchical */
+	protected ?array $breadcrumb_menu_trail_post_types = null;
+
+	/** @var bool Whether to add "Page N" item on paginated views */
+	protected bool $breadcrumb_include_pagination = false;
+
+	/** @var array{home: string, '404': string, search: string, pagination: string, author: string} Default English labels */
+	protected array $breadcrumb_labels = [
+		'home'       => 'Home',
+		'404'        => 'Page not found',
+		'search'     => 'Search: %s',
+		'pagination' => 'Page %d',
+		'author'     => 'Author: %s',
+	];
+
 	/**
 	 * Security & cleanup — override in child constructor to disable
 	 */

--- a/tests/Fixtures/LegacyBreadcrumbStub.php
+++ b/tests/Fixtures/LegacyBreadcrumbStub.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Stub global \Breadcrumb class.
+ *
+ * Loaded only by tests that exercise the legacy-class guard in
+ * StarterBase::timber_context() — see tests/Unit/Breadcrumb/StarterBaseBreadcrumbTest.php.
+ *
+ * Always require this file inside an `if ( ! class_exists( '\Breadcrumb' ) )`
+ * guard to keep it idempotent across multi-test runs.
+ */
+if ( ! class_exists( '\Breadcrumb' ) ) {
+	class Breadcrumb {
+		public function get(): array {
+			return [];
+		}
+	}
+}

--- a/tests/Unit/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Unit/Breadcrumb/BreadcrumbTest.php
@@ -173,4 +173,38 @@ final class BreadcrumbTest extends BreadcrumbTestCase {
 			[ 'type' => 'date_day',   'year' => 2024, 'month' => 5, 'day' => 15 ],
 		], $result );
 	}
+
+	// -------------------------------------------------------------------
+	// Strategy: post type archive
+	// -------------------------------------------------------------------
+
+	public function test_build_for_post_type_archive_returns_archive_label(): void {
+		Functions\expect( 'get_query_var' )->with( 'post_type' )->andReturn( 'project' );
+		$cpt_object = (object) [
+			'name'   => 'project',
+			'labels' => (object) [ 'archives' => 'Projects archive' ],
+		];
+		Functions\expect( 'get_post_type_object' )->once()->with( 'project' )->andReturn( $cpt_object );
+		Functions\expect( 'get_post_type_archive_link' )->once()->with( 'project' )->andReturn( 'https://example.test/projects/' );
+
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'build_for_post_type_archive' );
+
+		$this->assertSame( [
+			[
+				'type'  => 'item',
+				'title' => 'Projects archive',
+				'url'   => 'https://example.test/projects/',
+			],
+		], $result );
+	}
+
+	public function test_build_for_post_type_archive_skips_missing_cpt(): void {
+		Functions\expect( 'get_query_var' )->with( 'post_type' )->andReturn( false );
+
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'build_for_post_type_archive' );
+
+		$this->assertSame( [], $result );
+	}
 }

--- a/tests/Unit/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Unit/Breadcrumb/BreadcrumbTest.php
@@ -17,7 +17,7 @@ final class BreadcrumbTest extends BreadcrumbTestCase {
 
 	public function test_constructor_accepts_no_arguments(): void {
 		$bc = new Breadcrumb();
-		$this->assertSame( [], $bc->get() );
+		$this->assertInstanceOf( Breadcrumb::class, $bc );
 	}
 
 	public function test_constructor_applies_config_to_known_properties(): void {
@@ -36,7 +36,7 @@ final class BreadcrumbTest extends BreadcrumbTestCase {
 
 	public function test_constructor_ignores_unknown_config_keys(): void {
 		$bc = new Breadcrumb([ 'nonexistent_key' => 'whatever' ]);
-		$this->assertSame( [], $bc->get() );
+		$this->assertInstanceOf( Breadcrumb::class, $bc );
 	}
 
 	// -------------------------------------------------------------------
@@ -633,5 +633,79 @@ final class BreadcrumbTest extends BreadcrumbTestCase {
 		$this->assertSame( 'item', $result[0]['type'] );
 		$this->assertSame( 'Home', $result[0]['title'] );
 		$this->assertSame( 'Services', $result[1]['title'] );
+	}
+
+	// -------------------------------------------------------------------
+	// Integration: get() dispatcher
+	// -------------------------------------------------------------------
+
+	public function test_get_dispatches_404_and_hydrates(): void {
+		Functions\when( 'is_front_page' )->justReturn( false );
+		Functions\when( 'is_paged' )->justReturn( false );
+		Functions\when( 'is_404' )->justReturn( true );
+		Functions\when( 'is_search' )->justReturn( false );
+		Functions\when( 'is_date' )->justReturn( false );
+		Functions\when( 'is_author' )->justReturn( false );
+		Functions\when( 'is_post_type_archive' )->justReturn( false );
+		Functions\when( 'is_tax' )->justReturn( false );
+		Functions\when( 'is_category' )->justReturn( false );
+		Functions\when( 'is_tag' )->justReturn( false );
+		Functions\when( 'is_singular' )->justReturn( false );
+		Functions\when( 'home_url' )->justReturn( 'https://example.test/' );
+
+		\Brain\Monkey\Filters\expectApplied( 'timber_kit_breadcrumb_skip' )->andReturn( false );
+		\Brain\Monkey\Filters\expectApplied( 'timber_kit_breadcrumb_items' )->andReturnUsing( fn( $items ) => $items );
+		\Brain\Monkey\Filters\expectApplied( 'timber_kit_breadcrumb_labels' )->andReturnUsing( fn( $labels ) => $labels );
+
+		$bc = new Breadcrumb();
+		$result = $bc->get();
+
+		$this->assertCount( 2, $result );
+		$this->assertSame( 'home', $result[0]['type'] );
+		$this->assertSame( 'Home', $result[0]['title'] );
+		$this->assertSame( '404', $result[1]['type'] );
+		$this->assertSame( 'Page not found', $result[1]['title'] );
+	}
+
+	public function test_get_returns_empty_on_front_page(): void {
+		Functions\when( 'is_front_page' )->justReturn( true );
+		Functions\when( 'is_paged' )->justReturn( false );
+		\Brain\Monkey\Filters\expectApplied( 'timber_kit_breadcrumb_skip' )->andReturn( false );
+
+		$bc = new Breadcrumb();
+		$this->assertSame( [], $bc->get() );
+	}
+
+	public function test_get_respects_skip_filter(): void {
+		\Brain\Monkey\Filters\expectApplied( 'timber_kit_breadcrumb_skip' )->andReturn( true );
+
+		$bc = new Breadcrumb();
+		$this->assertSame( [], $bc->get() );
+	}
+
+	public function test_get_applies_items_filter_before_hydrate(): void {
+		Functions\when( 'is_front_page' )->justReturn( false );
+		Functions\when( 'is_paged' )->justReturn( false );
+		Functions\when( 'is_404' )->justReturn( true );
+		Functions\when( 'is_search' )->justReturn( false );
+		Functions\when( 'is_date' )->justReturn( false );
+		Functions\when( 'is_author' )->justReturn( false );
+		Functions\when( 'is_post_type_archive' )->justReturn( false );
+		Functions\when( 'is_tax' )->justReturn( false );
+		Functions\when( 'is_category' )->justReturn( false );
+		Functions\when( 'is_tag' )->justReturn( false );
+		Functions\when( 'is_singular' )->justReturn( false );
+		Functions\when( 'home_url' )->justReturn( 'https://example.test/' );
+
+		\Brain\Monkey\Filters\expectApplied( 'timber_kit_breadcrumb_skip' )->andReturn( false );
+		\Brain\Monkey\Filters\expectApplied( 'timber_kit_breadcrumb_items' )
+			->andReturnUsing( fn( $items ) => array_values( array_filter( $items, fn( $i ) => 'home' === $i['type'] ) ) );
+		\Brain\Monkey\Filters\expectApplied( 'timber_kit_breadcrumb_labels' )->andReturnUsing( fn( $labels ) => $labels );
+
+		$bc = new Breadcrumb();
+		$result = $bc->get();
+
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'home', $result[0]['type'] );
 	}
 }

--- a/tests/Unit/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Unit/Breadcrumb/BreadcrumbTest.php
@@ -382,6 +382,40 @@ final class BreadcrumbTest extends BreadcrumbTestCase {
 		$this->assertSame( 'https://example.test/blog', $result['article_list']['url'] );
 	}
 
+	// -------------------------------------------------------------------
+	// Strategy: singular (page, menu-trail success)
+	// -------------------------------------------------------------------
+
+	public function test_build_for_singular_page_with_menu_trail(): void {
+		Functions\when( 'get_post_type' )->justReturn( 'page' );
+		$post = (object) [ 'ID' => 30, 'post_title' => 'Web Design' ];
+		Functions\when( 'get_queried_object' )->justReturn( $post );
+		Functions\when( 'get_permalink' )->alias( function( $id = null ) {
+			return 'https://example.test/services/web';  // both no-arg and arg-30 return same
+		} );
+
+		Functions\expect( 'get_nav_menu_locations' )->once()->andReturn( [] );
+		Functions\expect( 'wp_get_nav_menu_items' )->once()->andReturn( [
+			(object) [ 'ID' => 1, 'object_id' => '10', 'menu_item_parent' => '0',
+				'url' => 'https://example.test/', 'title' => 'Home' ],
+			(object) [ 'ID' => 2, 'object_id' => '20', 'menu_item_parent' => '1',
+				'url' => 'https://example.test/services', 'title' => 'Services' ],
+			(object) [ 'ID' => 3, 'object_id' => '30', 'menu_item_parent' => '2',
+				'url' => 'https://example.test/services/web', 'title' => 'Web Design' ],
+		] );
+		Functions\expect( 'get_queried_object_id' )->andReturn( 30 );
+		\Brain\Monkey\Filters\expectApplied( 'wpml_object_id' )->andReturn( 30 );
+
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'build_for_singular' );
+
+		$this->assertSame( [
+			[ 'type' => 'item', 'title' => 'Home',     'url' => 'https://example.test/' ],
+			[ 'type' => 'item', 'title' => 'Services', 'url' => 'https://example.test/services' ],
+			[ 'type' => 'item', 'title' => 'Web Design', 'url' => null ],
+		], $result );
+	}
+
 	public function test_by_menu_trail_returns_ancestor_chain_with_current_filtered(): void {
 		$menu_items = [
 			(object) [

--- a/tests/Unit/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Unit/Breadcrumb/BreadcrumbTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Breadcrumb;
 
+use Brain\Monkey\Functions;
 use Parisek\TimberKit\Breadcrumb;
 use ReflectionClass;
 
@@ -35,5 +36,21 @@ final class BreadcrumbTest extends BreadcrumbTestCase {
 	public function test_constructor_ignores_unknown_config_keys(): void {
 		$bc = new Breadcrumb([ 'nonexistent_key' => 'whatever' ]);
 		$this->assertSame( [], $bc->get() );
+	}
+
+	// -------------------------------------------------------------------
+	// Strategy: home
+	// -------------------------------------------------------------------
+
+	public function test_build_home_item_returns_home_with_home_url(): void {
+		Functions\expect( 'home_url' )->once()->with( '/' )->andReturn( 'https://example.test/' );
+
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'build_home_item' );
+
+		$this->assertSame( [
+			'type' => 'home',
+			'url'  => 'https://example.test/',
+		], $result );
 	}
 }

--- a/tests/Unit/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Unit/Breadcrumb/BreadcrumbTest.php
@@ -735,4 +735,44 @@ final class BreadcrumbTest extends BreadcrumbTestCase {
 		$this->assertCount( 1, $result );
 		$this->assertSame( 'home', $result[0]['type'] );
 	}
+
+	// -------------------------------------------------------------------
+	// Integration: include_pagination
+	// -------------------------------------------------------------------
+
+	public function test_get_appends_pagination_when_enabled(): void {
+		Functions\when( 'is_front_page' )->justReturn( false );
+		Functions\when( 'is_paged' )->justReturn( true );
+		Functions\when( 'is_404' )->justReturn( false );
+		Functions\when( 'is_search' )->justReturn( false );
+		Functions\when( 'is_date' )->justReturn( false );
+		Functions\when( 'is_author' )->justReturn( false );
+		Functions\when( 'is_post_type_archive' )->justReturn( false );
+		Functions\when( 'is_tax' )->justReturn( false );
+		Functions\when( 'is_category' )->justReturn( true );
+		Functions\when( 'is_tag' )->justReturn( false );
+		Functions\when( 'is_singular' )->justReturn( false );
+		Functions\when( 'home_url' )->justReturn( 'https://example.test/' );
+
+		$term = (object) [ 'term_id' => 10, 'name' => 'News', 'taxonomy' => 'category' ];
+		Functions\when( 'get_queried_object' )->justReturn( $term );
+		Functions\when( 'is_taxonomy_hierarchical' )->justReturn( false );
+		Functions\when( 'get_term_link' )->justReturn( 'https://example.test/category/news/' );
+
+		Functions\when( 'get_query_var' )->justReturn( 3 );
+		Functions\when( 'get_pagenum_link' )->justReturn( 'https://example.test/category/news/' );
+
+		\Brain\Monkey\Filters\expectApplied( 'timber_kit_breadcrumb_skip' )->andReturn( false );
+		\Brain\Monkey\Filters\expectApplied( 'timber_kit_breadcrumb_items' )->andReturnUsing( fn( $items ) => $items );
+		\Brain\Monkey\Filters\expectApplied( 'timber_kit_breadcrumb_labels' )->andReturnUsing( fn( $labels ) => $labels );
+
+		$bc = new Breadcrumb([ 'include_pagination' => true ]);
+		$result = $bc->get();
+
+		$this->assertCount( 3, $result );
+		$this->assertSame( 'home', $result[0]['type'] );
+		$this->assertSame( 'item', $result[1]['type'] );
+		$this->assertSame( 'pagination', $result[2]['type'] );
+		$this->assertSame( 'Page 3', $result[2]['title'] );
+	}
 }

--- a/tests/Unit/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Unit/Breadcrumb/BreadcrumbTest.php
@@ -341,6 +341,47 @@ final class BreadcrumbTest extends BreadcrumbTestCase {
 		$this->assertSame( [], $result );
 	}
 
+	// -------------------------------------------------------------------
+	// Helper: get_global_links
+	// -------------------------------------------------------------------
+
+	public function test_get_global_links_returns_empty_when_acf_unavailable(): void {
+		// get_field is not stubbed — function_exists() returns false
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'get_global_links' );
+
+		$this->assertSame( [], $result );
+	}
+
+	public function test_get_global_links_returns_empty_when_acf_returns_null(): void {
+		Functions\when( 'get_field' )->justReturn( null );
+
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'get_global_links' );
+
+		$this->assertSame( [], $result );
+	}
+
+	public function test_get_global_links_normalises_array_entry_with_post_resolution(): void {
+		Functions\when( 'get_field' )->justReturn( [
+			'article_list' => [
+				'url'   => 'https://example.test/blog',
+				'title' => 'Blog',
+			],
+		] );
+		Functions\expect( 'url_to_postid' )->with( 'https://example.test/blog' )->andReturn( 42 );
+		\Brain\Monkey\Filters\expectApplied( 'wpml_object_id' )->with( 42, 'page' )->andReturn( 42 );
+		Functions\expect( 'get_permalink' )->with( 42 )->andReturn( 'https://example.test/blog' );
+
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'get_global_links' );
+
+		$this->assertArrayHasKey( 'article_list', $result );
+		$this->assertSame( 42, $result['article_list']['id'] );
+		$this->assertSame( 'Blog', $result['article_list']['title'] );
+		$this->assertSame( 'https://example.test/blog', $result['article_list']['url'] );
+	}
+
 	public function test_by_menu_trail_returns_ancestor_chain_with_current_filtered(): void {
 		$menu_items = [
 			(object) [

--- a/tests/Unit/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Unit/Breadcrumb/BreadcrumbTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Breadcrumb;
 
+use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 use Parisek\TimberKit\Breadcrumb;
 use ReflectionClass;
@@ -304,5 +305,70 @@ final class BreadcrumbTest extends BreadcrumbTestCase {
 		$result = $this->invoke_protected( $bc, 'get_menu_item', [ 'object_id', 42, $items ] );
 
 		$this->assertSame( 'About', $result->title );
+	}
+
+	// -------------------------------------------------------------------
+	// Helper: by_menu_trail
+	// -------------------------------------------------------------------
+
+	public function test_by_menu_trail_returns_empty_when_no_menu_items(): void {
+		Functions\expect( 'get_nav_menu_locations' )->once()->andReturn( [] );
+		Functions\expect( 'wp_get_nav_menu_items' )->once()->andReturn( false );
+
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'by_menu_trail' );
+
+		$this->assertSame( [], $result );
+	}
+
+	public function test_by_menu_trail_returns_empty_when_current_page_not_in_menu(): void {
+		Functions\expect( 'get_nav_menu_locations' )->once()->andReturn( [] );
+		Functions\expect( 'wp_get_nav_menu_items' )->once()->andReturn( [
+			(object) [
+				'ID'               => 10,
+				'object_id'        => '100',
+				'menu_item_parent' => '0',
+				'url'              => 'https://example.test/about',
+				'title'            => 'About',
+			],
+		] );
+		Functions\expect( 'get_queried_object_id' )->once()->andReturn( 999 );
+		\Brain\Monkey\Filters\expectApplied( 'wpml_object_id' )->andReturn( 999 );
+
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'by_menu_trail' );
+
+		$this->assertSame( [], $result );
+	}
+
+	public function test_by_menu_trail_returns_ancestor_chain_with_current_filtered(): void {
+		$menu_items = [
+			(object) [
+				'ID' => 1, 'object_id' => '10', 'menu_item_parent' => '0',
+				'url' => 'https://example.test/', 'title' => 'Home',
+			],
+			(object) [
+				'ID' => 2, 'object_id' => '20', 'menu_item_parent' => '1',
+				'url' => 'https://example.test/services', 'title' => 'Services',
+			],
+			(object) [
+				'ID' => 3, 'object_id' => '30', 'menu_item_parent' => '2',
+				'url' => 'https://example.test/services/web', 'title' => 'Web',
+			],
+		];
+
+		Functions\expect( 'get_nav_menu_locations' )->once()->andReturn( [] );
+		Functions\expect( 'wp_get_nav_menu_items' )->once()->andReturn( $menu_items );
+		Functions\expect( 'get_queried_object_id' )->once()->andReturn( 30 );
+		\Brain\Monkey\Filters\expectApplied( 'wpml_object_id' )->andReturn( 30 );
+		Functions\expect( 'get_permalink' )->andReturn( 'https://example.test/services/web' );
+
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'by_menu_trail' );
+
+		$this->assertCount( 2, $result );
+		$this->assertSame( 'item', $result[0]['type'] );
+		$this->assertSame( 'Home', $result[0]['title'] );
+		$this->assertSame( 'Services', $result[1]['title'] );
 	}
 }

--- a/tests/Unit/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Unit/Breadcrumb/BreadcrumbTest.php
@@ -476,6 +476,48 @@ final class BreadcrumbTest extends BreadcrumbTestCase {
 		], $result );
 	}
 
+	public function test_build_for_singular_hierarchical_cpt_uses_ancestors(): void {
+		Functions\when( 'get_post_type' )->justReturn( 'project' );
+		$post = (object) [ 'ID' => 70, 'post_title' => 'Project Z' ];
+		Functions\when( 'get_queried_object' )->justReturn( $post );
+
+		Functions\expect( 'is_post_type_hierarchical' )->with( 'project' )->andReturn( true );
+
+		// by_menu_trail returns [] (no menu items)
+		Functions\expect( 'get_nav_menu_locations' )->once()->andReturn( [] );
+		Functions\expect( 'wp_get_nav_menu_items' )->once()->andReturn( [] );
+		Functions\expect( 'get_queried_object_id' )->andReturn( 70 );
+		\Brain\Monkey\Filters\expectApplied( 'wpml_object_id' )->andReturn( 70 );
+
+		// Fallback to ancestors
+		Functions\when( 'get_post' )->justReturn( $post );
+		Functions\expect( 'get_post_ancestors' )->once()->with( $post )->andReturn( [ 60 ] );
+		Functions\when( 'get_the_title' )->alias( fn( $id ) => $id === 60 ? 'Parent Project' : '' );
+		Functions\when( 'get_permalink' )->alias( fn( $id = null ) => $id === 60 ? 'https://example.test/projects/parent/' : '' );
+
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'build_for_singular' );
+
+		$this->assertSame( [
+			[ 'type' => 'item', 'title' => 'Parent Project', 'url' => 'https://example.test/projects/parent/' ],
+			[ 'type' => 'item', 'title' => 'Project Z', 'url' => null ],
+		], $result );
+	}
+
+	public function test_build_for_singular_flat_cpt_just_title(): void {
+		Functions\when( 'get_post_type' )->justReturn( 'team' );
+		$post = (object) [ 'ID' => 80, 'post_title' => 'John Doe' ];
+		Functions\when( 'get_queried_object' )->justReturn( $post );
+		Functions\expect( 'is_post_type_hierarchical' )->with( 'team' )->andReturn( false );
+
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'build_for_singular' );
+
+		$this->assertSame( [
+			[ 'type' => 'item', 'title' => 'John Doe', 'url' => null ],
+		], $result );
+	}
+
 	public function test_by_menu_trail_returns_ancestor_chain_with_current_filtered(): void {
 		$menu_items = [
 			(object) [

--- a/tests/Unit/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Unit/Breadcrumb/BreadcrumbTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Breadcrumb;
+
+use Parisek\TimberKit\Breadcrumb;
+use ReflectionClass;
+
+final class BreadcrumbTest extends BreadcrumbTestCase {
+
+	// -------------------------------------------------------------------
+	// Constructor & config
+	// -------------------------------------------------------------------
+
+	public function test_constructor_accepts_no_arguments(): void {
+		$bc = new Breadcrumb();
+		$this->assertSame( [], $bc->get() );
+	}
+
+	public function test_constructor_applies_config_to_known_properties(): void {
+		$bc = new Breadcrumb([
+			'menu_name'     => 'custom-menu',
+			'list_page_map' => [ 'project' => 'projects_list' ],
+		]);
+
+		$reflection = new ReflectionClass( $bc );
+		$menuProp = $reflection->getProperty( 'menu_name' );
+		$mapProp = $reflection->getProperty( 'list_page_map' );
+
+		$this->assertSame( 'custom-menu', $menuProp->getValue( $bc ) );
+		$this->assertSame( [ 'project' => 'projects_list' ], $mapProp->getValue( $bc ) );
+	}
+
+	public function test_constructor_ignores_unknown_config_keys(): void {
+		$bc = new Breadcrumb([ 'nonexistent_key' => 'whatever' ]);
+		$this->assertSame( [], $bc->get() );
+	}
+}

--- a/tests/Unit/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Unit/Breadcrumb/BreadcrumbTest.php
@@ -64,4 +64,40 @@ final class BreadcrumbTest extends BreadcrumbTestCase {
 
 		$this->assertSame( [ [ 'type' => '404' ] ], $result );
 	}
+
+	// -------------------------------------------------------------------
+	// Strategy: search
+	// -------------------------------------------------------------------
+
+	public function test_build_for_search_returns_query_with_url(): void {
+		Functions\expect( 'get_search_query' )->once()->andReturn( 'foo bar' );
+		Functions\expect( 'get_search_link' )->once()->andReturn( 'https://example.test/?s=foo+bar' );
+
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'build_for_search' );
+
+		$this->assertSame( [
+			[
+				'type'  => 'search',
+				'query' => 'foo bar',
+				'url'   => 'https://example.test/?s=foo+bar',
+			],
+		], $result );
+	}
+
+	public function test_build_for_search_handles_empty_query(): void {
+		Functions\expect( 'get_search_query' )->once()->andReturn( '' );
+		Functions\expect( 'get_search_link' )->once()->andReturn( 'https://example.test/?s=' );
+
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'build_for_search' );
+
+		$this->assertSame( [
+			[
+				'type'  => 'search',
+				'query' => '',
+				'url'   => 'https://example.test/?s=',
+			],
+		], $result );
+	}
 }

--- a/tests/Unit/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Unit/Breadcrumb/BreadcrumbTest.php
@@ -416,6 +416,43 @@ final class BreadcrumbTest extends BreadcrumbTestCase {
 		], $result );
 	}
 
+	public function test_build_for_singular_page_falls_back_to_ancestors_when_not_in_menu(): void {
+		Functions\when( 'get_post_type' )->justReturn( 'page' );
+		$post = (object) [ 'ID' => 30, 'post_title' => 'Orphan Page' ];
+		Functions\when( 'get_queried_object' )->justReturn( $post );
+
+		Functions\expect( 'get_nav_menu_locations' )->once()->andReturn( [] );
+		Functions\expect( 'wp_get_nav_menu_items' )->once()->andReturn( [] );
+		Functions\expect( 'get_queried_object_id' )->andReturn( 30 );
+		\Brain\Monkey\Filters\expectApplied( 'wpml_object_id' )->andReturn( 30 );
+
+		Functions\expect( 'get_post' )->once()->andReturn( $post );
+		Functions\expect( 'get_post_ancestors' )->once()->with( $post )->andReturn( [ 20, 10 ] );
+		Functions\when( 'get_permalink' )->alias( function( $id = null ) {
+			return match( $id ) {
+				10 => 'https://example.test/about/',
+				20 => 'https://example.test/about/team/',
+				default => '',
+			};
+		} );
+		Functions\when( 'get_the_title' )->alias( function( $id ) {
+			return match( $id ) {
+				10 => 'About',
+				20 => 'Team',
+				default => '',
+			};
+		} );
+
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'build_for_singular' );
+
+		$this->assertSame( [
+			[ 'type' => 'item', 'title' => 'About', 'url' => 'https://example.test/about/' ],
+			[ 'type' => 'item', 'title' => 'Team', 'url' => 'https://example.test/about/team/' ],
+			[ 'type' => 'item', 'title' => 'Orphan Page', 'url' => null ],
+		], $result );
+	}
+
 	public function test_by_menu_trail_returns_ancestor_chain_with_current_filtered(): void {
 		$menu_items = [
 			(object) [

--- a/tests/Unit/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Unit/Breadcrumb/BreadcrumbTest.php
@@ -124,4 +124,53 @@ final class BreadcrumbTest extends BreadcrumbTestCase {
 			],
 		], $result );
 	}
+
+	// -------------------------------------------------------------------
+	// Strategy: date archive
+	// -------------------------------------------------------------------
+
+	public function test_build_for_date_archive_year_only(): void {
+		Functions\expect( 'get_query_var' )->times( 3 )->andReturnUsing(
+			static fn( string $key ): string => [ 'year' => '2024', 'monthnum' => '', 'day' => '' ][ $key ] ?? ''
+		);
+
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'build_for_date_archive' );
+
+		$this->assertSame( [
+			[ 'type' => 'date_year', 'year' => 2024, 'url' => null ],
+		], $result );
+	}
+
+	public function test_build_for_date_archive_year_and_month(): void {
+		Functions\expect( 'get_query_var' )->times( 3 )->andReturnUsing(
+			static fn( string $key ): string => [ 'year' => '2024', 'monthnum' => '5', 'day' => '' ][ $key ] ?? ''
+		);
+		Functions\expect( 'get_year_link' )->once()->with( 2024 )->andReturn( 'https://example.test/2024/' );
+
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'build_for_date_archive' );
+
+		$this->assertSame( [
+			[ 'type' => 'date_year',  'year' => 2024, 'url' => 'https://example.test/2024/' ],
+			[ 'type' => 'date_month', 'year' => 2024, 'month' => 5, 'url' => null ],
+		], $result );
+	}
+
+	public function test_build_for_date_archive_year_month_day(): void {
+		Functions\expect( 'get_query_var' )->times( 3 )->andReturnUsing(
+			static fn( string $key ): string => [ 'year' => '2024', 'monthnum' => '5', 'day' => '15' ][ $key ] ?? ''
+		);
+		Functions\expect( 'get_year_link' )->once()->with( 2024 )->andReturn( 'https://example.test/2024/' );
+		Functions\expect( 'get_month_link' )->once()->with( 2024, 5 )->andReturn( 'https://example.test/2024/05/' );
+
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'build_for_date_archive' );
+
+		$this->assertSame( [
+			[ 'type' => 'date_year',  'year' => 2024, 'url' => 'https://example.test/2024/' ],
+			[ 'type' => 'date_month', 'year' => 2024, 'month' => 5, 'url' => 'https://example.test/2024/05/' ],
+			[ 'type' => 'date_day',   'year' => 2024, 'month' => 5, 'day' => 15 ],
+		], $result );
+	}
 }

--- a/tests/Unit/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Unit/Breadcrumb/BreadcrumbTest.php
@@ -207,4 +207,61 @@ final class BreadcrumbTest extends BreadcrumbTestCase {
 
 		$this->assertSame( [], $result );
 	}
+
+	// -------------------------------------------------------------------
+	// Strategy: taxonomy
+	// -------------------------------------------------------------------
+
+	public function test_build_for_taxonomy_flat_term(): void {
+		$term = (object) [ 'term_id' => 10, 'name' => 'News', 'taxonomy' => 'category' ];
+		Functions\expect( 'get_queried_object' )->once()->andReturn( $term );
+		Functions\expect( 'is_taxonomy_hierarchical' )->once()->with( 'category' )->andReturn( false );
+		Functions\expect( 'get_term_link' )->once()->with( $term )->andReturn( 'https://example.test/category/news/' );
+
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'build_for_taxonomy' );
+
+		$this->assertSame( [
+			[ 'type' => 'item', 'title' => 'News', 'url' => 'https://example.test/category/news/' ],
+		], $result );
+	}
+
+	public function test_build_for_taxonomy_hierarchical_with_ancestors(): void {
+		$term = (object) [ 'term_id' => 30, 'name' => 'Web Design', 'taxonomy' => 'services' ];
+		$parent = (object) [ 'term_id' => 20, 'name' => 'Services', 'taxonomy' => 'services' ];
+
+		Functions\expect( 'get_queried_object' )->once()->andReturn( $term );
+		Functions\expect( 'is_taxonomy_hierarchical' )->once()->with( 'services' )->andReturn( true );
+		Functions\expect( 'get_ancestors' )->once()->with( 30, 'services', 'taxonomy' )->andReturn( [ 20 ] );
+		Functions\expect( 'get_term' )->once()->with( 20, 'services' )->andReturn( $parent );
+		Functions\expect( 'is_wp_error' )->andReturn( false );
+		Functions\expect( 'get_term_link' )->times( 2 )->andReturnUsing(
+			function ( $t ) use ( $parent, $term ) {
+				return $t === $parent ? 'https://example.test/services/' : 'https://example.test/services/web-design/';
+			}
+		);
+
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'build_for_taxonomy' );
+
+		$this->assertSame( [
+			[ 'type' => 'item', 'title' => 'Services',   'url' => 'https://example.test/services/' ],
+			[ 'type' => 'item', 'title' => 'Web Design', 'url' => 'https://example.test/services/web-design/' ],
+		], $result );
+	}
+
+	public function test_build_for_taxonomy_handles_wp_error_term_link(): void {
+		$term = (object) [ 'term_id' => 99, 'name' => 'Broken', 'taxonomy' => 'category' ];
+		$wp_error = new \stdClass();
+		Functions\expect( 'get_queried_object' )->once()->andReturn( $term );
+		Functions\expect( 'is_taxonomy_hierarchical' )->once()->with( 'category' )->andReturn( false );
+		Functions\expect( 'get_term_link' )->once()->with( $term )->andReturn( $wp_error );
+
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'build_for_taxonomy' );
+
+		$this->assertSame( [
+			[ 'type' => 'item', 'title' => 'Broken', 'url' => null ],
+		], $result );
+	}
 }

--- a/tests/Unit/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Unit/Breadcrumb/BreadcrumbTest.php
@@ -453,6 +453,29 @@ final class BreadcrumbTest extends BreadcrumbTestCase {
 		], $result );
 	}
 
+	public function test_build_for_singular_post_with_list_page_map(): void {
+		Functions\when( 'get_post_type' )->justReturn( 'post' );
+		$post = (object) [ 'ID' => 50, 'post_title' => 'My Article' ];
+		Functions\when( 'get_queried_object' )->justReturn( $post );
+
+		Functions\when( 'get_field' )->justReturn( [
+			'article_list' => [ 'url' => 'https://example.test/blog/', 'title' => 'Blog' ],
+		] );
+		Functions\expect( 'url_to_postid' )->with( 'https://example.test/blog/' )->andReturn( 42 );
+		\Brain\Monkey\Filters\expectApplied( 'wpml_object_id' )->with( 42, 'page' )->andReturn( 42 );
+		Functions\when( 'get_permalink' )->justReturn( 'https://example.test/blog/' );
+
+		$bc = new Breadcrumb([
+			'list_page_map' => [ 'post' => 'article_list' ],
+		]);
+		$result = $this->invoke_protected( $bc, 'build_for_singular' );
+
+		$this->assertSame( [
+			[ 'type' => 'item', 'title' => 'Blog', 'url' => 'https://example.test/blog/' ],
+			[ 'type' => 'item', 'title' => 'My Article', 'url' => null ],
+		], $result );
+	}
+
 	public function test_by_menu_trail_returns_ancestor_chain_with_current_filtered(): void {
 		$menu_items = [
 			(object) [

--- a/tests/Unit/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Unit/Breadcrumb/BreadcrumbTest.php
@@ -100,4 +100,28 @@ final class BreadcrumbTest extends BreadcrumbTestCase {
 			],
 		], $result );
 	}
+
+	// -------------------------------------------------------------------
+	// Strategy: author archive
+	// -------------------------------------------------------------------
+
+	public function test_build_for_author_archive_returns_author_with_url(): void {
+		$author = (object) [
+			'ID'           => 5,
+			'display_name' => 'Jane Doe',
+		];
+		Functions\expect( 'get_queried_object' )->once()->andReturn( $author );
+		Functions\expect( 'get_author_posts_url' )->once()->with( 5 )->andReturn( 'https://example.test/author/jane/' );
+
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'build_for_author_archive' );
+
+		$this->assertSame( [
+			[
+				'type'         => 'author',
+				'display_name' => 'Jane Doe',
+				'url'          => 'https://example.test/author/jane/',
+			],
+		], $result );
+	}
 }

--- a/tests/Unit/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Unit/Breadcrumb/BreadcrumbTest.php
@@ -264,4 +264,45 @@ final class BreadcrumbTest extends BreadcrumbTestCase {
 			[ 'type' => 'item', 'title' => 'Broken', 'url' => null ],
 		], $result );
 	}
+
+	// -------------------------------------------------------------------
+	// Helper: get_menu_item (pure, no WP calls)
+	// -------------------------------------------------------------------
+
+	public function test_get_menu_item_returns_matching_item_by_id(): void {
+		$items = [
+			(object) [ 'ID' => 1, 'title' => 'Home' ],
+			(object) [ 'ID' => 2, 'title' => 'About' ],
+			(object) [ 'ID' => 3, 'title' => 'Contact' ],
+		];
+
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'get_menu_item', [ 'ID', 2, $items ] );
+
+		$this->assertSame( 'About', $result->title );
+	}
+
+	public function test_get_menu_item_returns_false_when_no_match(): void {
+		$items = [ (object) [ 'ID' => 1, 'title' => 'Home' ] ];
+
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'get_menu_item', [ 'ID', 99, $items ] );
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_get_menu_item_normalizes_string_int_mismatch(): void {
+		// REGRESSION: wp_get_nav_menu_items() returns object_id as STRING
+		// (post_meta is stringified); get_queried_object_id() returns INT.
+		// Without is_numeric normalization, strict `===` silently fails.
+		$items = [
+			(object) [ 'object_id' => '42', 'title' => 'About' ],
+			(object) [ 'object_id' => '99', 'title' => 'Other' ],
+		];
+
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'get_menu_item', [ 'object_id', 42, $items ] );
+
+		$this->assertSame( 'About', $result->title );
+	}
 }

--- a/tests/Unit/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Unit/Breadcrumb/BreadcrumbTest.php
@@ -53,4 +53,15 @@ final class BreadcrumbTest extends BreadcrumbTestCase {
 			'url'  => 'https://example.test/',
 		], $result );
 	}
+
+	// -------------------------------------------------------------------
+	// Strategy: 404
+	// -------------------------------------------------------------------
+
+	public function test_build_for_404_returns_single_404_item(): void {
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'build_for_404' );
+
+		$this->assertSame( [ [ 'type' => '404' ] ], $result );
+	}
 }

--- a/tests/Unit/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Unit/Breadcrumb/BreadcrumbTest.php
@@ -267,6 +267,24 @@ final class BreadcrumbTest extends BreadcrumbTestCase {
 	}
 
 	// -------------------------------------------------------------------
+	// Strategy: pagination
+	// -------------------------------------------------------------------
+
+	public function test_build_pagination_item_returns_paged_with_url(): void {
+		Functions\expect( 'get_query_var' )->once()->with( 'paged' )->andReturn( 3 );
+		Functions\expect( 'get_pagenum_link' )->once()->with( 1 )->andReturn( 'https://example.test/category/news/' );
+
+		$bc = new Breadcrumb();
+		$result = $this->invoke_protected( $bc, 'build_pagination_item' );
+
+		$this->assertSame( [
+			'type' => 'pagination',
+			'page' => 3,
+			'url'  => 'https://example.test/category/news/',
+		], $result );
+	}
+
+	// -------------------------------------------------------------------
 	// Helper: get_menu_item (pure, no WP calls)
 	// -------------------------------------------------------------------
 

--- a/tests/Unit/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Unit/Breadcrumb/BreadcrumbTest.php
@@ -536,6 +536,74 @@ final class BreadcrumbTest extends BreadcrumbTestCase {
 		], $result );
 	}
 
+	// -------------------------------------------------------------------
+	// Hydrate
+	// -------------------------------------------------------------------
+
+	public function test_hydrate_resolves_all_types(): void {
+		Functions\when( 'wp_date' )->justReturn( 'May' );
+
+		$bc = new Breadcrumb([
+			'labels' => [
+				'home'       => 'Domů',
+				'404'        => 'Nenalezeno',
+				'search'     => 'Hledání: %s',
+				'pagination' => 'Strana %d',
+				'author'     => 'Autor: %s',
+			],
+		]);
+
+		$items = [
+			[ 'type' => 'home', 'url' => 'https://example.test/' ],
+			[ 'type' => 'item', 'title' => 'About', 'url' => '/about/' ],
+			[ 'type' => '404' ],
+			[ 'type' => 'search', 'query' => 'foo', 'url' => '/?s=foo' ],
+			[ 'type' => 'pagination', 'page' => 2, 'url' => '/page/1/' ],
+			[ 'type' => 'author', 'display_name' => 'Jane', 'url' => '/author/jane/' ],
+			[ 'type' => 'date_year', 'year' => 2024, 'url' => null ],
+			[ 'type' => 'date_month', 'year' => 2024, 'month' => 5, 'url' => null ],
+			[ 'type' => 'date_day', 'year' => 2024, 'month' => 5, 'day' => 15 ],
+		];
+
+		\Brain\Monkey\Filters\expectApplied( 'timber_kit_breadcrumb_labels' )
+			->andReturnUsing( fn( $labels ) => $labels );
+
+		$result = $this->invoke_protected( $bc, 'hydrate', [ $items ] );
+
+		$this->assertSame( 'Domů', $result[0]['title'] );
+		$this->assertSame( 'About', $result[1]['title'] );
+		$this->assertSame( 'Nenalezeno', $result[2]['title'] );
+		$this->assertSame( 'Hledání: foo', $result[3]['title'] );
+		$this->assertSame( 'Strana 2', $result[4]['title'] );
+		$this->assertSame( 'Autor: Jane', $result[5]['title'] );
+		$this->assertSame( '2024', $result[6]['title'] );
+		$this->assertSame( 'May', $result[7]['title'] );
+		$this->assertSame( '15', $result[8]['title'] );
+	}
+
+	public function test_hydrate_falls_back_to_english_when_labels_missing(): void {
+		$bc = new Breadcrumb();  // default English labels
+		$items = [ [ 'type' => '404' ] ];
+
+		\Brain\Monkey\Filters\expectApplied( 'timber_kit_breadcrumb_labels' )
+			->andReturnUsing( fn( $labels ) => $labels );
+
+		$result = $this->invoke_protected( $bc, 'hydrate', [ $items ] );
+		$this->assertSame( 'Page not found', $result[0]['title'] );
+	}
+
+	public function test_hydrate_applies_labels_filter(): void {
+		$bc = new Breadcrumb();
+		$items = [ [ 'type' => 'home', 'url' => '/' ] ];
+
+		\Brain\Monkey\Filters\expectApplied( 'timber_kit_breadcrumb_labels' )
+			->once()
+			->andReturnUsing( fn( $labels ) => array_merge( $labels, [ 'home' => 'Hauptseite' ] ) );
+
+		$result = $this->invoke_protected( $bc, 'hydrate', [ $items ] );
+		$this->assertSame( 'Hauptseite', $result[0]['title'] );
+	}
+
 	public function test_by_menu_trail_returns_ancestor_chain_with_current_filtered(): void {
 		$menu_items = [
 			(object) [

--- a/tests/Unit/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Unit/Breadcrumb/BreadcrumbTest.php
@@ -636,6 +636,33 @@ final class BreadcrumbTest extends BreadcrumbTestCase {
 	}
 
 	// -------------------------------------------------------------------
+	// Filter: menu_trail
+	// -------------------------------------------------------------------
+
+	public function test_by_menu_trail_applies_menu_trail_filter(): void {
+		Functions\expect( 'get_nav_menu_locations' )->once()->andReturn( [] );
+		Functions\expect( 'wp_get_nav_menu_items' )->once()->andReturn( [
+			(object) [ 'ID' => 1, 'object_id' => '10', 'menu_item_parent' => '0',
+				'url' => 'https://example.test/about/', 'title' => 'About' ],
+		] );
+		Functions\expect( 'get_queried_object_id' )->andReturn( 10 );
+		\Brain\Monkey\Filters\expectApplied( 'wpml_object_id' )->andReturn( 10 );
+		Functions\when( 'get_permalink' )->justReturn( 'https://elsewhere/' );
+
+		\Brain\Monkey\Filters\expectApplied( 'timber_kit_breadcrumb_menu_trail' )
+			->once()
+			->andReturnUsing( function( $items, $menu_name ) {
+				$items[0]['title'] = 'Modified ' . $items[0]['title'];
+				return $items;
+			} );
+
+		$bc = new Breadcrumb([ 'menu_name' => 'main-menu' ]);
+		$result = $this->invoke_protected( $bc, 'by_menu_trail' );
+
+		$this->assertSame( 'Modified About', $result[0]['title'] );
+	}
+
+	// -------------------------------------------------------------------
 	// Integration: get() dispatcher
 	// -------------------------------------------------------------------
 

--- a/tests/Unit/Breadcrumb/BreadcrumbTestCase.php
+++ b/tests/Unit/Breadcrumb/BreadcrumbTestCase.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Breadcrumb;
+
+use Brain\Monkey;
+use PHPUnit\Framework\TestCase;
+use Parisek\TimberKit\Breadcrumb;
+use ReflectionMethod;
+
+abstract class BreadcrumbTestCase extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Invoke a protected method on a Breadcrumb instance via reflection.
+	 * Used by subclass tests to exercise strategy methods (`build_for_*`)
+	 * and helpers (`get_menu_item`, `by_menu_trail`, `get_global_links`)
+	 * in isolation.
+	 *
+	 * @param array<int, mixed> $args
+	 */
+	protected function invoke_protected( Breadcrumb $bc, string $method, array $args = [] ): mixed {
+		$reflection = new ReflectionMethod( $bc, $method );
+		return $reflection->invoke( $bc, ...$args );
+	}
+}

--- a/tests/Unit/Breadcrumb/StarterBaseBreadcrumbTest.php
+++ b/tests/Unit/Breadcrumb/StarterBaseBreadcrumbTest.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit\Breadcrumb;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Brain\Monkey\Filters;
+use Parisek\TimberKit\StarterBase;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * Tests the legacy-class guard in StarterBase::timber_context().
+ *
+ * Each test runs in a separate PHP process (@runInSeparateProcess) so the
+ * global \Breadcrumb class declaration doesn't leak between tests.
+ *
+ * StarterBase is instantiated without invoking its constructor (which would
+ * fire 30+ WordPress hooks during testing). We use reflection to call
+ * timber_context() directly on a constructor-less instance.
+ */
+final class StarterBaseBreadcrumbTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_auto_populate_skipped_when_breadcrumb_class_exists(): void {
+		require __DIR__ . '/../../Fixtures/LegacyBreadcrumbStub.php';
+
+		$this->stub_timber_context_wp_functions();
+
+		$context = $this->invoke_timber_context( [ 'existing_key' => 'preserved' ] );
+
+		$this->assertArrayNotHasKey( 'breadcrumb', $context );
+		$this->assertSame( 'preserved', $context['existing_key'] );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_auto_populate_runs_when_breadcrumb_class_absent(): void {
+		// Fixture NOT required — \Breadcrumb is absent in this fresh process.
+		$this->stub_timber_context_wp_functions();
+
+		// Stub the WP functions Breadcrumb::get() needs to traverse the dispatcher;
+		// shortest path: front_page returns [] before any strategy dispatch fires.
+		Functions\when( 'is_front_page' )->justReturn( true );
+		Functions\when( 'is_paged' )->justReturn( false );
+		Filters\expectApplied( 'timber_kit_breadcrumb_skip' )->andReturn( false );
+
+		$context = $this->invoke_timber_context( [] );
+
+		$this->assertArrayHasKey( 'breadcrumb', $context );
+		$this->assertSame( [], $context['breadcrumb'] );
+	}
+
+	/**
+	 * Stub the WordPress functions that timber_context() calls unconditionally.
+	 * These must be wired before invoke_timber_context() is called.
+	 */
+	private function stub_timber_context_wp_functions(): void {
+		Functions\when( 'get_home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'get_template_directory_uri' )->justReturn( 'https://example.com/wp-content/themes/test' );
+		Functions\when( 'is_front_page' )->justReturn( false );
+		Functions\when( 'function_exists' )->justReturn( false );
+		Functions\when( 'get_bloginfo' )->justReturn( 'en-US' );
+		Functions\when( 'get_search_query' )->justReturn( '' );
+	}
+
+	/**
+	 * @param array<string, mixed> $initial
+	 * @return array<string, mixed>
+	 */
+	private function invoke_timber_context( array $initial ): array {
+		$reflection = new ReflectionClass( StarterBase::class );
+		$instance = $reflection->newInstanceWithoutConstructor();
+
+		$method = new ReflectionMethod( $instance, 'timber_context' );
+		return $method->invoke( $instance, $initial );
+	}
+}

--- a/tests/Unit/HelpersTestCase.php
+++ b/tests/Unit/HelpersTestCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use Brain\Monkey;
+use Brain\Monkey\Functions;
 use PHPUnit\Framework\TestCase;
 
 abstract class HelpersTestCase extends TestCase {
@@ -12,6 +13,11 @@ abstract class HelpersTestCase extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		Monkey\setUp();
+		// get_post_type is called by Helpers::isNavMenuItemPostId() on the
+		// function_exists() branch.  Default to 'post' so tests that don't
+		// need nav_menu_item dispatch don't have to mock it individually.
+		// Tests that need a specific return value override this in their body.
+		Functions\when( 'get_post_type' )->justReturn( 'post' );
 	}
 
 	protected function tearDown(): void {


### PR DESCRIPTION
## Summary

- New `Parisek\TimberKit\Breadcrumb` class — strategy dispatcher returning typed item arrays for any WP query state (404, search, date, author, archives, taxonomy, singular, pagination)
- `StarterBase` configuration surface: 5 new `$breadcrumb_*` properties + auto-populate of `$context['breadcrumb']` in `timber_context()`
- Legacy compatibility guard: `class_exists('\Breadcrumb', false)` skips auto-populate when consuming project still ships old global class
- Filter API: `timber_kit_breadcrumb_items|labels|skip|menu_trail` (matches existing `timber_kit_*` naming convention)
- ~40 brain/monkey tests covering all strategy branches + helpers + filters + edge cases

## Why a spec-first workflow

The full design lives in `docs/adr/2026-05-24-breadcrumb-design.md` (copied from the consuming `wordpress-base` project where this work originated). 14 sections + §4.1 legacy guard sub-section. Implementation tasks were tracked against the spec via TDD.

## Migration impact

**Backward compatible** for downstream consumers — legacy `\Breadcrumb` class detection auto-opts-out of new auto-populate. See `CHANGELOG.md` `[Unreleased]` Migration note for the two-path guide.

The items shape `[{type, url, title}]` is shape-compatible with previous `[{url, title}]` — `type` is an additive key, no Twig component changes required downstream.

## Test plan

- [ ] `composer test` — all 656 tests pass (existing + new ~42 breadcrumb tests)
- [ ] `composer phpstan` — 0 errors
- [ ] Review the ADR (`docs/adr/2026-05-24-breadcrumb-design.md`) against the implementation
- [ ] Spot-check that existing `Helpers::*` / `Resizer` / `BlockRenderer` tests still pass (no regression)
- [ ] Confirm filter naming `timber_kit_breadcrumb_*` matches your convention preference
- [ ] Confirm the `[Unreleased]` CHANGELOG entry slot (bundled with speculation-rules work)
- [ ] Mark PR "Ready for review" when satisfied, then merge + tag (likely `v1.7.0`)

## Follow-up

After this PR is merged + tagged, a separate PR against `portadesign/wordpress-base` will:
- `composer require parisek/timber-kit:^1.7` (or whatever the merged tag becomes)
- Delete project-side `classes/Breadcrumb.php` + tests entirely
- Refactor `Base.php` to use `$breadcrumb_*` property overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)