### PR TITLE
fix(Helpers): collapse 'option'/'options' alias in decodeOptionsNamespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `Helpers::formatFields('option')` no longer silently returns `[]` when the registered options page uses ACF's default `post_id` of `'options'` (the default for any `acf_add_options_page()` call without an explicit `post_id`). The previous `decodeOptionsNamespace()` compared the caller's `'option'` (singular) against the page's `'options'` (plural) via `acf_decode_post_id()`, which on ACF Pro 6.x does NOT collapse the alias — the helper's docblock claimed it did, but the existing test fixture papered over the gap by stubbing `acf_decode_post_id` to normalize both forms. Now the alias is canonicalized inside `decodeOptionsNamespace()`, so calls with either form match the page's namespace and surface all registered fields. Discovered during the neoli WordPress theme migration to timber-kit ([portadesign/neoli#17](https://github.com/portadesign/neoli/pull/17)) — symptom was an empty footer + missing global ACF data despite the data being present in `wp_options`. New regression test (`test_options_singular_alias_matches_plural_post_id`) mirrors real ACF Pro 6.x semantics (no normalization in the stub) so the fix can't silently re-regress.
+
 ## [1.7.0] - 2026-05-25
 
 ### Added

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -836,9 +836,11 @@ class Helpers {
 	 * stores its fields under `company_settings`, not under the default
 	 * `option` namespace — so `formatFields('option')` must not surface them,
 	 * and `formatFields('company_settings')` must not pick up unrelated
-	 * default-namespace pages. Both sides are normalized through
-	 * `acf_decode_post_id()`, which collapses the `option` / `options` alias
-	 * to a single canonical id.
+	 * default-namespace pages. Both sides are routed through
+	 * `decodeOptionsNamespace()`, which canonicalizes the default-namespace
+	 * `option` / `options` alias to a single id (`'options'`). ACF Pro's
+	 * own `acf_decode_post_id()` does NOT collapse the alias on its own —
+	 * see {@see decodeOptionsNamespace()} for details.
 	 *
 	 * Multiple pages sharing the same namespace are still unioned. Fields
 	 * with the same `name` across same-namespace pages collide on

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -895,8 +895,17 @@ class Helpers {
 	 * string doesn't decode to an options namespace.
 	 *
 	 * Used to compare a caller's `$post_id` against each registered options
-	 * page's `post_id` after collapsing the `option` / `options` alias —
-	 * `acf_decode_post_id()` returns the same `id` for both forms.
+	 * page's `post_id` after collapsing the `option` / `options` alias to a
+	 * single canonical id.
+	 *
+	 * ACF Pro's `acf_decode_post_id()` does NOT collapse the alias on its own:
+	 * `acf_decode_post_id('option')` returns `id='option'` while
+	 * `acf_decode_post_id('options')` returns `id='options'`. Both refer to
+	 * the default options namespace, so the comparison must canonicalize them
+	 * to the same string. Without this, `formatFields('option')` (singular)
+	 * silently returns an empty array when the registered options page uses
+	 * the ACF default `post_id` of `'options'` (plural) — which is every
+	 * page registered without an explicit `post_id` argument.
 	 *
 	 * @param mixed $post_id Caller's `$post_id` argument or a page's
 	 *                      `$page['post_id']` field.
@@ -908,7 +917,18 @@ class Helpers {
 			return null;
 		}
 		$id = $decoded['id'] ?? null;
-		return is_string( $id ) && $id !== '' ? $id : null;
+		if ( ! is_string( $id ) || $id === '' ) {
+			return null;
+		}
+		// Collapse the 'option' / 'options' alias — both refer to the default
+		// options namespace. ACF Pro's acf_decode_post_id() keeps them
+		// separate; canonicalize to the plural form (the default `post_id`
+		// that ACF uses for an options page registered without an explicit
+		// `post_id`, so this matches what `acf_get_options_pages()` reports).
+		if ( $id === 'option' ) {
+			$id = 'options';
+		}
+		return $id;
 	}
 
 	/**

--- a/tests/Unit/Helpers/FormatFieldsTest.php
+++ b/tests/Unit/Helpers/FormatFieldsTest.php
@@ -420,6 +420,59 @@ class FormatFieldsTest extends HelpersTestCase {
 		$this->assertSame( [], $result );
 	}
 
+	public function test_options_singular_alias_matches_plural_post_id(): void {
+		// Regression for the option/options alias bug discovered during the
+		// neoli → timber-kit migration (see portadesign/neoli#17).
+		//
+		// `acf_add_options_page()` without an explicit `post_id` defaults to
+		// `post_id => 'options'` (plural). The previous existing fixture for
+		// this code path stubbed `acf_decode_post_id` to normalize BOTH input
+		// forms to `id => 'option'` (singular) — which papered over a real-
+		// world gap: in ACF Pro 6.x, `acf_decode_post_id` does NOT collapse
+		// the alias. Concretely:
+		//
+		//   acf_decode_post_id('option')  => ['type' => 'option', 'id' => 'option']
+		//   acf_decode_post_id('options') => ['type' => 'option', 'id' => 'options']
+		//
+		// Result: `formatFields('option')` and the default-`'options'` options
+		// page have non-matching namespaces, `decodeOptionsNamespace` returns
+		// two different strings, and `getFieldObjectsForOptions` falls through
+		// without surfacing any field group.
+		//
+		// `decodeOptionsNamespace` must canonicalize the alias so both forms
+		// resolve to the same namespace. This test stubs `acf_decode_post_id`
+		// with the REAL ACF Pro 6.x semantics (no normalization) and asserts
+		// that `formatFields('option')` still finds the registered page.
+
+		Functions\when( 'get_field_objects' )->justReturn( false );
+		Functions\when( 'acf_decode_post_id' )->alias( function ( $id ) {
+			// Mirror real ACF Pro 6.x: do NOT collapse the alias.
+			return [ 'type' => 'option', 'id' => (string) $id ];
+		} );
+		Functions\when( 'acf_get_options_pages' )->justReturn( [
+			// Default `post_id` is `'options'` (plural) for an options page
+			// registered without an explicit `post_id` argument.
+			'settings' => [ 'menu_slug' => 'settings', 'post_id' => 'options' ],
+		] );
+		Functions\when( 'acf_get_field_groups' )->alias( function ( $screen ) {
+			return ( $screen['options_page'] ?? '' ) === 'settings'
+				? [ [ 'key' => 'group_options_footer', 'name' => 'footer_group' ] ]
+				: [];
+		} );
+		Functions\when( 'acf_get_fields' )->alias( function ( $group ) {
+			return [ [ 'key' => 'field_footer', 'name' => 'footer', 'type' => 'text' ] ];
+		} );
+		Functions\when( 'get_field' )->alias( fn ( $name, $id ) => "$name@$id" );
+
+		// Caller passes singular `'option'`; page registers default plural
+		// `'options'`. The alias collapse in `decodeOptionsNamespace` must
+		// make these resolve to the same namespace.
+		$result = Helpers::formatFields( 'option' );
+
+		$this->assertArrayHasKey( 'footer', $result, 'formatFields("option") must find the default-post_id="options" page' );
+		$this->assertSame( 'footer@option', $result['footer'] );
+	}
+
 	public function test_block_prefix_string_does_not_hit_options_path(): void {
 		// `'block_*'` strings must not be misclassified as options page ids.
 		Functions\when( 'acf_decode_post_id' )->justReturn( [ 'type' => 'block', 'id' => 'block_abc' ] );

--- a/tests/Unit/Helpers/FormatFieldsTest.php
+++ b/tests/Unit/Helpers/FormatFieldsTest.php
@@ -473,6 +473,52 @@ class FormatFieldsTest extends HelpersTestCase {
 		$this->assertSame( 'footer@option', $result['footer'] );
 	}
 
+	public function test_options_wpml_prefixed_namespace_is_preserved(): void {
+		// Regression guard against an overly aggressive alias collapse: the
+		// `option`/`options` canonicalization in `decodeOptionsNamespace`
+		// must NOT touch WPML's language-prefixed options ids like
+		// `'options_en'`, `'options_cs'`, etc. WPML's ACF integration stores
+		// per-language values under those prefixed namespaces, and a page
+		// registered with `post_id => 'options_en'` must still surface only
+		// when the caller asks for the same prefix.
+		//
+		// Behavior asserted here:
+		//   * `formatFields('options_en')` matches a page with `post_id => 'options_en'`
+		//   * `formatFields('options_en')` does NOT match a default-namespace
+		//     page (`post_id => 'options'`)
+
+		Functions\when( 'get_field_objects' )->justReturn( false );
+		Functions\when( 'acf_decode_post_id' )->alias( function ( $id ) {
+			// Real ACF Pro 6.x: type=option, id=verbatim. No normalization.
+			return [ 'type' => 'option', 'id' => (string) $id ];
+		} );
+		Functions\when( 'acf_get_options_pages' )->justReturn( [
+			'general'    => [ 'menu_slug' => 'general',    'post_id' => 'options' ],
+			'general_en' => [ 'menu_slug' => 'general-en', 'post_id' => 'options_en' ],
+		] );
+		Functions\when( 'acf_get_field_groups' )->alias( function ( $screen ) {
+			$slug = $screen['options_page'] ?? '';
+			if ( $slug === 'general' ) {
+				return [ [ 'key' => 'group_default', 'name' => 'default_group' ] ];
+			}
+			if ( $slug === 'general-en' ) {
+				return [ [ 'key' => 'group_en', 'name' => 'en_group' ] ];
+			}
+			return [];
+		} );
+		Functions\when( 'acf_get_fields' )->alias( function ( $group ) {
+			$name = $group['key'] === 'group_en' ? 'site_logo_en' : 'site_logo';
+			return [ [ 'key' => "field_{$group['key']}", 'name' => $name, 'type' => 'text' ] ];
+		} );
+		Functions\when( 'get_field' )->alias( fn ( $name, $id ) => "$name@$id" );
+
+		$result = Helpers::formatFields( 'options_en' );
+
+		$this->assertArrayHasKey( 'site_logo_en', $result, 'WPML-prefixed call must surface the matching page' );
+		$this->assertArrayNotHasKey( 'site_logo', $result, 'WPML-prefixed call must NOT leak the default-namespace page' );
+		$this->assertSame( 'site_logo_en@options_en', $result['site_logo_en'] );
+	}
+
 	public function test_block_prefix_string_does_not_hit_options_path(): void {
 		// `'block_*'` strings must not be misclassified as options page ids.
 		Functions\when( 'acf_decode_post_id' )->justReturn( [ 'type' => 'block', 'id' => 'block_abc' ] );
@@ -853,9 +899,14 @@ class FormatFieldsTest extends HelpersTestCase {
 
 	public function test_options_namespace_filter_aliases_option_and_options(): void {
 		// A page registered with the plural form `post_id => 'options'` must
-		// still match a `formatFields('option')` caller, because
-		// `acf_decode_post_id()` collapses both forms onto the same canonical
-		// id ('option').
+		// still match a `formatFields('option')` caller. The aliasing happens
+		// inside `decodeOptionsNamespace()` — ACF Pro's own `acf_decode_post_id()`
+		// does NOT collapse the alias on its own (see
+		// `test_options_singular_alias_matches_plural_post_id` for a stub that
+		// mirrors real ACF Pro 6.x behavior). This older fixture stubs
+		// `acf_decode_post_id` with a loose normalization that pre-dates the
+		// understanding of ACF's real behavior; the assertion still holds
+		// because both code paths produce the same answer.
 		Functions\when( 'get_field_objects' )->justReturn( false );
 		Functions\when( 'acf_decode_post_id' )->alias( function ( $id ) {
 			return in_array( $id, [ 'option', 'options' ], true )


### PR DESCRIPTION
## From which project

Discovered during the **neoli** WordPress theme migration to `parisek/timber-kit:^1.7` — see [portadesign/neoli#17](https://github.com/portadesign/neoli/pull/17), commit [`90530747`](https://github.com/portadesign/neoli/pull/17/commits/90530747).

> **Note from owner:** This pattern has hit multiple migrations now. Each affected project worked around it locally by switching `Helpers::formatFields('option')` → `Helpers::formatFields('options')` (plural). Fixing it upstream means future migrations don't repeat the workaround.

## Why

`Helpers::formatFields('option')` (singular) silently returns `[]` when the registered options page uses ACF's default `post_id` of `'options'` (the default for any `acf_add_options_page()` call without an explicit `post_id`).

### Root cause

`decodeOptionsNamespace()` compares the caller's `'option'` (singular) against the page's `'options'` (plural) via `acf_decode_post_id()`. The helper's docblock claims `acf_decode_post_id()` collapses both forms to a single canonical id:

> Both sides are normalized through `acf_decode_post_id()`, which collapses the `option` / `options` alias to a single canonical id.

But on **ACF Pro 6.x** the alias is **NOT** collapsed:

```php
acf_decode_post_id('option');   // => ['type' => 'option', 'id' => 'option']
acf_decode_post_id('options');  // => ['type' => 'option', 'id' => 'options']
```

`decodeOptionsNamespace` returns the `id` field verbatim, so the caller's `'option'` namespace never matches the page's `'options'` namespace, `getFieldObjectsForOptions()` falls through, and `formatFields('option')` returns `[]`.

### Why the existing test didn't catch it

`FormatFieldsTest::test_options_post_id_resolves_via_acf_get_options_pages` stubs `acf_decode_post_id` to **normalize** both inputs to `id => 'option'`:

```php
Functions\when( 'acf_decode_post_id' )->alias( function ( $id ) {
    return in_array( $id, [ 'option', 'options' ], true )
        ? [ 'type' => 'option', 'id' => 'option' ]
        : [ 'type' => 'post', 'id' => $id ];
} );
```

This fixture papers over the real-world gap. The test passes; production fails.

### Real-world impact

Every project that migrates from a local `classes/Helpers.php` (which accepted `'option'` directly via `get_field_objects()`) to timber-kit's `Helpers` silently loses the entire options-page data unless the caller is also updated to `'options'` (plural). In neoli, this manifested as:

- Empty footer (`footer.email`, `footer.company_info`, etc. all null in `timber_context()`)
- Missing CTA button (`links.header_button`)
- Disabled announcement bar (`announcement.active`)
- Disabled modal (`modal.enabled`)

The data was present in `wp_options` the entire time — the namespace match just kept silently dropping it.

## What it means

`decodeOptionsNamespace()` now canonicalizes the alias internally — both `'option'` (singular) and `'options'` (plural) resolve to `'options'`, matching ACF's default `post_id` value that `acf_get_options_pages()` reports verbatim.

### Diff preview

```diff
 private static function decodeOptionsNamespace( $post_id ): ?string {
     $decoded = acf_decode_post_id( (string) $post_id );
     if ( ! is_array( $decoded ) || ( $decoded['type'] ?? '' ) !== 'option' ) {
         return null;
     }
     $id = $decoded['id'] ?? null;
-    return is_string( $id ) && $id !== '' ? $id : null;
+    if ( ! is_string( $id ) || $id === '' ) {
+        return null;
+    }
+    // Collapse the 'option' / 'options' alias — both refer to the default
+    // options namespace. ACF Pro's acf_decode_post_id() keeps them
+    // separate; canonicalize to the plural form (the default `post_id`
+    // that ACF uses for an options page registered without an explicit
+    // `post_id`, so this matches what `acf_get_options_pages()` reports).
+    if ( $id === 'option' ) {
+        $id = 'options';
+    }
+    return $id;
 }
```

### Documentation impact

The docblock previously promised collapse-via-`acf_decode_post_id()` and was inaccurate. It's been updated to describe what the helper actually does and why ACF Pro 6.x doesn't collapse on its own.

### New regression test

Added `test_options_singular_alias_matches_plural_post_id` to `FormatFieldsTest`. It stubs `acf_decode_post_id` with REAL ACF Pro 6.x semantics (the stub does NOT normalize the alias) and asserts that `formatFields('option')` still finds an options page registered with the default `post_id => 'options'`. Without the fix, this test fails with `assertArrayHasKey('footer', $result)`.

### Sibling projects impacted

Any downstream project that:

- Calls `Helpers::formatFields('option')` (singular — the historical convention from the pre-timber-kit Helpers shim used in `wordpress-base` doctrine and `AGENTS.md`)
- AND registers its options page via `acf_add_options_page()` without overriding `post_id`

…silently loses options-page data after upgrading to a timber-kit release that includes `decodeOptionsNamespace()`. Both forms now work after this fix.

### Test results

```
$ vendor/bin/phpunit tests/Unit/Helpers/FormatFieldsTest.php
PHPUnit 11.5.55 by Sebastian Bergmann and contributors.

....................................                              36 / 36 (100%)

Time: 00:00.061, Memory: 14.00 MB

OK (36 tests, 51 assertions)
```

## Out of scope (left for separate PRs)

- Downstream sync to `wordpress-base` / `tailwind-base` happens explicitly per AGENTS.md doctrine after this merges.
- `decodeOptionsNamespace`'s caller `getFieldObjectsForOptions` is unchanged — only the namespace canonicalization is affected.
- The other `is_string`-path in `Helpers::formatFields()` (line ~679, where `$post_id = $post`) is unchanged — the alias collapse fires later in `isOptionsPostId` → `getFieldObjectsForOptions` → `decodeOptionsNamespace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)