### PR TITLE
feat(starter-base): add setup_breadcrumb_labels() init hook for lazy translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **`StarterBase::setup_breadcrumb_labels()`** — new public hook method, registered on `init` (priority 1), that projects override to populate `$breadcrumb_labels` with translated strings. WordPress 6.7+ emits a `_load_textdomain_just_in_time` notice when `_x()` / `__()` are called before `init` (e.g. in `Base::__construct()`), because the textdomain hasn't loaded yet. The new hook gives projects a sanctioned post-`init` callsite. Default implementation is a no-op — the English defaults declared on the `$breadcrumb_labels` property remain in effect for projects that don't override. Backward-compatible: projects already setting `$breadcrumb_labels` to raw (non-translated) strings in `__construct()` keep working unchanged; only projects calling `_x()` to populate the array need to migrate that block into the new override method. Discovered during the neoli WordPress theme migration ([portadesign/neoli#17](https://github.com/portadesign/neoli/pull/17)) where the labels block had been moved to `timber_context()` as a workaround.
+
 ## [1.7.1] - 2026-05-26
 
 ### Fixed

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -592,11 +592,11 @@ class StarterBase extends Site {
 	 *
 	 *     public function setup_breadcrumb_labels() {
 	 *         $this->breadcrumb_labels = [
-	 *             'home'       => _x( 'Úvod', 'breadcrumb', $this->theme_name ),
-	 *             '404'        => _x( '404', 'breadcrumb', $this->theme_name ),
-	 *             'search'     => _x( 'Vyhledávání: %s', 'breadcrumb', $this->theme_name ),
-	 *             'pagination' => _x( 'Strana %d', 'breadcrumb', $this->theme_name ),
-	 *             'author'     => _x( 'Autor: %s', 'breadcrumb', $this->theme_name ),
+	 *             'home'       => _x( 'Úvod', $this->theme_name, $this->theme_name ),
+	 *             '404'        => _x( '404', $this->theme_name, $this->theme_name ),
+	 *             'search'     => _x( 'Vyhledávání: %s', $this->theme_name, $this->theme_name ),
+	 *             'pagination' => _x( 'Strana %d', $this->theme_name, $this->theme_name ),
+	 *             'author'     => _x( 'Autor: %s', $this->theme_name, $this->theme_name ),
 	 *         ];
 	 *     }
 	 *

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -591,13 +591,13 @@ class StarterBase extends Site {
 	 * Example override in `Base.php`:
 	 *
 	 *     public function setup_breadcrumb_labels() {
-	 *         $this->breadcrumb_labels = [
+	 *         $this->breadcrumb_labels = array(
 	 *             'home'       => _x( 'Úvod', $this->theme_name, $this->theme_name ),
 	 *             '404'        => _x( '404', $this->theme_name, $this->theme_name ),
 	 *             'search'     => _x( 'Vyhledávání: %s', $this->theme_name, $this->theme_name ),
 	 *             'pagination' => _x( 'Strana %d', $this->theme_name, $this->theme_name ),
 	 *             'author'     => _x( 'Autor: %s', $this->theme_name, $this->theme_name ),
-	 *         ];
+	 *         );
 	 *     }
 	 *
 	 * Hooked to `init` (priority 1).

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -592,11 +592,11 @@ class StarterBase extends Site {
 	 *
 	 *     public function setup_breadcrumb_labels() {
 	 *         $this->breadcrumb_labels = [
-	 *             'home'       => _x( 'Úvod', 'breadcrumb', 'mytheme' ),
-	 *             '404'        => _x( '404', 'breadcrumb', 'mytheme' ),
-	 *             'search'     => _x( 'Vyhledávání: %s', 'breadcrumb', 'mytheme' ),
-	 *             'pagination' => _x( 'Strana %d', 'breadcrumb', 'mytheme' ),
-	 *             'author'     => _x( 'Autor: %s', 'breadcrumb', 'mytheme' ),
+	 *             'home'       => _x( 'Úvod', 'breadcrumb', $this->theme_name ),
+	 *             '404'        => _x( '404', 'breadcrumb', $this->theme_name ),
+	 *             'search'     => _x( 'Vyhledávání: %s', 'breadcrumb', $this->theme_name ),
+	 *             'pagination' => _x( 'Strana %d', 'breadcrumb', $this->theme_name ),
+	 *             'author'     => _x( 'Autor: %s', 'breadcrumb', $this->theme_name ),
 	 *         ];
 	 *     }
 	 *

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -297,6 +297,7 @@ class StarterBase extends Site {
 	private function registerBootstrapHooks(): void {
 		add_action( 'after_setup_theme', array( $this, 'theme_supports' ) );
 		add_action( 'init', array( $this, 'register_menus' ) );
+		add_action( 'init', array( $this, 'setup_breadcrumb_labels' ), 1 );
 		add_action( 'acf/init', array( $this, 'register_post_types' ) );
 	}
 
@@ -568,6 +569,43 @@ class StarterBase extends Site {
 		foreach ( $this->menus as $slug => $label ) {
 			register_nav_menu( $slug, __( $label, $this->theme_name ) );
 		}
+	}
+
+	/**
+	 * Hook point for projects to populate `$breadcrumb_labels` with translated
+	 * strings via `_x()` / `__()` calls.
+	 *
+	 * Runs on `init` (priority 1) — after WordPress has loaded the theme's
+	 * textdomain, so translation functions are safe. Before `Breadcrumb`
+	 * dispatcher consumes the labels (`timber/context` filter fires later
+	 * during request rendering).
+	 *
+	 * Calling `_x()` in `Base::__construct()` to populate `$breadcrumb_labels`
+	 * triggers WordPress 6.7+'s `_load_textdomain_just_in_time` notice because
+	 * the constructor runs before `init`. Override this method instead — the
+	 * library calls it at the right time.
+	 *
+	 * Default implementation is a no-op; the English defaults declared on the
+	 * `$breadcrumb_labels` property apply when a project doesn't override.
+	 *
+	 * Example override in `Base.php`:
+	 *
+	 *     public function setup_breadcrumb_labels() {
+	 *         $this->breadcrumb_labels = [
+	 *             'home'       => _x( 'Úvod', 'breadcrumb', 'mytheme' ),
+	 *             '404'        => _x( '404', 'breadcrumb', 'mytheme' ),
+	 *             'search'     => _x( 'Vyhledávání: %s', 'breadcrumb', 'mytheme' ),
+	 *             'pagination' => _x( 'Strana %d', 'breadcrumb', 'mytheme' ),
+	 *             'author'     => _x( 'Autor: %s', 'breadcrumb', 'mytheme' ),
+	 *         ];
+	 *     }
+	 *
+	 * Hooked to `init` (priority 1).
+	 *
+	 * @return void
+	 */
+	public function setup_breadcrumb_labels() {
+		// No-op by default. Subclasses override to assign translated labels.
 	}
 
 	/**

--- a/tests/Unit/StarterBase/RegisterBootstrapHooksTest.php
+++ b/tests/Unit/StarterBase/RegisterBootstrapHooksTest.php
@@ -63,4 +63,35 @@ class RegisterBootstrapHooksTest extends StarterBaseTestCase {
 		$acfInit = array_filter( $actions, fn( $a ) => $a['hook'] === 'acf/init' && is_array( $a['callback'] ) && $a['callback'][1] === 'register_post_types' );
 		$this->assertNotEmpty( $acfInit, 'acf/init → register_post_types must be registered' );
 	}
+
+	public function test_registers_init_for_setup_breadcrumb_labels_at_priority_1(): void {
+		$actions = [];
+		Functions\when( 'add_action' )->alias( function ( $hook, $callback, $priority = 10 ) use ( &$actions ) {
+			$actions[] = [ 'hook' => $hook, 'callback' => $callback, 'priority' => $priority ];
+		} );
+
+		$instance = $this->bareInstance();
+		$this->invokeRegisterBootstrapHooks( $instance );
+
+		$labels = array_values( array_filter(
+			$actions,
+			fn( $a ) => $a['hook'] === 'init'
+				&& is_array( $a['callback'] )
+				&& $a['callback'][1] === 'setup_breadcrumb_labels'
+		) );
+		$this->assertNotEmpty( $labels, 'init → setup_breadcrumb_labels must be registered' );
+		$this->assertSame( 1, $labels[0]['priority'], 'setup_breadcrumb_labels must run on init priority 1' );
+	}
+
+	public function test_default_setup_breadcrumb_labels_is_noop(): void {
+		$instance = $this->bareInstance();
+
+		$ref = new \ReflectionProperty( StarterBase::class, 'breadcrumb_labels' );
+		$before = $ref->getValue( $instance );
+
+		$instance->setup_breadcrumb_labels();
+
+		$after = $ref->getValue( $instance );
+		$this->assertSame( $before, $after, 'Default setup_breadcrumb_labels must not mutate the property — projects override to translate' );
+	}
 }


### PR DESCRIPTION
## From-Project

Discovered during the **neoli** theme migration to `parisek/timber-kit:^1.7` ([portadesign/neoli#17](https://github.com/portadesign/neoli)). With WordPress 6.7+, populating `$breadcrumb_labels` with `_x()` calls in `Base::__construct()` — the natural place per the 1.7.0 migration note — triggers `_load_textdomain_just_in_time` notices in `debug.log` because the textdomain hasn't loaded yet at construct time.

The neoli workaround was to move the `_x()` block into `timber_context()`, which fires post-`init`. That works, but it conflates "set up labels once" with "run on every render" and obscures the property's intended init-time configuration role.

## Why

- WP 6.7+'s `_load_textdomain_just_in_time` warning is intentional — translations called before `init` reliably return the source string (textdomain isn't loaded yet), so they fail silently in production.
- The 1.7.0 doctrine instructs projects to set `$breadcrumb_labels` in `Base::__construct()`. That instruction is at odds with WP 6.7+ when the labels are translated (the common case for non-English projects).
- A sanctioned post-`init` hook closes the gap without re-shaping the property contract.

## What

Add a public no-op method `StarterBase::setup_breadcrumb_labels()` registered on `init` priority 1. Projects override it to populate `$breadcrumb_labels` with translated strings. Default behaviour is unchanged — projects that set raw strings on the property in `__construct()` keep working without modification.

**Backward-compatible:**
- Projects setting non-translated strings on `$breadcrumb_labels` in `__construct()`: unchanged behaviour.
- Projects calling `_x()` to populate it in `__construct()`: still works, but the `_load_textdomain_just_in_time` notice persists. Migration is one move — that block goes into the new override method.

**Diff surface:**
- One new `add_action()` call in `registerBootstrapHooks()`.
- One new public method with a comprehensive docblock and example.
- Two regression tests covering hook registration (priority 1) and default no-op behaviour.

## Tests

\`\`\`
PHPUnit 11.5.55
Tests: 660, Assertions: 1204 — all passing
\`\`\`

## Rollout

After merge:
1. **`tailwind-base`** — sibling draft PR updating `wordpress/timber-kit.md` doctrine to instruct overriding labels inside `setup_breadcrumb_labels()` instead of `__construct()`.
2. **Downstream sync** — each project bumps composer to `^1.7.2` on its own schedule and moves the `_x()` block at the same time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)