### PR TITLE
docs: document $breadcrumb_* properties + setup_breadcrumb_labels() override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Documentation
+
+- **README — new `### Breadcrumbs` subsection under `## Configuration`** documenting the `$breadcrumb_*` properties and the `setup_breadcrumb_labels()` override pattern. Mirrors the `### Performance` (speculation rules) section's shape: rationale → property table → worked example. Worked example uses English source strings (`_x( 'Home', $this->theme_name, $this->theme_name )`, …) so projects in any locale can copy-paste it and substitute the source strings for their language; clarifies that `$this->theme_name` in both `_x()` slots is intentional (context + textdomain unified). Discovered during the neoli WordPress theme migration ([portadesign/neoli#17](https://github.com/portadesign/neoli/pull/17)) — the `setup_breadcrumb_labels()` hook landed in 1.7.2 but was undocumented outside the source-code docstring.
+- **`StarterBase::setup_breadcrumb_labels()` docstring example** — switched the Czech example (`'Úvod'`, `'Vyhledávání: %s'`, …) to English (`'Home'`, `'Search: %s'`, …) to align with the README's locale-agnostic stance. The hook itself is unchanged; only the inline example in the PHPDoc.
+
 ## [1.7.2] - 2026-05-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -264,6 +264,41 @@ When any override is active, an admin notice on WPForms admin screens lists whic
 | `$gutenberg_editor_styles` | bool | `true` | Load editor stylesheet |
 | `$gutenberg_disable_core_patterns` | bool | `true` | Remove core block patterns |
 
+### Breadcrumbs
+
+Breadcrumb data (`$context['breadcrumb']`) is auto-populated by `StarterBase::timber_context()` from the properties below — projects only override these to customise behaviour. A legacy compatibility guard (`class_exists('\Breadcrumb', false)`) skips auto-populate when a project still ships the pre-1.7 global `\Breadcrumb` class.
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `$breadcrumb_labels` | `array<string, string>` | `['home' => 'Home', '404' => 'Page not found', 'search' => 'Search: %s', 'pagination' => 'Page %d', 'author' => 'Author: %s']` | Pre-translated labels for typed items. Defaults are English raw strings — override via `setup_breadcrumb_labels()` (not `__construct()`), see below. |
+| `$breadcrumb_menu_name` | `string` | `'main-menu'` | Nav-menu location slug for the menu-trail strategy (`by_menu_trail`). Set to a different menu's location slug if breadcrumbs should follow a non-main navigation. |
+| `$breadcrumb_list_page_map` | `array<string, string>` | `[]` | Post type → ACF option key for "listing page" injection between Home and a single post of that type. Example: `['post' => 'article_list']` injects `links.article_list` (from the ACF Global Options Page) as the parent crumb on every single `post`. |
+| `$breadcrumb_menu_trail_post_types` | `?array` | `null` | Post types eligible for menu-trail. `null` = auto-detect via `is_post_type_hierarchical()`. Pass an explicit list to opt-in / opt-out specific CPTs regardless of hierarchy. |
+| `$breadcrumb_include_pagination` | `bool` | `false` | Append a `"Page N"` item on paginated archive views. Off by default — opt in per project. |
+
+#### Localising labels — override `setup_breadcrumb_labels()`, not `__construct()`
+
+Calling `_x()` from `Base::__construct()` to populate `$breadcrumb_labels` triggers WordPress 6.7+'s `_load_textdomain_just_in_time` notice — the constructor runs before `init`, but the theme's textdomain has not loaded yet. `StarterBase` registers `setup_breadcrumb_labels()` on `init` (priority 1) as the project-side hook for translated labels:
+
+```php
+class Base extends \Parisek\TimberKit\StarterBase {
+
+    public function setup_breadcrumb_labels() {
+        $this->breadcrumb_labels = array(
+            'home'       => _x( 'Home', $this->theme_name, $this->theme_name ),
+            '404'        => _x( 'Page not found', $this->theme_name, $this->theme_name ),
+            'search'     => _x( 'Search: %s', $this->theme_name, $this->theme_name ),
+            'pagination' => _x( 'Page %d', $this->theme_name, $this->theme_name ),
+            'author'     => _x( 'Author: %s', $this->theme_name, $this->theme_name ),
+        );
+    }
+}
+```
+
+`$this->theme_name` in both `_x()` slots is intentional — it doubles as the translation context and the textdomain, so a single project identifier scopes everything. Substitute the source strings with the project's locale (Czech, German, …) and the WPML / Polylang stack picks the right translation at render time.
+
+Projects that don't need translated labels (single-locale English sites) can skip the override entirely — the English defaults declared on `$breadcrumb_labels` apply unchanged.
+
 ### Performance
 
 Replaces the standalone [Speculation Rules](https://wordpress.org/plugins/speculation-rules/) plugin. After upgrading, downstream projects can `wp plugin deactivate speculation-rules && wp plugin delete speculation-rules` — the same prerender / moderate / logged-out behaviour ships from the theme.

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -592,11 +592,11 @@ class StarterBase extends Site {
 	 *
 	 *     public function setup_breadcrumb_labels() {
 	 *         $this->breadcrumb_labels = array(
-	 *             'home'       => _x( 'Úvod', $this->theme_name, $this->theme_name ),
-	 *             '404'        => _x( '404', $this->theme_name, $this->theme_name ),
-	 *             'search'     => _x( 'Vyhledávání: %s', $this->theme_name, $this->theme_name ),
-	 *             'pagination' => _x( 'Strana %d', $this->theme_name, $this->theme_name ),
-	 *             'author'     => _x( 'Autor: %s', $this->theme_name, $this->theme_name ),
+	 *             'home'       => _x( 'Home', $this->theme_name, $this->theme_name ),
+	 *             '404'        => _x( 'Page not found', $this->theme_name, $this->theme_name ),
+	 *             'search'     => _x( 'Search: %s', $this->theme_name, $this->theme_name ),
+	 *             'pagination' => _x( 'Page %d', $this->theme_name, $this->theme_name ),
+	 *             'author'     => _x( 'Author: %s', $this->theme_name, $this->theme_name ),
 	 *         );
 	 *     }
 	 *


### PR DESCRIPTION
## From-Project

Discovered while migrating the neoli WordPress theme to timber-kit 1.7.2. The `setup_breadcrumb_labels()` hook landed in 1.7.2 (PR #27) and immediately got adopted in neoli's `Base.php`, but only the source-code docstring documents the override pattern — the README's `## Configuration` section has nothing on breadcrumbs.

## Why

- The `$breadcrumb_*` property surface is the natural counterpart to `### Performance` (speculation rules) — both are configurable behaviours bundled in `StarterBase::timber_context()`'s auto-populate path. The README documents the latter, not the former.
- The `_load_textdomain_just_in_time` notice rationale (why `setup_breadcrumb_labels()` exists at all instead of `__construct()`) is non-obvious — a reader who only sees the property without the timing context will likely call `_x()` in `__construct()` and chase the resulting WP 6.7+ notice.
- The `$this->theme_name`-as-both-context-and-textdomain convention is also non-obvious; documenting it once in the README prevents repeated re-discovery per project.

## What

- **README — new `### Breadcrumbs` subsection** under `## Configuration`, between `### Gutenberg` and `### Performance`. Property table + worked example mirrors the shape of `### Performance`.
- **Worked example uses English source strings** (`_x( 'Home', $this->theme_name, $this->theme_name )`, …). Locale-agnostic — any project copy-pastes and substitutes the source strings for their language; the WPML / Polylang stack picks the right translation at render time.
- **`StarterBase::setup_breadcrumb_labels()` PHPDoc example** switched from Czech (`'Úvod'`, `'Vyhledávání: %s'`, …) to English (`'Home'`, `'Search: %s'`, …) so the source-code-level and README-level guidance are visually identical.
- **CHANGELOG `[Unreleased]` → `### Documentation`** logs both changes.

No code changes — docs only. The `setup_breadcrumb_labels()` hook itself is unchanged.

## Downstream impact

None. Existing projects (including neoli on 1.7.2) keep working unchanged. The README change is purely additive — projects that hadn't found the override pattern via the docstring will now find it via the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)