### PR TITLE
docs(adr): add Architecture Decision Record support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@
 /.gitattributes      export-ignore
 /.gitignore          export-ignore
 /tests               export-ignore
+/docs                export-ignore
 /phpunit.xml         export-ignore
 /phpunit.property.xml export-ignore
 /phpstan.neon        export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ build/
 *~
 .DS_Store
 Thumbs.db
+# Ignore docs/ contents (not the dir itself, so the adr/ negation below can re-include).
+/docs/*
+# ADRs are the one committed thing under docs/ — keep them tracked.
+!/docs/adr/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,17 @@ DDEV is the local-dev expectation (`ddev exec "composer test"`). Both run in CI 
 - **Squash-merge PRs** into `main` so the merge commit subject ends with `(#N)`. The auto-release workflow scrapes `(#N)` suffixes from `git log <prev_tag>..<tag>` to assemble the release's Pull Requests section. Merge commits without the suffix won't show up.
 - **Stacked PRs**: when a PR depends on another, target the parent branch (not main). After the parent merges, GitHub auto-retargets — but if `--delete-branch` runs on the parent merge, the child PR auto-closes (chicken-and-egg, recovery requires recreating the deleted branch). Either skip `--delete-branch` until the whole stack lands, or retarget the child to `main` *before* merging the parent.
 
+## Architecture decisions (ADRs)
+
+Significant decisions live in `docs/adr/` — the only tracked subtree under the
+otherwise git-ignored `docs/`. See `docs/adr/README.md` for the template and index.
+
+- Record **sparingly** — only when a decision is (1) hard to reverse, (2) surprising without context, and (3) the result of a real trade-off. Most changes warrant none.
+- Propose and get a yes **before** writing one. Don't auto-create.
+- One file per decision, `NNNN-kebab-title.md`, sequential and permanent (never renumber/reuse).
+- Structure is the Nygard triad: `## Context` / `## Decision` / `## Consequences`. No status line.
+- To reverse a past decision, write a new ADR linking back — don't edit the old one.
+
 ## Release process — DO NOT bypass
 
 Two GitHub Actions automate releases. **Never stamp + tag manually** unless the workflow is broken:

--- a/docs/adr/0001-wpml-block-override.md
+++ b/docs/adr/0001-wpml-block-override.md
@@ -1,0 +1,61 @@
+# 0001. Sync ACF Copy fields into translated blocks at render time
+
+## Context
+
+When an editor changes a field marked **Copy** (`wpml_cf_preferences = 1`) —
+typically an image or file in an ACF Gutenberg block — in the source language,
+the change never reaches the frontend of translated pages. The translated
+`post_content` keeps the old attachment id indefinitely.
+
+The cause is structural. Block instances are serialised into `post_content` as
+HTML comments, and each language owns its own copy. WPML only flags a
+translation `needs_update` when *translatable* (text) content changes; a Copy
+field change does not trigger that flow, and even when it does, translated
+`post_content` is only rewritten during an explicit ATE import job — never on
+save.
+
+This is a long-standing WPML pain point. The reviewed prior art was all
+insufficient: the `acfml_*` preference filters change defaults not runtime
+values; `wpml-config.xml` `<gutenberg-blocks>` only remaps ids already present
+in the translation; "Translate Everything" only fires on translatable changes.
+WPML's own workaround — reprocess every translation through the Translation
+Editor on each Copy change — is not viable for an editorial workflow. Full
+research and decision log: parisek/timber-kit#29.
+
+## Decision
+
+Make **ACF configuration the single source of truth for Copy fields**, applied
+at render time. `Parisek\TimberKit\WpmlBlockOverride` hooks `render_block_data`
+(priority 20, after WPML's own handlers) and, for ACF blocks rendered in a
+non-default language, overwrites `attrs.data.<field>` for Copy-marked fields
+with the source post's value, remapping reference ids to their target-language
+equivalents via `wpml_object_id`. No DB writes, no admin UI, no drift. Translate
+fields (`wpml_cf_preferences = 2`) stay entirely with ACFML/ATE.
+
+A translation block is paired to its source counterpart by **block name +
+ordinal position** (the Nth occurrence of a name maps to the Nth in the source),
+because no stable per-instance id exists in serialised `attrs` at this filter
+stage. The per-name counter resets at the start of each `the_content` pass so a
+secondary `do_blocks()` run cannot desync it. Before matching, a
+**structural-integrity gate** verifies the source and translation hold the same
+count of that block name; on any mismatch the whole name is skipped — a safe
+no-op. Copy-field metadata is cached in a transient invalidated on field-group
+save; block content is read fresh each request and memoised per-request only.
+
+## Consequences
+
+- Translated pages reflect source Copy values with zero editor action and no DB
+  drift. Supported: top-level and nested repeater/group Copy at arbitrary depth;
+  reference remap for attachment / post / term ids.
+- Not supported: `flexible_content` sub-fields (need layout-name awareness) and
+  REST output (`render_block_data` doesn't fire for raw REST).
+- Cache invalidation does **not** fire for programmatic
+  `acf_add_local_field_group()`; code-only changes to `wpml_cf_preferences`
+  serve stale cache up to the TTL (`WP_DEBUG` bypasses the transient in dev).
+  Production workaround: clear the transient on deploy.
+- Equal-count-but-manually-reordered translations are skipped rather than
+  risk landing a Copy value on the wrong instance — an accepted limitation.
+- Guard: `tests/Unit/WpmlBlockOverride/` (ApplyCopyFields, WalkFields,
+  GetCopyFieldsIndex). The `WP_DEBUG`-bypass branch can't be exercised in the
+  harness (the constant is fixed `false` for the whole run) — it's covered by
+  integration testing in the atelier99 reference implementation (atelier99#14).

--- a/docs/adr/0002-breadcrumb-design.md
+++ b/docs/adr/0002-breadcrumb-design.md
@@ -1,0 +1,55 @@
+# 0002. Move Breadcrumb upstream into the kit with typed items
+
+## Context
+
+Each downstream project carried its own copy of a `\Breadcrumb` class in the
+theme. That copy missed coverage every project eventually needs (404, search,
+date, author, post-type archive, taxonomy hierarchy, pagination) and lacked
+defensive guards (`WP_Error` from `get_term_link`, ACF Pro absence, WPML
+normalisation of the menu trail). Fixing it once per project meant the same bugs
+recurred across the fleet.
+
+The kit (`parisek/timber-kit`) is the natural upstream: it already owns the
+`StarterBase` property idiom (`$menus`, `$article_post_types`, …) and a
+`timber_kit_*` filter convention. The downstream `wordpress-base` is a
+*create-project template* — new projects clone it; there are no long-running
+sites with historical `new \Breadcrumb()` call sites that need a migration shim.
+
+## Decision
+
+Move the class into the kit as `src/Breadcrumb.php` and **delete the project
+copy outright** — no deprecated shim. Key shape decisions:
+
+- **Typed items.** Each item carries a `type` discriminator (`home`, `item`,
+  `404`, `search`, `pagination`, `author`, `date_year/month/day`). The class
+  hydrates `title` from labels internally before returning, so a Twig component
+  still reads the existing `{url, title}` shape and ignores the extra `type`
+  key — no template change.
+- **Configuration via `StarterBase` properties** (`$breadcrumb_*`), mirroring
+  the existing property idiom. `StarterBase::timber_context()` auto-populates
+  `$context['breadcrumb']`, gated on `class_exists('\Breadcrumb', false)` so an
+  unmigrated project that still ships the legacy global class auto-opts-out and
+  keeps its own call site working with no Base.php change.
+- **Translation-free kit.** It ships English-default labels; projects override
+  them in their own text domain. The kit can't know a project's domain, and a
+  default guarantees titles are never `null`.
+- **Extension via `timber_kit_breadcrumb_*` filters** (items, labels, skip,
+  menu-trail), matching the existing `timber_kit_*` majority over the
+  slash-style used elsewhere.
+
+## Consequences
+
+- One upstream Breadcrumb with full strategy coverage and guards; downstream
+  projects configure properties instead of forking.
+- Backward-compatible: the additive `type` key is ignored by existing
+  components, and the `items|length <= 2` hide rule still holds because Home is
+  now an explicit item in the array.
+- The `class_exists` guard prevents double-compute for projects that
+  composer-update the kit before migrating their `Base.php`; migrated projects
+  (legacy class deleted) get auto-populate for free.
+- English-default labels mean a project that forgets to configure labels
+  degrades gracefully (visible English) rather than rendering empty titles.
+- Guard: `tests/Unit/BreadcrumbTest.php` (Brain\Monkey).
+- This record distils what began as a long-form migration plan; the full
+  blow-by-blow (per-strategy tables, PR sequencing, risk matrix) lives in git
+  history and the originating discussion, not here.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,55 @@
+# Architecture Decision Records
+
+Short, immutable notes on decisions that shaped this repo — the *why* behind
+choices a future reader would otherwise have to reverse-engineer from the code.
+
+`docs/` is git-ignored repo-wide; only this `adr/` subtree is tracked (see
+`.gitignore`). So ADRs commit, scratch docs don't.
+
+## When to write one
+
+Offer an ADR **sparingly** — only when **all three** are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful.
+2. **Surprising without context** — a future reader will wonder *"why did they
+   do it this way?"*
+3. **The result of a real trade-off** — there were genuine alternatives and one
+   was picked for specific reasons.
+
+Most changes are none of these. A routine helper tweak, a typo fix, a test — no
+ADR. If you're unsure, it probably doesn't need one.
+
+Propose the ADR, get a yes, *then* write it. Don't auto-create.
+
+## Format
+
+Classic Nygard triad — Context / Decision / Consequences. No status line, no
+ceremony. Keep it to what the three headings demand.
+
+- One file per decision: `NNNN-kebab-title.md`, zero-padded, sequential.
+- Numbers are permanent — never renumber or reuse, even if an ADR is later
+  superseded. To reverse a decision, write a new ADR and link back to the old
+  one (leave the old file in place as history).
+
+```markdown
+# NNNN. Short title in the imperative
+
+## Context
+
+What forces are at play — the problem, constraints, and what made the obvious
+path unworkable.
+
+## Decision
+
+What we decided, stated plainly.
+
+## Consequences
+
+What follows — the good, the bad, and what now has to stay true. Name the
+guard (test, CI check, convention) that keeps it from drifting, if any.
+```
+
+## Index
+
+- [0001](0001-wpml-block-override.md) — Sync ACF Copy fields into translated blocks at render time
+- [0002](0002-breadcrumb-design.md) — Move Breadcrumb upstream into the kit with typed items


### PR DESCRIPTION
## What

Adds Architecture Decision Record support, ported from [parisek/acf-json-schema](https://github.com/parisek/acf-json-schema)'s `docs/adr/` convention.

## Changes

- **`docs/adr/README.md`** — the convention doc: classic Nygard triad (Context / Decision / Consequences), the "offer sparingly, propose-then-write" rule, permanent zero-padded `NNNN-kebab-title.md` numbering, and the index.
- **`.gitignore`** — selective tracking. `/docs/*` is ignored, `!/docs/adr/` re-includes just the ADR subtree. `docs/` becomes scratch space (specs, notes) that never pollutes git, while ADRs are first-class committed history.
- **`.gitattributes`** — `/docs export-ignore` so ADRs never ship in the `composer require` dist (consistent with `tests/`, `CHANGELOG.md`, etc.).
- **`AGENTS.md`** — new "Architecture decisions (ADRs)" section pointing at the template and restating the sparingly / propose-first / `NNNN` / triad rules.

## Reseeded ADRs

The two ADRs deleted in 99f5f14 are recreated, distilled from their long-form originals into the lean triad format (the blow-by-blow rationale stays in git history / parisek/timber-kit#29):

- **0001** — Sync ACF Copy fields into translated blocks at render time (`WpmlBlockOverride`).
- **0002** — Move `Breadcrumb` upstream into the kit with typed items.

## Notes

- No `CHANGELOG.md` entry: `docs/` is `export-ignore`, so this ships nothing into the library dist and isn't behavior-affecting.
- Verified the selective `.gitignore` works: `git check-ignore` confirms ADRs are tracked while `docs/<scratch>.md` is ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)