### PR TITLE
ci(release): grant actions: write so the release dispatch works

### DIFF
--- a/.github/workflows/release-stamp.yml
+++ b/.github/workflows/release-stamp.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: write
+  actions: write # dispatch release.yml in the final step (gh workflow run)
 
 jobs:
   stamp:
@@ -104,9 +105,9 @@ jobs:
 
       - name: Trigger release workflow
         # Tag pushes made by GITHUB_TOKEN don't fire downstream `on: push: tags`
-        # workflows by GitHub design. Cross-workflow `workflow_dispatch` over
-        # the API does work with GITHUB_TOKEN, so explicitly invoke release.yml
-        # for the tag we just pushed.
+        # workflows by GitHub design. Dispatch release.yml explicitly instead —
+        # this requires the job's `actions: write` permission (declared above),
+        # or the API returns 403 "Resource not accessible by integration".
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.version }}


### PR DESCRIPTION
## Problem

The **Stamp Release** workflow's final step, *Trigger release workflow*, runs `gh workflow run release.yml` — a cross-workflow `workflow_dispatch`. That API call requires the `actions: write` permission, but the job only declared:

```yaml
permissions:
  contents: write
```

So the dispatch failed with **`HTTP 403: Resource not accessible by integration`**. This bit the **v1.7.6** release: the stamp, commit, tag, and push all succeeded (those only need `contents: write`), but `release.yml` was never triggered, so the GitHub Release had to be dispatched manually afterwards.

Tag pushes made by `GITHUB_TOKEN` don't fire `on: push: tags` workflows (GitHub's anti-recursion design), which is exactly why the explicit dispatch step exists — so it needs to actually work.

## Fix

Add `actions: write` to the workflow's `permissions` block and correct the now-misleading comment (which claimed the dispatch "does work with GITHUB_TOKEN" — it only does with this permission).

```yaml
permissions:
  contents: write
  actions: write # dispatch release.yml in the final step (gh workflow run)
```

No code or shipped-artifact change — workflow only. Next release should run end-to-end without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)