### PR TITLE
ci(release): run stamp guards via composer scripts

### DIFF
--- a/.github/workflows/release-stamp.yml
+++ b/.github/workflows/release-stamp.yml
@@ -62,10 +62,10 @@ jobs:
       - run: composer install --no-interaction --prefer-dist
 
       - name: Run tests
-        run: vendor/bin/phpunit
+        run: composer test
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse
+        run: composer phpstan
 
       - name: Stamp CHANGELOG
         env:


### PR DESCRIPTION
Final consistency pass for the parisek release-infra unification: the **Stamp Release** guards now call `composer test` + `composer phpstan` rather than the raw `vendor/bin/*` binaries, so each package's own composer scripts are the single source of truth for how its tests/analysis run. This matches the three libraries just brought onto the pipeline (twig-typography, twig-attribute, acf-json-schema).

## Equivalence / safety
- `composer test` = `phpunit --testsuite=Unit`, and `phpunit.xml` defines only the `Unit` suite → identical to the previous bare `vendor/bin/phpunit` (the `Property` suite lives in `phpunit.property.xml` and was never part of this guard).
- `composer phpstan` additionally applies `-d memory_limit=2G`, which the raw `phpstan analyse` call lacked — a small improvement, not a regression.

Workflow-only change; `.github` is `export-ignore`, so no shipped artifact and no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)