### PR TITLE
feat: typography-aware translation Twig helpers _xt/__t/_nt/_nxt (#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **Typography-aware translation Twig helpers `_xt` / `__t` / `_nt` / `_nxt`.** Same signatures as WordPress's `_x` / `__` / `_n` / `_nx`, but the translated string is piped through the env's `|typography` filter — so long-form copy gets consistent typographic treatment without `|typography` on every callsite (`_x` → `_xt` is a one-character opt-in). Registered in `StarterBase::timber_twig()` with `is_safe: ['html']`; the typography filter is resolved at call time (falls back to the raw translation if absent). This is the production (Timber) side of [parisek/styleguide#21](https://github.com/parisek/styleguide/issues/21) — the authoring surface (`_xt('…', 'ctx')`) is now identical in the styleguide preview and on the live site. See [#42](https://github.com/parisek/timber-kit/issues/42).
+
 ## [1.7.7] - 2026-06-01
 
 ### Security

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -787,7 +787,85 @@ class StarterBase extends Site {
 		$twig->addFunction( new TwigFunction( 'merge_resizer', [ $this, 'twig_merge_resizer' ] ) );
 		$twig->addFunction( new TwigFunction( 'gtm4wp_the_gtm_tag', [ $this, 'twig_gtm4wp_the_gtm_tag' ] ) );
 
+		// Typography-aware translation helpers (`…t` suffix = "translate +
+		// typography"): `_xt`/`__t`/`_nt`/`_nxt` mirror `_x`/`__`/`_n`/`_nx` but
+		// pipe the translated string through `|typography`, so long-form copy
+		// gets consistent typographic treatment without `|typography` on every
+		// callsite. Production (Timber) side of parisek/styleguide#21 — keeps
+		// the authoring surface identical preview ↔ live site. `is_safe: html`
+		// mirrors the `|typography` filter's own contract.
+		$twig->addFunction( new TwigFunction( '_xt', [ $this, 'twig_xt' ], [ 'needs_environment' => true, 'is_safe' => [ 'html' ] ] ) );
+		$twig->addFunction( new TwigFunction( '__t', [ $this, 'twig_t' ], [ 'needs_environment' => true, 'is_safe' => [ 'html' ] ] ) );
+		$twig->addFunction( new TwigFunction( '_nt', [ $this, 'twig_nt' ], [ 'needs_environment' => true, 'is_safe' => [ 'html' ] ] ) );
+		$twig->addFunction( new TwigFunction( '_nxt', [ $this, 'twig_nxt' ], [ 'needs_environment' => true, 'is_safe' => [ 'html' ] ] ) );
+
 		return $twig;
+	}
+
+	/**
+	 * `_xt` — `_x()` then `|typography`. Backs the `_xt` Twig function.
+	 *
+	 * @param Environment $twig    Injected via `needs_environment`.
+	 * @param string      $text    Source string.
+	 * @param string      $context Gettext context.
+	 * @param string      $domain  Text domain.
+	 */
+	public function twig_xt( Environment $twig, string $text, string $context = '', string $domain = 'default' ): string {
+		return $this->apply_typography( $twig, _x( $text, $context, $domain ) );
+	}
+
+	/**
+	 * `__t` — `__()` then `|typography`. Backs the `__t` Twig function.
+	 *
+	 * @param Environment $twig   Injected via `needs_environment`.
+	 * @param string      $text   Source string.
+	 * @param string      $domain Text domain.
+	 */
+	public function twig_t( Environment $twig, string $text, string $domain = 'default' ): string {
+		return $this->apply_typography( $twig, __( $text, $domain ) );
+	}
+
+	/**
+	 * `_nt` — `_n()` then `|typography`. Backs the `_nt` Twig function.
+	 *
+	 * @param Environment $twig   Injected via `needs_environment`.
+	 * @param string      $single Singular form.
+	 * @param string      $plural Plural form.
+	 * @param int         $number Count selecting singular/plural.
+	 * @param string      $domain Text domain.
+	 */
+	public function twig_nt( Environment $twig, string $single, string $plural, int $number = 1, string $domain = 'default' ): string {
+		return $this->apply_typography( $twig, _n( $single, $plural, $number, $domain ) );
+	}
+
+	/**
+	 * `_nxt` — `_nx()` then `|typography`. Backs the `_nxt` Twig function.
+	 *
+	 * @param Environment $twig    Injected via `needs_environment`.
+	 * @param string      $single  Singular form.
+	 * @param string      $plural  Plural form.
+	 * @param int         $number  Count selecting singular/plural.
+	 * @param string      $context Gettext context.
+	 * @param string      $domain  Text domain.
+	 */
+	public function twig_nxt( Environment $twig, string $single, string $plural, int $number, string $context = '', string $domain = 'default' ): string {
+		return $this->apply_typography( $twig, _nx( $single, $plural, $number, $context, $domain ) );
+	}
+
+	/**
+	 * Run a string through the env's `|typography` filter, resolved at call
+	 * time so the project's tuned TypographyExtension wins. Falls back to the
+	 * raw value if no `typography` filter is registered (defensive — the filter
+	 * is registered by `timber_twig()` itself, so this is normally unreachable).
+	 */
+	private function apply_typography( Environment $twig, string $value ): string {
+		$callable = $twig->getFilter( 'typography' )?->getCallable();
+
+		if ( ! is_callable( $callable ) ) {
+			return $value;
+		}
+
+		return (string) $callable( $value );
 	}
 
 	/**

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -810,7 +810,7 @@ class StarterBase extends Site {
 	 * @param string      $context Gettext context.
 	 * @param string      $domain  Text domain.
 	 */
-	public function twig_xt( Environment $twig, string $text, string $context = '', string $domain = 'default' ): string {
+	public function twig_xt( Environment $twig, string $text, string $context, string $domain = 'default' ): string {
 		return $this->apply_typography( $twig, _x( $text, $context, $domain ) );
 	}
 
@@ -834,7 +834,7 @@ class StarterBase extends Site {
 	 * @param int         $number Count selecting singular/plural.
 	 * @param string      $domain Text domain.
 	 */
-	public function twig_nt( Environment $twig, string $single, string $plural, int $number = 1, string $domain = 'default' ): string {
+	public function twig_nt( Environment $twig, string $single, string $plural, int $number, string $domain = 'default' ): string {
 		return $this->apply_typography( $twig, _n( $single, $plural, $number, $domain ) );
 	}
 
@@ -848,7 +848,7 @@ class StarterBase extends Site {
 	 * @param string      $context Gettext context.
 	 * @param string      $domain  Text domain.
 	 */
-	public function twig_nxt( Environment $twig, string $single, string $plural, int $number, string $context = '', string $domain = 'default' ): string {
+	public function twig_nxt( Environment $twig, string $single, string $plural, int $number, string $context, string $domain = 'default' ): string {
 		return $this->apply_typography( $twig, _nx( $single, $plural, $number, $context, $domain ) );
 	}
 

--- a/tests/Unit/StarterBase/TwigTranslationHelpersTest.php
+++ b/tests/Unit/StarterBase/TwigTranslationHelpersTest.php
@@ -9,6 +9,7 @@ use Tests\Unit\StarterBaseTestCase;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 use Twig\TwigFilter;
+use Twig\TwigFunction;
 
 /**
  * Coverage for the typography-aware translation helpers
@@ -16,13 +17,18 @@ use Twig\TwigFilter;
  * functions `_xt` / `__t` / `_nt` / `_nxt` (parisek/timber-kit#42, mirroring
  * parisek/styleguide#21). Each calls the matching WordPress translator and
  * pipes the result through the env's `|typography` filter.
+ *
+ * The mocked translators fold every argument they receive into the returned
+ * marker (`X:text|context|domain`, …) so a dropped or swapped `$context` /
+ * `$number` / `$domain` would change the assertion — i.e. full argument
+ * forwarding is proven, not just that the right translator ran.
  */
 class TwigTranslationHelpersTest extends StarterBaseTestCase {
 
 	/**
 	 * A Twig env whose `typography` filter wraps its input in `T(…)` so the
-	 * compose order (translate THEN typography) is unambiguous in assertions —
-	 * no dependency on php-typography's concrete output.
+	 * compose order (translate THEN typography) is unambiguous — no dependency
+	 * on php-typography's concrete output.
 	 */
 	private function envWithMarkerTypography(): Environment {
 		$env = new Environment( new ArrayLoader() );
@@ -35,40 +41,71 @@ class TwigTranslationHelpersTest extends StarterBaseTestCase {
 		return $env;
 	}
 
-	public function test_xt_translates_then_typographies(): void {
-		Functions\when( '_x' )->alias( static fn ( string $t, string $c = '', string $d = 'default' ): string => 'X:' . $t );
+	public function test_xt_forwards_all_args_then_typographies(): void {
+		Functions\when( '_x' )->alias( static fn ( string $t, string $c, string $d = 'default' ): string => "X:$t|$c|$d" );
 		$base = $this->createStarterBase();
 
-		$this->assertSame( 'T(X:hello)', $base->twig_xt( $this->envWithMarkerTypography(), 'hello', 'ctx', 'dom' ) );
+		$this->assertSame( 'T(X:hello|ctx|dom)', $base->twig_xt( $this->envWithMarkerTypography(), 'hello', 'ctx', 'dom' ) );
 	}
 
-	public function test_underscore_t_translates_then_typographies(): void {
-		Functions\when( '__' )->alias( static fn ( string $t, string $d = 'default' ): string => 'U:' . $t );
+	public function test_underscore_t_forwards_all_args_then_typographies(): void {
+		Functions\when( '__' )->alias( static fn ( string $t, string $d = 'default' ): string => "U:$t|$d" );
 		$base = $this->createStarterBase();
 
-		$this->assertSame( 'T(U:hello)', $base->twig_t( $this->envWithMarkerTypography(), 'hello', 'dom' ) );
+		$this->assertSame( 'T(U:hello|dom)', $base->twig_t( $this->envWithMarkerTypography(), 'hello', 'dom' ) );
 	}
 
-	public function test_nt_translates_plural_then_typographies(): void {
-		Functions\when( '_n' )->alias( static fn ( string $s, string $p, int $n = 1, string $d = 'default' ): string => $n === 1 ? $s : $p );
+	public function test_nt_selects_plural_and_forwards_then_typographies(): void {
+		Functions\when( '_n' )->alias( static fn ( string $s, string $p, int $n, string $d = 'default' ): string => 'N:' . ( $n === 1 ? $s : $p ) . "|$d" );
 		$base = $this->createStarterBase();
 
-		$this->assertSame( 'T(one)', $base->twig_nt( $this->envWithMarkerTypography(), 'one', 'many', 1, 'dom' ) );
-		$this->assertSame( 'T(many)', $base->twig_nt( $this->envWithMarkerTypography(), 'one', 'many', 4, 'dom' ) );
+		$this->assertSame( 'T(N:one|dom)', $base->twig_nt( $this->envWithMarkerTypography(), 'one', 'many', 1, 'dom' ) );
+		$this->assertSame( 'T(N:many|dom)', $base->twig_nt( $this->envWithMarkerTypography(), 'one', 'many', 4, 'dom' ) );
 	}
 
-	public function test_nxt_translates_plural_with_context_then_typographies(): void {
-		Functions\when( '_nx' )->alias( static fn ( string $s, string $p, int $n, string $c = '', string $d = 'default' ): string => $n === 1 ? $s : $p );
+	public function test_nxt_selects_plural_with_context_and_forwards_then_typographies(): void {
+		Functions\when( '_nx' )->alias( static fn ( string $s, string $p, int $n, string $c, string $d = 'default' ): string => 'NX:' . ( $n === 1 ? $s : $p ) . "|$c|$d" );
 		$base = $this->createStarterBase();
 
-		$this->assertSame( 'T(many)', $base->twig_nxt( $this->envWithMarkerTypography(), 'one', 'many', 2, 'ctx', 'dom' ) );
+		$this->assertSame( 'T(NX:many|ctx|dom)', $base->twig_nxt( $this->envWithMarkerTypography(), 'one', 'many', 2, 'ctx', 'dom' ) );
 	}
 
 	public function test_typography_absent_falls_back_to_raw_translation(): void {
-		Functions\when( '_x' )->alias( static fn ( string $t, string $c = '', string $d = 'default' ): string => 'X:' . $t );
+		Functions\when( '_x' )->alias( static fn ( string $t, string $c, string $d = 'default' ): string => "X:$t|$c|$d" );
 		$base = $this->createStarterBase();
 		$env  = new Environment( new ArrayLoader() ); // no `typography` filter registered
 
-		$this->assertSame( 'X:hello', $base->twig_xt( $env, 'hello', 'ctx', 'dom' ) );
+		$this->assertSame( 'X:hello|ctx|dom', $base->twig_xt( $env, 'hello', 'ctx', 'dom' ) );
+	}
+
+	/**
+	 * Render through Twig with the functions registered exactly as
+	 * `timber_twig()` registers them, so the public names `_xt`/`__t`/`_nt`/
+	 * `_nxt`, the `needs_environment` injection and the `is_safe: ['html']`
+	 * contract are all exercised — the HTML-emitting marker filter (`<b>…</b>`)
+	 * is NOT autoescaped, proving the safety flag.
+	 */
+	public function test_functions_render_through_twig_with_environment_and_html_safety(): void {
+		Functions\when( '_x' )->alias( static fn ( string $t, string $c, string $d = 'default' ): string => "X:$t|$c|$d" );
+		Functions\when( '__' )->alias( static fn ( string $t, string $d = 'default' ): string => "U:$t|$d" );
+		Functions\when( '_n' )->alias( static fn ( string $s, string $p, int $n, string $d = 'default' ): string => 'N:' . ( $n === 1 ? $s : $p ) . "|$d" );
+		Functions\when( '_nx' )->alias( static fn ( string $s, string $p, int $n, string $c, string $d = 'default' ): string => 'NX:' . ( $n === 1 ? $s : $p ) . "|$c|$d" );
+
+		$base = $this->createStarterBase();
+
+		$twig = new Environment( new ArrayLoader() );
+		$twig->addFilter( new TwigFilter( 'typography', static fn ( string $v ): string => '<b>' . $v . '</b>', [ 'is_safe' => [ 'html' ] ] ) );
+		foreach ( [ '_xt' => 'twig_xt', '__t' => 'twig_t', '_nt' => 'twig_nt', '_nxt' => 'twig_nxt' ] as $name => $method ) {
+			$twig->addFunction( new TwigFunction( $name, [ $base, $method ], [ 'needs_environment' => true, 'is_safe' => [ 'html' ] ] ) );
+		}
+
+		$out = $twig->createTemplate(
+			'{{ _xt("hello", "ctx", "dom") }}|{{ __t("hi", "dom") }}|{{ _nt("one", "many", 2, "dom") }}|{{ _nxt("a", "b", 2, "ctx", "dom") }}',
+		)->render();
+
+		$this->assertSame(
+			'<b>X:hello|ctx|dom</b>|<b>U:hi|dom</b>|<b>N:many|dom</b>|<b>NX:b|ctx|dom</b>',
+			$out,
+		);
 	}
 }

--- a/tests/Unit/StarterBase/TwigTranslationHelpersTest.php
+++ b/tests/Unit/StarterBase/TwigTranslationHelpersTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\StarterBase;
+
+use Brain\Monkey\Functions;
+use Tests\Unit\StarterBaseTestCase;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Twig\TwigFilter;
+
+/**
+ * Coverage for the typography-aware translation helpers
+ * `StarterBase::twig_xt()` / `twig_t()` / `twig_nt()` / `twig_nxt()` — the Twig
+ * functions `_xt` / `__t` / `_nt` / `_nxt` (parisek/timber-kit#42, mirroring
+ * parisek/styleguide#21). Each calls the matching WordPress translator and
+ * pipes the result through the env's `|typography` filter.
+ */
+class TwigTranslationHelpersTest extends StarterBaseTestCase {
+
+	/**
+	 * A Twig env whose `typography` filter wraps its input in `T(…)` so the
+	 * compose order (translate THEN typography) is unambiguous in assertions —
+	 * no dependency on php-typography's concrete output.
+	 */
+	private function envWithMarkerTypography(): Environment {
+		$env = new Environment( new ArrayLoader() );
+		$env->addFilter( new TwigFilter(
+			'typography',
+			static fn ( string $value ): string => 'T(' . $value . ')',
+			[ 'is_safe' => [ 'html' ] ],
+		) );
+
+		return $env;
+	}
+
+	public function test_xt_translates_then_typographies(): void {
+		Functions\when( '_x' )->alias( static fn ( string $t, string $c = '', string $d = 'default' ): string => 'X:' . $t );
+		$base = $this->createStarterBase();
+
+		$this->assertSame( 'T(X:hello)', $base->twig_xt( $this->envWithMarkerTypography(), 'hello', 'ctx', 'dom' ) );
+	}
+
+	public function test_underscore_t_translates_then_typographies(): void {
+		Functions\when( '__' )->alias( static fn ( string $t, string $d = 'default' ): string => 'U:' . $t );
+		$base = $this->createStarterBase();
+
+		$this->assertSame( 'T(U:hello)', $base->twig_t( $this->envWithMarkerTypography(), 'hello', 'dom' ) );
+	}
+
+	public function test_nt_translates_plural_then_typographies(): void {
+		Functions\when( '_n' )->alias( static fn ( string $s, string $p, int $n = 1, string $d = 'default' ): string => $n === 1 ? $s : $p );
+		$base = $this->createStarterBase();
+
+		$this->assertSame( 'T(one)', $base->twig_nt( $this->envWithMarkerTypography(), 'one', 'many', 1, 'dom' ) );
+		$this->assertSame( 'T(many)', $base->twig_nt( $this->envWithMarkerTypography(), 'one', 'many', 4, 'dom' ) );
+	}
+
+	public function test_nxt_translates_plural_with_context_then_typographies(): void {
+		Functions\when( '_nx' )->alias( static fn ( string $s, string $p, int $n, string $c = '', string $d = 'default' ): string => $n === 1 ? $s : $p );
+		$base = $this->createStarterBase();
+
+		$this->assertSame( 'T(many)', $base->twig_nxt( $this->envWithMarkerTypography(), 'one', 'many', 2, 'ctx', 'dom' ) );
+	}
+
+	public function test_typography_absent_falls_back_to_raw_translation(): void {
+		Functions\when( '_x' )->alias( static fn ( string $t, string $c = '', string $d = 'default' ): string => 'X:' . $t );
+		$base = $this->createStarterBase();
+		$env  = new Environment( new ArrayLoader() ); // no `typography` filter registered
+
+		$this->assertSame( 'X:hello', $base->twig_xt( $env, 'hello', 'ctx', 'dom' ) );
+	}
+}


### PR DESCRIPTION
Production (Timber) side of [parisek/styleguide#21](https://github.com/parisek/styleguide/issues/21). Closes #42.

> ⏸️ Prepared, **not for immediate release** — pairs with the styleguide-side helpers (queued there for a feature release).

## What

Registers four Twig functions in `StarterBase::timber_twig()`, alongside the existing `resizer` / `component_*` / `page_*`:

| fn | backing method | = |
|---|---|---|
| `_xt(text, context, domain)` | `twig_xt` | `_x(…)` then `\|typography` |
| `__t(text, domain)` | `twig_t` | `__(…)` then `\|typography` |
| `_nt(single, plural, number, domain)` | `twig_nt` | `_n(…)` then `\|typography` |
| `_nxt(single, plural, number, context, domain)` | `twig_nxt` | `_nx(…)` then `\|typography` |

Each calls the real WP translator and applies the env's `|typography` filter (resolved at call time, `is_callable`-guarded fallback to the raw translation). `needs_environment` + `is_safe: ['html']`. The authoring surface `_xt('…', 'ctx')` is now identical in the styleguide preview and on the live WP site.

## Tests

`tests/Unit/StarterBase/TwigTranslationHelpersTest.php` — Brain Monkey mocks the WP translators with distinct markers and a `T(…)` marker `typography` filter, so the compose order (translate THEN typography) is asserted unambiguously for all four helpers; plus the typography-absent fallback. PHPStan level 8 clean; full suite green (677 tests).

## Cross-CMS

Mirrors the four signatures from styleguide#21 (preview) and the Drupal side tracked under `parisek/custom-components` — identical authoring surface across all three.