### PR TITLE
feat(acf): $acf_datastore flag — opt-in ACF Datastore (revisions + autosave)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **`StarterBase::$acf_datastore` flag** (default `false`) — opt-in switch for the **ACF Datastore** (`acf/settings/enable_datastore`, ACF Pro 6.8.1+ / WP 6.7+). When enabled in a downstream `Base`, `registerAcfHooks()` adds `add_filter( 'acf/settings/enable_datastore', '__return_true' )`, routing ACF field saves through the REST / Gutenberg `wp.data` flow instead of the legacy metabox AJAX request. This lets ACF values participate in **post revisions** and **autosave**. Value storage is unchanged (still postmeta), ACF Local JSON is untouched, and the Timber read path (`Helpers::formatFields()` → `get_field()`) is identical. The REST save still calls `acf_save_post()` and fires the same `acf/save_post` action, so `BlockRenderer::flushPostBlockCache` (block-cache invalidation) and `acfml`'s WPML sync keep firing unchanged. Site-wide boolean by design — ACF evaluates `acf_is_using_datastore()` in no-post contexts (`rest_api_init`) where `get_post_type()` is `false`, so a per-post-type gate would silently disable the save hooks everywhere. Left **off** in the library because the feature is still in ACF's feedback phase and is not yet WPML-certified against the datastore; projects opt in deliberately (pilot on staging). Fully reversible via `__return_false`. Evaluation, source-verified backport-risk analysis, and the staging checklist live in [portadesign/wordpress-base#38](https://github.com/portadesign/wordpress-base/issues/38).
+
 ## [1.9.0] - 2026-06-10
 
 ### Added

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -210,6 +210,30 @@ class StarterBase extends Site {
 	protected bool $wpml_block_override = false;
 
 	/**
+	 * ACF Datastore ({@see https://www.advancedcustomfields.com/resources/acf-settings-enable_datastore/}).
+	 *
+	 * Opt-in (default off). Switches how ACF saves field values — through the
+	 * REST / Gutenberg `wp.data` flow instead of the legacy metabox AJAX request
+	 * — which lets ACF values participate in **revisions** and **autosave**.
+	 * Storage is unchanged (still postmeta), Local JSON is untouched, and the
+	 * Timber read path (`get_field()`) is identical. The REST save still calls
+	 * `acf_save_post()` and fires the same `acf/save_post` action, so
+	 * `BlockRenderer::flushPostBlockCache` and `acfml`'s WPML sync keep working.
+	 *
+	 * Site-wide on/off only — ACF evaluates `acf_is_using_datastore()` in
+	 * no-post contexts (`rest_api_init`) where `get_post_type()` is `false`, so
+	 * a per-post-type conditional would silently disable the save hooks
+	 * everywhere. Requires WP 6.7+ and ACF Pro 6.8.1+ (ACF self-guards both).
+	 * Fully reversible. Left off in the library because the feature is still in
+	 * ACF's feedback phase and is not yet WPML-certified against the datastore;
+	 * projects enable it deliberately (pilot on staging — see
+	 * {@link https://github.com/portadesign/wordpress-base/issues/38}).
+	 *
+	 * @var bool
+	 */
+	protected bool $acf_datastore = false;
+
+	/**
 	 * Performance — replaces the standalone Speculation Rules plugin
 	 * (https://wordpress.org/plugins/speculation-rules/)
 	 */
@@ -365,7 +389,8 @@ class StarterBase extends Site {
 
 	/**
 	 * Register ACF JSON sync and field-formatting hooks — load/save paths,
-	 * save filename, wysiwyg sanitization, and post-object value fix.
+	 * save filename, wysiwyg sanitization, and post-object value fix. Plus the
+	 * opt-in `acf/settings/enable_datastore` filter when `$acf_datastore` is on.
 	 *
 	 * @return void
 	 */
@@ -375,6 +400,12 @@ class StarterBase extends Site {
 		add_filter( 'acf/json/save_file_name', array( $this, 'acf_json_save_file_name' ), 10, 3 );
 		add_filter( 'acf/update_value/type=wysiwyg', array( $this, 'sanitize_acf_editor_value' ), 10, 1 );
 		add_filter( 'acf/format_value/type=post_object', array( $this, 'fix_wrong_acf_orders_with_ids' ), 10, 3 );
+		if ( $this->acf_datastore ) {
+			// Opt-in: route ACF saves through the REST/datastore path so values land
+			// in revisions + autosave. Site-wide boolean — see the $acf_datastore
+			// docblock for why a per-post-type gate would silently disable it.
+			add_filter( 'acf/settings/enable_datastore', '__return_true' );
+		}
 	}
 
 	/**

--- a/tests/Unit/StarterBase/RegisterAcfHooksTest.php
+++ b/tests/Unit/StarterBase/RegisterAcfHooksTest.php
@@ -56,6 +56,44 @@ class RegisterAcfHooksTest extends StarterBaseTestCase {
 
 		$this->invokeRegisterAcfHooks( $this->bareInstance() );
 
-		$this->assertCount( 5, $filters, 'registerAcfHooks should register exactly 5 filters' );
+		$this->assertCount( 5, $filters, 'registerAcfHooks should register exactly 5 filters when the datastore flag is off (default)' );
+	}
+
+	public function test_does_not_register_datastore_filter_by_default(): void {
+		$filters = [];
+		Functions\when( 'add_filter' )->alias( function ( $hook, ...$rest ) use ( &$filters ) {
+			$filters[] = $hook;
+		} );
+
+		$this->invokeRegisterAcfHooks( $this->bareInstance() );
+
+		$this->assertNotContains(
+			'acf/settings/enable_datastore',
+			$filters,
+			'ACF datastore must be opt-in — not registered while $acf_datastore is off (default)'
+		);
+	}
+
+	public function test_registers_datastore_filter_when_flag_enabled(): void {
+		$filters = [];
+		Functions\when( 'add_filter' )->alias( function ( $hook, $callback = null, ...$rest ) use ( &$filters ) {
+			$filters[] = [ 'hook' => $hook, 'callback' => $callback ];
+		} );
+
+		$instance = $this->bareInstance();
+		$prop = new \ReflectionProperty( StarterBase::class, 'acf_datastore' );
+		$prop->setValue( $instance, true );
+
+		$this->invokeRegisterAcfHooks( $instance );
+
+		$datastore = array_filter( $filters, fn( $f ) => $f['hook'] === 'acf/settings/enable_datastore' );
+		$this->assertCount( 1, $datastore, 'flag on → exactly one acf/settings/enable_datastore filter registered' );
+
+		$entry = array_values( $datastore )[0];
+		$this->assertSame(
+			'__return_true',
+			$entry['callback'],
+			'datastore is enabled site-wide via the __return_true callback'
+		);
 	}
 }


### PR DESCRIPTION
## Summary

Adds an opt-in `StarterBase::$acf_datastore` flag (default `false`) for the **ACF Datastore** (`acf/settings/enable_datastore`, ACF Pro 6.8.1+ / WP 6.7+). Prepares the library side of the evaluation tracked in [portadesign/wordpress-base#38](https://github.com/portadesign/wordpress-base/issues/38).

When a downstream `Base` flips it on, `registerAcfHooks()` registers:

```php
add_filter( 'acf/settings/enable_datastore', '__return_true' );
```

This routes ACF field saves through the REST / Gutenberg `wp.data` flow instead of the legacy metabox AJAX request, so ACF values participate in **post revisions** and **autosave**.

## Why a flag, not on-by-default

Per the repo doctrine (AGENTS.md → *Feature flags & breaking changes*) and the issue's own verdict (*"Fleet-wide canonical default in `wordpress-base`: not yet"*), this ships behind a flag, default off:

- Still in ACF's **feedback phase** (API may shift).
- Not yet **WPML-certified** against the datastore (rides stable `acf/save_post` / `acf/update_value` hooks, but uncertified).
- Fleet WP-floor not yet guaranteed ≥ 6.7.

Opinionated default lives downstream — `wordpress-base`'s `Base` can enable it per-project after the staging checklist in #38.

## Why a single site-wide boolean (not per-post-type)

ACF evaluates `acf_is_using_datastore()` in no-post contexts (`rest_api_init`, revision hooks) where `get_post_type()` returns `false`. A per-post-type conditional would therefore **silently disable the save hooks everywhere** — so the gate is an intentional site-level on/off.

## What does NOT change

- Value storage — still **postmeta**.
- ACF **Local JSON** / `acf_json_save_paths` — untouched.
- Timber read path — `Helpers::formatFields()` → `get_field()` identical.
- Block-cache invalidation — REST save still calls `acf_save_post()` → fires `acf/save_post`, so `BlockRenderer::flushPostBlockCache` keeps firing.
- `acfml` WPML sync — rides the same `acf/save_post` + `acf/update_value` hooks.

Fully reversible via `add_filter( 'acf/settings/enable_datastore', '__return_false', 100 )`.

## Tests (TDD)

`RegisterAcfHooksTest`:
- off (default) → `acf/settings/enable_datastore` **not** registered; filter count stays 5.
- on → exactly one `acf/settings/enable_datastore` filter, callback `__return_true`.

`composer test` green (suite-wide), `composer phpstan` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)