### PR TITLE
feat(media): $enabled_image_sizes — opt-in allowlist for intermediate sub-sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **`StarterBase::$enabled_image_sizes` property (`string[]|null`, default `null`)** — opt-in allowlist of image sub-size slugs to generate on upload, hooked to `intermediate_image_sizes_advanced`. When `null` (the default) all registered sizes are generated — identical to WordPress's out-of-the-box behaviour. When set, only the listed slugs survive; any other registered size (including WordPress 5.3+ `1536x1536` and `2048x2048`) is silently dropped. Useful for cutting disk usage and upload time on projects whose Twig templates use only a subset of the standard sizes. Built-in WP slugs for reference: `thumbnail`, `medium`, `medium_large`, `large`, `1536x1536`, `2048x2048`. Affects new uploads only — `wp media regenerate` is needed to apply the allowlist to existing images.
+
 ## [1.11.0] - 2026-06-15
 
 ### Added

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -203,6 +203,29 @@ class StarterBase extends Site {
 	protected ?int $max_upload_height = null;
 
 	/**
+	 * Opt-in allowlist of image sub-size slugs to generate on upload.
+	 *
+	 * When `null` (the default), all sizes registered by WordPress core and
+	 * plugins are generated — identical to WP's out-of-the-box behaviour.
+	 *
+	 * When set to a string array, only the listed slugs survive the
+	 * `intermediate_image_sizes_advanced` filter. Every other registered size
+	 * (including WordPress 5.3+ sizes `1536x1536` and `2048x2048`) is silently
+	 * dropped for new uploads.
+	 *
+	 * Built-in WordPress slugs for reference:
+	 *   `thumbnail`, `medium`, `medium_large`, `large`, `1536x1536`, `2048x2048`
+	 *
+	 * Example — keep only the three sizes the project's Twig templates actually use:
+	 * ```php
+	 * $this->enabled_image_sizes = ['thumbnail', 'medium', 'large'];
+	 * ```
+	 *
+	 * @var string[]|null
+	 */
+	protected ?array $enabled_image_sizes = null;
+
+	/**
 	 * Gutenberg enhancements
 	 */
 
@@ -488,6 +511,11 @@ class StarterBase extends Site {
 		// timber-kit is authoritative over the threshold across the fleet, and the
 		// callback returns 0 to disable core scaling entirely. See the callback note.
 		add_filter( 'big_image_size_threshold', array( $this, 'big_image_size_threshold' ), 10, 1 );
+		// Image sub-size allowlist — opt-in. When null (default) all registered sizes
+		// are generated (WP core behaviour). When set, only the listed slugs survive.
+		if ( null !== $this->enabled_image_sizes ) {
+			add_filter( 'intermediate_image_sizes_advanced', array( $this, 'filter_image_sizes' ), 10, 3 );
+		}
 	}
 
 	/**
@@ -3220,6 +3248,32 @@ class StarterBase extends Site {
 		}
 
 		return $this->big_image_size_threshold;
+	}
+
+	/**
+	 * Remove any registered sub-size slugs not present in {@see $enabled_image_sizes}.
+	 *
+	 * When `$enabled_image_sizes` is `null` (the default), this method is never
+	 * hooked and the filter is never called — all registered sizes are generated,
+	 * preserving WordPress's out-of-the-box behaviour.
+	 *
+	 * When an allowlist is set, sizes absent from the list (e.g. WordPress 5.3+
+	 * `1536x1536` and `2048x2048`) are dropped before `wp_create_image_subsizes()`
+	 * generates derivatives for the newly uploaded file.
+	 *
+	 * Hooked to `intermediate_image_sizes_advanced`.
+	 *
+	 * @param array<string, array<string, mixed>> $sizes         Registered sizes keyed by slug.
+	 * @param array<string, mixed>                $image_meta    Full image metadata.
+	 * @param int                                 $attachment_id Attachment post ID.
+	 * @return array<string, array<string, mixed>> Filtered sizes.
+	 */
+	public function filter_image_sizes( array $sizes, array $image_meta, int $attachment_id ): array {
+		if ( null === $this->enabled_image_sizes ) {
+			return $sizes;
+		}
+
+		return array_intersect_key( $sizes, array_flip( $this->enabled_image_sizes ) );
 	}
 
 	/**

--- a/tests/Unit/StarterBase/FilterImageSizesTest.php
+++ b/tests/Unit/StarterBase/FilterImageSizesTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\StarterBase;
+
+use Tests\Unit\StarterBaseTestCase;
+
+/**
+ * Verifies filter_image_sizes() enforces the $enabled_image_sizes allowlist
+ * against the intermediate_image_sizes_advanced filter payload.
+ */
+class FilterImageSizesTest extends StarterBaseTestCase {
+
+	/** All four WP built-in sizes used as a representative fixture. */
+	private function allSizes(): array {
+		return [
+			'thumbnail'  => [ 'width' => 150, 'height' => 150, 'crop' => true ],
+			'medium'     => [ 'width' => 300, 'height' => 300, 'crop' => false ],
+			'large'      => [ 'width' => 1024, 'height' => 1024, 'crop' => false ],
+			'1536x1536'  => [ 'width' => 1536, 'height' => 1536, 'crop' => false ],
+			'2048x2048'  => [ 'width' => 2048, 'height' => 2048, 'crop' => false ],
+		];
+	}
+
+	public function test_returns_all_sizes_when_allowlist_is_null(): void {
+		$base = $this->createStarterBase( [ 'enabled_image_sizes' => null ] );
+
+		$result = $base->filter_image_sizes( $this->allSizes(), [], 1 );
+
+		$this->assertSame( $this->allSizes(), $result );
+	}
+
+	public function test_keeps_only_allowlisted_slugs(): void {
+		$base = $this->createStarterBase( [
+			'enabled_image_sizes' => [ 'thumbnail', 'medium', 'large' ],
+		] );
+
+		$result = $base->filter_image_sizes( $this->allSizes(), [], 1 );
+
+		$this->assertArrayHasKey( 'thumbnail', $result );
+		$this->assertArrayHasKey( 'medium', $result );
+		$this->assertArrayHasKey( 'large', $result );
+		$this->assertArrayNotHasKey( '1536x1536', $result );
+		$this->assertArrayNotHasKey( '2048x2048', $result );
+	}
+
+	public function test_drops_wp53_sizes_by_default_when_allowlist_excludes_them(): void {
+		$base = $this->createStarterBase( [
+			'enabled_image_sizes' => [ 'thumbnail', 'medium', 'medium_large', 'large' ],
+		] );
+
+		$result = $base->filter_image_sizes( $this->allSizes(), [], 1 );
+
+		$this->assertArrayNotHasKey( '1536x1536', $result );
+		$this->assertArrayNotHasKey( '2048x2048', $result );
+		$this->assertCount( 3, $result ); // thumbnail + medium + large (medium_large not in fixture)
+	}
+
+	public function test_empty_allowlist_drops_all_sizes(): void {
+		$base = $this->createStarterBase( [ 'enabled_image_sizes' => [] ] );
+
+		$result = $base->filter_image_sizes( $this->allSizes(), [], 1 );
+
+		$this->assertSame( [], $result );
+	}
+
+	public function test_allowlist_entry_not_in_registered_sizes_is_silently_ignored(): void {
+		$base = $this->createStarterBase( [
+			'enabled_image_sizes' => [ 'thumbnail', 'nonexistent-size' ],
+		] );
+
+		$result = $base->filter_image_sizes( $this->allSizes(), [], 1 );
+
+		$this->assertArrayHasKey( 'thumbnail', $result );
+		$this->assertArrayNotHasKey( 'nonexistent-size', $result );
+		$this->assertCount( 1, $result );
+	}
+
+	public function test_size_settings_are_preserved_unmodified(): void {
+		$base = $this->createStarterBase( [
+			'enabled_image_sizes' => [ 'thumbnail' ],
+		] );
+
+		$result = $base->filter_image_sizes( $this->allSizes(), [], 1 );
+
+		$this->assertSame(
+			[ 'width' => 150, 'height' => 150, 'crop' => true ],
+			$result['thumbnail']
+		);
+	}
+
+	public function test_image_meta_and_attachment_id_are_not_used(): void {
+		// The method ignores $image_meta and $attachment_id — passing arbitrary
+		// values must not change the outcome.
+		$base = $this->createStarterBase( [
+			'enabled_image_sizes' => [ 'medium' ],
+		] );
+
+		$result1 = $base->filter_image_sizes( $this->allSizes(), [], 0 );
+		$result2 = $base->filter_image_sizes( $this->allSizes(), [ 'width' => 5000, 'height' => 3000 ], 99 );
+
+		$this->assertSame( $result1, $result2 );
+	}
+}

--- a/tests/Unit/StarterBase/RegisterMediaHooksTest.php
+++ b/tests/Unit/StarterBase/RegisterMediaHooksTest.php
@@ -121,6 +121,40 @@ class RegisterMediaHooksTest extends StarterBaseTestCase {
 		$this->assertNotContains( 'wp_generate_attachment_metadata', $filters );
 	}
 
+	public function test_registers_intermediate_image_sizes_when_allowlist_set(): void {
+		$filters = [];
+		Functions\when( 'add_filter' )->alias( function ( $hook, ...$rest ) use ( &$filters ) {
+			$filters[] = $hook;
+		} );
+		Functions\when( 'add_action' )->justReturn( true );
+
+		$instance = $this->bareInstance();
+		$this->setProperty( $instance, 'clean_image_filenames', false );
+		$this->setProperty( $instance, 'big_image_size_threshold', 2560 );
+		$this->setProperty( $instance, 'enabled_image_sizes', [ 'thumbnail', 'medium', 'large' ] );
+
+		$this->invokeRegisterMediaHooks( $instance );
+
+		$this->assertContains( 'intermediate_image_sizes_advanced', $filters );
+	}
+
+	public function test_skips_intermediate_image_sizes_when_allowlist_is_null(): void {
+		$filters = [];
+		Functions\when( 'add_filter' )->alias( function ( $hook, ...$rest ) use ( &$filters ) {
+			$filters[] = $hook;
+		} );
+		Functions\when( 'add_action' )->justReturn( true );
+
+		$instance = $this->bareInstance();
+		$this->setProperty( $instance, 'clean_image_filenames', false );
+		$this->setProperty( $instance, 'big_image_size_threshold', 2560 );
+		$this->setProperty( $instance, 'enabled_image_sizes', null );
+
+		$this->invokeRegisterMediaHooks( $instance );
+
+		$this->assertNotContains( 'intermediate_image_sizes_advanced', $filters );
+	}
+
 	/**
 	 * Helper to set a protected/private property on a bare instance.
 	 */


### PR DESCRIPTION
## Summary

- Adds `StarterBase::$enabled_image_sizes` (`string[]|null`, default `null`) — opt-in allowlist of image sub-size slugs generated on upload
- Hooked to `intermediate_image_sizes_advanced`, which runs inside `wp_create_image_subsizes()` for every upload path (media library, REST, WP-CLI sideload)
- When `null` (default): no hook registered, WP behaviour unchanged
- When set: only listed slugs survive; everything else (including WP 5.3+ `1536x1536` and `2048x2048`) is dropped for new uploads

## Motivation

Projects typically use 3–4 image sizes in Twig templates, but WordPress generates 6+ by default. The two 5.3+ sizes (`1536x1536`, `2048x2048`) add significant disk usage and upload time without being referenced by any template. This property gives projects surgical control with zero overhead when not used.

## Example

```php
// In Base::__construct(), before parent::__construct():
$this->enabled_image_sizes = ['thumbnail', 'medium', 'large'];
// → 1536x1536 and 2048x2048 are no longer generated on new uploads
```

## Scope

- New uploads only — existing images are unchanged. `wp media regenerate` + the same `$enabled_image_sizes` setting applies the allowlist to existing uploads.
- Does not touch `big_image_size_threshold` (max dimension cap) — orthogonal concern.
- Does not auto-disable any size — opt-in only, default is WP default.

## Test plan

- [ ] `FilterImageSizesTest` — 7 unit tests: passthrough when null, allowlist filtering, empty allowlist, unknown slug ignored, settings preserved unmodified, meta/id unused
- [ ] `RegisterMediaHooksTest` — 2 new tests: hook registered when allowlist set, hook skipped when null
- [ ] Full suite: `composer test` → 790 tests, 0 failures
- [ ] `composer phpstan` → no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)