### PR TITLE
ci: enforce Conventional Commits on PR titles (commitlint)

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,37 @@
+name: Lint PR Title
+
+# Enforces Conventional Commits on the PR title. PRs are squash-merged with the
+# PR title as the commit subject, so the title is what the release scheme
+# (RELEASING.md → bump mapping) actually reads — linting it keeps `feat`/`fix`/
+# `feat!` reliable. Same-repo PRs only, so plain `pull_request` (no secrets) is
+# enough; no untrusted code is checked out.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  conventional-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Allowed types — mirror RELEASING.md's bump table.
+          types: |
+            feat
+            fix
+            docs
+            chore
+            refactor
+            perf
+            test
+            ci
+            build
+            revert
+          # Scope is optional (both `feat(media):` and `feat:` are accepted).
+          requireScope: false


### PR DESCRIPTION
## What

Adds `.github/workflows/commitlint.yml` — lints the **PR title** against Conventional Commits ([amannn/action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request)) on every PR open/edit/sync.

## Why

The release scheme (RELEASING.md bump table) reads commit types to decide MAJOR/MINOR/PATCH, but nothing enforced the convention — a `update stuff` title could slip through and break the mapping. Since PRs are **squash-merged with the PR title as the commit subject**, linting the title is exactly the right enforcement point.

## Scope (deliberately minimal — the alternative to release-please)

- **Keeps** the existing `release-stamp.yml` + `release.yml` pipeline untouched.
- Allowed types mirror RELEASING.md: `feat fix docs chore refactor perf test ci build revert`.
- Scope optional (`feat(media):` and `feat:` both pass).
- Same-repo PRs only → plain `pull_request` (no `pull_request_target`, no secrets, no untrusted checkout).

## Follow-up note

RELEASING.md lists a `deprecated:` type → MINOR, which isn't in the allowed set here (and isn't a standard Conventional Commit type). Recommend using `feat:` for deprecations (with a `### Deprecated` CHANGELOG note) and dropping `deprecated:` from RELEASING.md, or adding it to both — flagging for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
