### PR TITLE
feat: $minify_style flag for non-minified builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **`StarterBase::$minify_style` flag (bool, default `true`)** — use the minified main stylesheet (`style.min.css`) in production. Set `false` for a build that emits only `style.css` (no `.min`), so the native `assets()` enqueues `style.css` and the theme needn't override `assets()` just for the filename. `WP_DEBUG` still forces unminified `style.css` regardless.
+
 ## [1.12.0] - 2026-06-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ For an admin label without a dedicated setup hook (e.g. an options-page `page_ti
 | `$menus` | array | `[]` | Registered navigation menus |
 | `$font_stylesheets` | array | `[]` | CSS files to enqueue on the frontend. Also forwarded into the Gutenberg editor canvas (both iframed and non-iframed) via `block_editor_settings_all`, so custom `@font-face` declarations render in the editor without falling back to system fonts. Relative paths are resolved under `static/` and cache-busted with `filemtime`; absolute URLs pass through |
 | `$theme_script_strategy` | string | `'module'` | How `static/dist/js/script.js` is enqueued: `'module'` → `wp_enqueue_script_module()` (Vite/ESM); `'defer'` → classic deferred `wp_enqueue_script()` for a webpack IIFE bundle. Override `enqueueThemeScript()` for finer control |
+| `$minify_style` | bool | `true` | Use `style.min.css` in production. `false` = always `style.css` (build emits no `.min`) |
 | `$preload_fonts` | array | `[]` | Font files to preload |
 | `$search_post_types` | array | `['post']` | Post types for search |
 | `$article_post_types` | array | `['post']` | Post types treated as articles |

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -47,6 +47,15 @@ class StarterBase extends Site {
 	/** @var array<string, string> Font stylesheets to enqueue (handle-suffix => relative path from static/). */
 	protected array $font_stylesheets = [];
 
+	/**
+	 * Use the minified main stylesheet (`static/dist/css/style.min.css`) in
+	 * production. Set false for a build that emits only `style.css` (no `.min`),
+	 * so `assets()` always enqueues `style.css` and the theme needn't override
+	 * `assets()` just for the filename. Under `WP_DEBUG` the unminified `style.css`
+	 * is used regardless.
+	 */
+	protected bool $minify_style = true;
+
 	/** @var string[] Font files to preload (relative paths from static/). */
 	protected array $preload_fonts = [];
 
@@ -1385,11 +1394,8 @@ class StarterBase extends Site {
 		}
 
 		if ( ! is_admin() ) {
-			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-				wp_enqueue_style( $this->theme_name, get_template_directory_uri() . '/static/dist/css/style.css', [], $this->assetVersion( get_template_directory() . '/static/dist/css/style.css' ) );
-			} else {
-				wp_enqueue_style( $this->theme_name, get_template_directory_uri() . '/static/dist/css/style.min.css', [], $this->assetVersion( get_template_directory() . '/static/dist/css/style.min.css' ) );
-			}
+			$style_file = ( $this->minify_style && ! ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ) ? 'style.min.css' : 'style.css';
+			wp_enqueue_style( $this->theme_name, get_template_directory_uri() . '/static/dist/css/' . $style_file, [], $this->assetVersion( get_template_directory() . '/static/dist/css/' . $style_file ) );
 			$this->enqueueThemeScript();
 
 			wp_dequeue_script( 'jquery' );

--- a/tests/Unit/StarterBase/AssetsTest.php
+++ b/tests/Unit/StarterBase/AssetsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\StarterBase;
+
+use Brain\Monkey\Functions;
+use Tests\Unit\StarterBaseTestCase;
+
+/**
+ * Verifies that assets() enqueues the correct stylesheet based on $minify_style
+ * and the WP_DEBUG constant.
+ */
+class AssetsTest extends StarterBaseTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		// Stubs shared by all tests in this suite.
+		Functions\when( 'is_admin' )->justReturn( false );
+		Functions\when( 'get_template_directory_uri' )->justReturn( 'https://example.test/wp-content/themes/test' );
+		Functions\when( 'get_template_directory' )->justReturn( '/nonexistent/path/that/will/not/exist' );
+		Functions\when( 'wp_normalize_path' )->returnArg();
+		Functions\when( 'wp_dequeue_script' )->justReturn( true );
+		Functions\when( 'wp_enqueue_script' )->justReturn( true );
+		Functions\when( 'wp_enqueue_script_module' )->justReturn( true );
+	}
+
+	/**
+	 * Default: $minify_style = true, WP_DEBUG not defined → style.min.css.
+	 */
+	public function test_default_enqueues_minified_stylesheet_in_production(): void {
+		$enqueued_src = null;
+		Functions\when( 'wp_enqueue_style' )->alias(
+			function ( $handle, $src ) use ( &$enqueued_src ) {
+				// Capture only the main theme style (no suffix on handle).
+				if ( $handle === 'test_theme' ) {
+					$enqueued_src = $src;
+				}
+			}
+		);
+
+		$base = $this->createStarterBase( [
+			'theme_name'     => 'test_theme',
+			'font_stylesheets' => [],
+		] );
+		$base->assets();
+
+		$this->assertStringContainsString(
+			'style.min.css',
+			(string) $enqueued_src,
+			'With $minify_style = true (default) and no WP_DEBUG, assets() must enqueue style.min.css'
+		);
+	}
+
+	/**
+	 * $minify_style = false, WP_DEBUG not defined → always style.css.
+	 */
+	public function test_minify_style_false_enqueues_unminified_stylesheet(): void {
+		$enqueued_src = null;
+		Functions\when( 'wp_enqueue_style' )->alias(
+			function ( $handle, $src ) use ( &$enqueued_src ) {
+				if ( $handle === 'test_theme' ) {
+					$enqueued_src = $src;
+				}
+			}
+		);
+
+		$base = $this->createStarterBase( [
+			'theme_name'       => 'test_theme',
+			'font_stylesheets' => [],
+			'minify_style'     => false,
+		] );
+		$base->assets();
+
+		$this->assertStringContainsString(
+			'style.css',
+			(string) $enqueued_src,
+			'With $minify_style = false, assets() must enqueue style.css regardless of WP_DEBUG'
+		);
+		$this->assertStringNotContainsString(
+			'style.min.css',
+			(string) $enqueued_src,
+			'With $minify_style = false, assets() must NOT enqueue style.min.css'
+		);
+	}
+}


### PR DESCRIPTION
## What

Adds a `$minify_style` boolean property (default `true`) to `StarterBase`. When `false`, `assets()` always enqueues `style.css` instead of `style.min.css` in production.

## Why

Projects like `atelier99` whose build pipeline emits only `style.css` (no `.min`) previously had to override `assets()` entirely just to change one filename. With this flag they can set `$minify_style = false` and use the native `assets()` as-is.

## Behaviour

- Default `true` → `style.min.css` in production, `style.css` under `WP_DEBUG` (no change from today).
- `false` → always `style.css`, `WP_DEBUG` still forces `style.css` regardless.

## Tests

Added `tests/Unit/StarterBase/AssetsTest.php` with two cases: default enqueues `.min.css`, and `$minify_style = false` enqueues `style.css` (not `.min.css`). All 789 tests pass, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)