### PR TITLE
feat(helpers): formatTerms() returns term count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **`Helpers::formatTerms()` now returns `count`** — each formatted term carries `'count' => (int) $term->count` (the term's object count) alongside `id` / `title` / `url` / `children`. Additive and backward-compatible: existing consumers reading the previous keys are unaffected. Lets callers that render term lists with a count (e.g. category-filter chips "SEA (18)") use the helper directly instead of querying `Timber::get_terms()` and reading `->count` by hand.
+
 ## [1.12.0] - 2026-06-20
 
 ### Added

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -250,9 +250,10 @@ class Helpers {
 	 * string) are given an empty `url`.
 	 *
 	 * @param iterable $terms List of Timber\Term objects.
-	 * @return array<int, array{id: int, title: string, url: string, children: array}>
-	 *               Indexed list of term data arrays, each optionally
-	 *               containing nested `children` in the same format.
+	 * @return array<int, array{id: int, title: string, url: string, count: int, children: array}>
+	 *               Indexed list of term data arrays. `count` is the term's
+	 *               object count (from `WP_Term->count`). Each entry may also
+	 *               contain nested `children` in the same format.
 	 */
 	public static function formatTerms( $terms ) {
 

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -275,6 +275,7 @@ class Helpers {
 						'id' => $term->ID,
 						'title' => $term->title,
 						'url' => $link,
+						'count' => (int) $term->count,
 						'children' => Helpers::formatTerms( $children ),
 					];
 				}

--- a/tests/Unit/Helpers/FormatTermsTest.php
+++ b/tests/Unit/Helpers/FormatTermsTest.php
@@ -42,6 +42,7 @@ class FormatTermsTest extends HelpersTestCase {
 		$term->ID = 5;
 		$term->title = 'Test Category';
 		$term->taxonomy = 'category';
+		$term->count = 12;
 		$term->children = false;
 
 		$result = Helpers::formatTerms( [ $term ] );
@@ -50,7 +51,25 @@ class FormatTermsTest extends HelpersTestCase {
 		$this->assertSame( 5, $result[0]['id'] );
 		$this->assertSame( 'Test Category', $result[0]['title'] );
 		$this->assertSame( '/category/test', $result[0]['url'] );
+		$this->assertSame( 12, $result[0]['count'] );
 		$this->assertSame( [], $result[0]['children'] );
+	}
+
+	public function test_casts_count_to_int(): void {
+		// WP_Term->count can arrive as a numeric string; the helper must expose
+		// it as an int. The same `(int) $term->count` line formats parent and
+		// recursive child terms, so this covers both code paths.
+		$term = $this->createStub( \Timber\Term::class );
+		$term->method( 'link' )->willReturn( '/category/test' );
+		$term->ID = 5;
+		$term->title = 'Test Category';
+		$term->taxonomy = 'category';
+		$term->count = '7';
+		$term->children = false;
+
+		$result = Helpers::formatTerms( [ $term ] );
+
+		$this->assertSame( 7, $result[0]['count'] );
 	}
 
 	public function test_clears_url_with_taxonomy_query_param(): void {


### PR DESCRIPTION
## What
`Helpers::formatTerms()` now includes `count` per term:

```diff
 $items[] = [
   'id' => $term->ID,
   'title' => $term->title,
   'url' => $link,
+  'count' => (int) $term->count,
   'children' => Helpers::formatTerms( $children ),
 ];
```

`$term->count` is the native `WP_Term` object-count exposed by `Timber\Term` — no extra query, no manual counting.

## Why
From proficio-de's blog category-filter work. The chips render a count (`SEA (18)`); `formatTerms()` previously returned `{id, title, url, children}` **without** count, so the downstream had to query `Timber::get_terms()` and read `->count` by hand. With this, term-list renderers can use the helper directly.

## Safety
**Additive + backward-compatible** — existing consumers read the prior keys unchanged; the extra `count` key is simply ignored where unused.

## Follow-ups (separate, not in this PR)
- Downstream `proficio_category_filter_items()` in proficio-de can switch to `Helpers::formatTerms(Timber::get_terms('category'))` once this ships and the dep is bumped.
- Doc: `wordpress/timber-kit-helpers.md` (tailwind-base) output-shape note for `formatTerms` to mention `count`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)