### PR TITLE
fix: default $admin_resizable_sidebar to false (opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
+- **`StarterBase::$admin_resizable_sidebar` now defaults to `false`** (was `true`) — the resizable Gutenberg editor sidebar is now **opt-in**. Its JS/CSS ship inside the package and are served from `vendor/` via `packageAssetUrl()`, but the standard theme `.htaccess` blanket-denies `vendor/` (`RewriteRule ^vendor/(.*)?$ / [F,L]`). The old default therefore made **every** consumer's block editor request those assets and receive **403** — the README's "works out of the box" claim was wrong in the presence of the skeleton `.htaccess`. ⚠️ **Behavior change**: themes that want the sidebar must now set `$admin_resizable_sidebar = true` **and** add an allow rule for static assets under `vendor/` to the theme `.htaccess` (snippet in README § Resizable sidebar). `wordpress-base`'s `starter_theme` ships that allow rule so scaffolded projects only need the flag. Surfaced from downstream project `pm-a`.
+
 - **HSTS now always carries `; preload`** when `$security_headers` is on and the request is over TLS — the header is `max-age=31536000; includeSubDomains; preload` (previously without `preload`). This package targets an HTTPS-only fleet, so `preload` is the house default rather than an opt-in flag. ⚠️ `preload` is a hard-to-reverse commitment: it advertises the domain **and every subdomain** for browsers' built-in HSTS preload list (separate submission at [hstspreload.org](https://hstspreload.org)). On the rare project that serves — or might serve — a non-HTTPS subdomain, override the value via `$security_headers_config['Strict-Transport-Security']` (the existing per-header escape hatch).
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -420,7 +420,18 @@ When any override is active, an admin notice on WPForms admin screens lists whic
 | `$gutenberg_responsive_embeds` | bool | `true` | Responsive video embeds |
 | `$gutenberg_editor_styles` | bool | `true` | Load editor stylesheet |
 | `$gutenberg_disable_core_patterns` | bool | `true` | Remove core block patterns |
-| `$admin_resizable_sidebar` | bool | `true` | Toggle the resizable Gutenberg editor sidebar. The JS/CSS ship inside the package, so it works out of the box; set `false` to disable |
+| `$admin_resizable_sidebar` | bool | `false` | Opt-in resizable Gutenberg editor sidebar. Default **off** — the JS/CSS ship inside the package and are served from its `vendor/` dir, which the standard theme `.htaccess` denies, so enabling it also requires an `.htaccess` allow rule (see below). Set `true` to enable |
+
+> **Enabling `$admin_resizable_sidebar` — `.htaccess` requirement.** The sidebar's JS/CSS are served from the package's `vendor/` directory (`vendor/parisek/timber-kit/assets/…`) via `packageAssetUrl()`. The standard theme `.htaccess` blanket-denies `vendor/` for security (`RewriteRule ^vendor/(.*)?$ / [F,L]`), so the browser would get **403** for those assets. When you set `$admin_resizable_sidebar = true`, also allow static assets under `vendor/` in the project's theme `.htaccess`, **before** the blanket deny:
+>
+> ```apache
+> # Allow static assets shipped inside vendor (e.g. parisek/timber-kit admin
+> # CSS/JS enqueued via packageAssetUrl()) — must precede the blanket deny.
+> RewriteRule ^vendor/.+\.(css|js|mjs|map|woff2?|ttf|otf|eot|svg|png|jpe?g|gif|webp|avif)$ - [L]
+> RewriteRule ^vendor/(.*)?$ / [F,L]
+> ```
+>
+> PHP / source / config under `vendor/` stay forbidden. Projects scaffolded from `wordpress-base` (current `starter_theme`) already ship this allow rule.
 
 ### Options Pages
 

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -246,11 +246,16 @@ class StarterBase extends Site {
 	];
 
 	/**
-	 * Enqueue the resizable Gutenberg editor sidebar (admin/js|css/
-	 * gutenberg-resizable-sidebar.*). Set false on themes that don't ship those
-	 * files, to skip the enqueue (and the asset-version lookups on missing files).
+	 * Resizable Gutenberg editor sidebar (assets/js|css/gutenberg-resizable-sidebar.*).
+	 *
+	 * Opt-in — default OFF. The JS/CSS ship inside the package and are served from
+	 * its `vendor/` dir via packageAssetUrl(). The standard theme `.htaccess`
+	 * blanket-denies `vendor/` (`RewriteRule ^vendor/(.*)?$ / [F,L]`), so enabling
+	 * this WITHOUT first allowing static assets under `vendor/` in the project's
+	 * theme `.htaccess` makes the editor request those files and get a 403. Set
+	 * `true` to enable, and add the allow rule from README § Gutenberg editor.
 	 */
-	protected bool $admin_resizable_sidebar = true;
+	protected bool $admin_resizable_sidebar = false;
 
 	/**
 	 * Auto-populate $context['breadcrumb'] with a Parisek\TimberKit\Breadcrumb on


### PR DESCRIPTION
## From-Project

Surfaced in downstream project **`pm-a`**: the block editor logged **403** for `vendor/parisek/timber-kit/assets/{css,js}/gutenberg-resizable-sidebar.*`.

## Why

`$admin_resizable_sidebar` defaulted to `true`. Its JS/CSS ship inside the package and are enqueued via `packageAssetUrl()`, which resolves to a URL under the theme's `vendor/` dir. The standard theme `.htaccess` (from `wordpress-base`/`starter_theme`) blanket-denies `vendor/` for security:

```apache
RewriteRule ^vendor/(.*)?$ / [F,L]
```

So the on-by-default sidebar made **every** consumer's editor request those assets and receive `403` (`[F]`). The README even claimed it "works out of the box" — wrong in the presence of the skeleton `.htaccess`. (The styleguide package avoids this because it serves assets through its `/styleguide` router, not a direct `vendor/` URL — timber-kit uses a direct URL, so it's the first to hit the deny.)

## What

- **`StarterBase::$admin_resizable_sidebar` default `true` → `false`** — the sidebar is now opt-in (the "checkbox" pattern, like the other boolean flags). Projects that have been silently 403-ing lose nothing; projects that want it enable it explicitly.
- **Docstring rewritten** to explain the `vendor/` + `.htaccess` interaction and point at the README.
- **README** property row updated (`false` default) + a `>` note with the exact `.htaccess` allow rule required when enabling.
- **CHANGELOG** `[Unreleased] → Changed` entry flagging the behavior change.

### Enabling after this change

Set `$admin_resizable_sidebar = true` in the theme `Base`, **and** add an allow rule for static assets under `vendor/` to the theme `.htaccess`, before the blanket deny:

```apache
RewriteRule ^vendor/.+\.(css|js|mjs|map|woff2?|ttf|otf|eot|svg|png|jpe?g|gif|webp|avif)$ - [L]
RewriteRule ^vendor/(.*)?$ / [F,L]
```

Companion PRs: `wordpress-base` `starter_theme/.htaccess` ships that allow rule; `tailwind-base` rule doc `wordpress/timber-kit.md` documents the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)