### PR TITLE
feat: add opt-in block-passthrough, privacy-policy context, and post/taxonomy label helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **`StarterBase::$restrict_allowed_blocks` flag (bool, default `true`)** — set `false` to skip wiring the `allowed_block_types_all` filter entirely, so the editor keeps all block types. For sites whose existing content pre-dates the `$allowed_core_blocks` allowlist, where restricting after the fact would flag already published blocks as invalid. Replaces the no-op `allowed_block_types_all()` override three downstream projects carry today. Default `true` preserves current behavior.
+
+- **`StarterBase::$render_block_passthrough_blocks` (string[], default `[]`)** — block names `render_block()` must return unchanged, bypassing the core-block wrapper. Accepts exact names (`'wpforms/form-selector'`), a namespace wildcard (`'wpforms/*'`), or `'*'` to disable the wrapper entirely. Passthrough wins over the forced contact-form wrapping. Escape hatch for third-party form/gallery blocks the wrapper breaks (WPForms, Envira, CF7 variants) and for legacy-content sites — both previously required overriding the whole `render_block()` method downstream.
+
+- **`StarterBase::$context_privacy_policy` flag (bool, default `false`) + `$privacy_policy_context_key` (string, default `'ccnstL'`)** — opt-in population of `get_privacy_policy_url()` into the Timber context. Every audited downstream project sets this key manually in its `timber_context()` override (the non-semantic default key keeps cookie-consent markup invisible to ad-block heuristics); enabling the flag replaces that boilerplate. Off by default per the library's flag doctrine — the key typically drives a cookie-consent partial, which must not start rendering on projects that deliberately ship without one.
+
+- **`Helpers::relabelPostType( string $post_type, array $labels )`** — merge custom labels onto a registered post type (the "rename built-in `post` to a domain term" boilerplate found copy-pasted in 12 downstream article controllers, 8 of them with untranslated starter values). Applies immediately when `init` already fired, otherwise defers to `init` priority 999; keeps the top-level `label` in sync with `labels.name`.
+
+- **`Helpers::hideTaxonomyMetaFields( string $taxonomy = 'category', array $fields = ['description', 'slug', 'parent'], bool $hide_columns = true )`** — hide taxonomy meta fields on add/edit screens (CSS over `.term-{field}-wrap`) and drop the matching list-table columns. Replaces the recurring `manage_edit-{tax}_columns` + `{tax}_edit_form`/`{tax}_add_form` hook trio duplicated across 8–10 downstream projects.
+
 ## [1.14.1] - 2026-06-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ composer require parisek/timber-kit
 
 ### StarterBase
 
-Extends `Timber\Site` with 25 configurable properties. Handles theme setup, Twig extensions, security hardening, Gutenberg blocks, media processing, and admin cleanup — all opt-in via boolean flags.
+Extends `Timber\Site` with dozens of configurable properties. Handles theme setup, Twig extensions, security hardening, Gutenberg blocks, media processing, and admin cleanup — all opt-in via boolean flags.
 
 ### Helpers
 
@@ -30,6 +30,8 @@ Static methods for formatting ACF data into clean arrays for Twig templates:
 - `readTime()` — estimated reading time in minutes (Unicode-aware word counting, image budget, WPML-aware per-language WPM)
 - `getLanguage()` — normalized (lowercased, trimmed) language code for a post or the current request, with WPML per-post / site-wide / locale fallbacks. WPML region/script subtags are preserved (e.g. `pt-br`, `zh-hans`); only the locale fallback is strictly 2 letters
 - `formatImageFrom( ?array $raw ): ?array` — pure-core formatter extracted from `formatImage()`'s associative-array branch. No WordPress dependencies, safe for unit / property tests; missing keys resolve to `null` silently, `id` / `width` / `height` are cast to `int|null`, and the WordPress SVG-1px workaround is applied uniformly
+- `relabelPostType( string $post_type, array $labels )` — merge custom labels onto a registered post type (rename the built-in `post` to Články/News/…). Applies immediately after `init`, otherwise defers to `init` priority 999; keeps the top-level `label` in sync with `labels.name`
+- `hideTaxonomyMetaFields( string $taxonomy = 'category', array $fields = ['description', 'slug', 'parent'], bool $hide_columns = true )` — hide taxonomy form fields (CSS on add/edit screens) and drop the matching list-table columns, for taxonomies where editors should only pick a name
 
 ### Resizer
 
@@ -306,6 +308,8 @@ For an admin label without a dedicated setup hook (e.g. an options-page `page_ti
 | `$article_post_types` | array | `['post']` | Post types treated as articles |
 | `$block_category` | array | `['slug' => 'custom', 'title' => 'Custom']` | Custom block category |
 | `$favicon_path` | string | `'images/touch/favicon.svg'` | Favicon path |
+| `$context_privacy_policy` | bool | `false` | Opt-in: populate the site's privacy-policy URL (`get_privacy_policy_url()`) into the Timber context under `$privacy_policy_context_key`. Off by default — the key typically drives a cookie-consent partial, which must not appear on projects that ship without one |
+| `$privacy_policy_context_key` | string | `'ccnstL'` | Context key for the privacy-policy URL. The default is deliberately non-semantic so cookie-consent markup keyed off it stays invisible to ad-block heuristics |
 
 ### Security & Cleanup
 
@@ -420,6 +424,8 @@ When any override is active, an admin notice on WPForms admin screens lists whic
 | `$gutenberg_responsive_embeds` | bool | `true` | Responsive video embeds |
 | `$gutenberg_editor_styles` | bool | `true` | Load editor stylesheet |
 | `$gutenberg_disable_core_patterns` | bool | `true` | Remove core block patterns |
+| `$restrict_allowed_blocks` | bool | `true` | Restrict the editor to `$allowed_core_blocks` + ACF blocks via `allowed_block_types_all`. Set `false` on sites whose existing content pre-dates the allowlist — the filter is then not wired at all, so no no-op `allowed_block_types_all()` override is needed |
+| `$render_block_passthrough_blocks` | string[] | `[]` | Block names `render_block()` returns unchanged, bypassing the core-block wrapper. Exact names (`'wpforms/form-selector'`), namespace wildcards (`'wpforms/*'`), or `'*'` to disable wrapping entirely. Escape hatch for third-party form/gallery blocks the wrapper would break |
 | `$admin_resizable_sidebar` | bool | `false` | Opt-in resizable Gutenberg editor sidebar. Default **off** — the JS/CSS ship inside the package and are served from its `vendor/` dir, which the standard theme `.htaccess` denies, so enabling it also requires an `.htaccess` allow rule (see below). Set `true` to enable |
 
 > **Enabling `$admin_resizable_sidebar` — `.htaccess` requirement.** The sidebar's JS/CSS are served from the package's `vendor/` directory (`vendor/parisek/timber-kit/assets/…`) via `packageAssetUrl()`. The standard theme `.htaccess` blanket-denies `vendor/` for security (`RewriteRule ^vendor/(.*)?$ / [F,L]`), so the browser would get **403** for those assets. When you set `$admin_resizable_sidebar = true`, also allow static assets under `vendor/` in the project's theme `.htaccess`, **before** the blanket deny:

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1662,4 +1662,73 @@ class Helpers {
 
 		return strtolower( substr( $locale, 0, 2 ) );
 	}
+
+	/**
+	 * Merge custom labels onto a registered post type.
+	 *
+	 * Replaces the per-project boilerplate that renames the built-in `post`
+	 * type to a domain term (Články, Novinky, Reference, …). Safe to call
+	 * from a template controller at any point: applies immediately when
+	 * `init` already fired, otherwise defers to `init` at a late priority so
+	 * default-priority post type registrations run first.
+	 *
+	 * @param string $post_type Post type name (e.g. `post`).
+	 * @param array<string, string> $labels Label overrides, keyed by WP_Post_Type_Labels property (`name`, `singular_name`, `add_new`, …). Keys not passed keep their registered value.
+	 * @return void
+	 */
+	public static function relabelPostType( string $post_type, array $labels ): void {
+		$apply = static function () use ( $post_type, $labels ): void {
+			$object = get_post_type_object( $post_type );
+			if ( null === $object ) {
+				return;
+			}
+			foreach ( $labels as $key => $value ) {
+				$object->labels->{$key} = $value;
+			}
+			// The top-level label mirrors labels.name everywhere WP shows it
+			// (admin menu, admin bar), so keep the two in sync.
+			if ( isset( $labels['name'] ) ) {
+				$object->label = $labels['name'];
+			}
+		};
+
+		if ( did_action( 'init' ) ) {
+			$apply();
+		} else {
+			add_action( 'init', $apply, 999 );
+		}
+	}
+
+	/**
+	 * Hide meta fields on a taxonomy's add/edit screens and list table.
+	 *
+	 * Covers the recurring "editors should only pick a name" admin cleanup:
+	 * hides the given fields' form rows via CSS on both the add and edit
+	 * screens, and (by default) drops the matching list table columns.
+	 *
+	 * @param string $taxonomy Taxonomy name (default `category`).
+	 * @param string[] $fields Field slugs to hide — matched against `.term-{field}-wrap` form rows and same-named list columns. Default description, slug, and parent.
+	 * @param bool $hide_columns Whether to also drop matching list table columns.
+	 * @return void
+	 */
+	public static function hideTaxonomyMetaFields( string $taxonomy = 'category', array $fields = [ 'description', 'slug', 'parent' ], bool $hide_columns = true ): void {
+		if ( $hide_columns ) {
+			add_filter( "manage_edit-{$taxonomy}_columns", static function ( array $columns ) use ( $fields ): array {
+				foreach ( $fields as $field ) {
+					unset( $columns[ $field ] );
+				}
+				return $columns;
+			} );
+		}
+
+		$print_css = static function () use ( $fields ): void {
+			$selectors = array_map(
+				static fn( string $field ): string => ".term-{$field}-wrap",
+				$fields
+			);
+			echo '<style>' . implode( ', ', $selectors ) . ' { display: none; }</style>';
+		};
+		add_action( "{$taxonomy}_edit_form", $print_css );
+		add_action( "{$taxonomy}_add_form", $print_css );
+	}
 }

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -59,6 +59,19 @@ class StarterBase extends Site {
 	/** @var array{slug: string, title: string} Custom Gutenberg block category definition. */
 	protected array $block_category = [ 'slug' => 'custom', 'title' => 'Custom' ];
 
+	/**
+	 * Whether to restrict the editor to $allowed_core_blocks + ACF blocks.
+	 *
+	 * Set false on sites with pre-existing content authored before the theme
+	 * adopted the allowlist — restricting after the fact would flag already
+	 * published blocks as invalid in the editor. Disabling skips wiring the
+	 * `allowed_block_types_all` filter entirely, so a project no longer needs
+	 * a no-op `allowed_block_types_all()` override for this.
+	 *
+	 * @var bool
+	 */
+	protected bool $restrict_allowed_blocks = true;
+
 	/** @var string[] Core Gutenberg blocks allowed in the editor. ACF blocks are always allowed. */
 	protected array $allowed_core_blocks = [
 		'core/paragraph',
@@ -86,6 +99,40 @@ class StarterBase extends Site {
 
 	/** @var string Twig template used to wrap core Gutenberg blocks on non-article pages. */
 	protected string $block_wrapper_template = '@component/content/content.twig';
+
+	/**
+	 * Block names render_block() must return unchanged, bypassing the wrapper.
+	 *
+	 * Accepts exact names ('wpforms/form-selector'), a namespace wildcard
+	 * ('wpforms/*'), or '*' to disable the wrapper entirely. Escape hatch for
+	 * third-party form/gallery blocks the wrapper would break, and for sites
+	 * whose existing content pre-dates the wrapper — previously both required
+	 * a full render_block() override.
+	 *
+	 * @var string[]
+	 */
+	protected array $render_block_passthrough_blocks = [];
+
+	/**
+	 * Populate the site's privacy-policy URL into the Timber context.
+	 *
+	 * Opt-in: enabling adds a context key that templates (typically a
+	 * cookie-consent partial) may render, so it must not appear on projects
+	 * that deliberately ship without it.
+	 *
+	 * @var bool
+	 */
+	protected bool $context_privacy_policy = false;
+
+	/**
+	 * Context key for the privacy-policy URL when $context_privacy_policy is on.
+	 *
+	 * The default is deliberately non-semantic so cookie-consent markup keyed
+	 * off it stays invisible to ad-block heuristics.
+	 *
+	 * @var string
+	 */
+	protected string $privacy_policy_context_key = 'ccnstL';
 
 	/** @var string Nav menu location for breadcrumb menu-trail strategy */
 	protected string $breadcrumb_menu_name = 'main-menu';
@@ -494,7 +541,9 @@ class StarterBase extends Site {
 	 * @return void
 	 */
 	private function registerBlockHooks(): void {
-		add_filter( 'allowed_block_types_all', array( $this, 'allowed_block_types_all' ), 10, 2 );
+		if ( $this->restrict_allowed_blocks ) {
+			add_filter( 'allowed_block_types_all', array( $this, 'allowed_block_types_all' ), 10, 2 );
+		}
 		add_action( 'init', array( $this, 'gutenberg_blocks' ) );
 		add_action( 'acf/init', array( $this, 'acf_options_page' ) );
 		add_action( 'acf/save_post', array( $this, 'clear_cache_on_options_save' ), 20 );
@@ -863,6 +912,10 @@ class StarterBase extends Site {
 			$context['langcode'] = get_bloginfo( 'language' );
 		}
 		$context['search_query'] = get_search_query();
+
+		if ( $this->context_privacy_policy ) {
+			$context[ $this->privacy_policy_context_key ] = get_privacy_policy_url();
+		}
 
 		// Auto-populate $context['breadcrumb'] — unless the project still ships
 		// a global \Breadcrumb class (legacy convention from wordpress-base
@@ -1696,6 +1749,12 @@ class StarterBase extends Site {
 			return $block_content;
 		}
 
+		// Project-declared passthrough wins over everything below, including
+		// the forced contact-form wrapping.
+		if ( $this->isPassthroughBlock( $block['blockName'] ?? null ) ) {
+			return $block_content;
+		}
+
 		// Apply filter only on core gutenberg blocks
 		// Custom blocks will get filter via Twig
 		if ( strpos( (string) $block['blockName'], 'core/' ) === FALSE && ! in_array( $block['blockName'], [ 'contact-form-7/contact-form-selector' ] ) ) {
@@ -1727,6 +1786,26 @@ class StarterBase extends Site {
 			];
 			return Timber::compile( $this->block_wrapper_template, $context );
 		}
+	}
+
+	/**
+	 * Whether a block name matches $render_block_passthrough_blocks.
+	 *
+	 * Supports exact names, a trailing `/*` namespace wildcard, and `*`.
+	 *
+	 * @param string|null $block_name The block name, or null for freeform blocks.
+	 * @return bool True when render_block() must leave the block unchanged.
+	 */
+	protected function isPassthroughBlock( ?string $block_name ): bool {
+		foreach ( $this->render_block_passthrough_blocks as $pattern ) {
+			if ( '*' === $pattern || $pattern === $block_name ) {
+				return true;
+			}
+			if ( str_ends_with( $pattern, '/*' ) && null !== $block_name && str_starts_with( $block_name, substr( $pattern, 0, -1 ) ) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/tests/Unit/Helpers/HideTaxonomyMetaFieldsTest.php
+++ b/tests/Unit/Helpers/HideTaxonomyMetaFieldsTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Helpers;
+
+use Brain\Monkey\Functions;
+use Parisek\TimberKit\Helpers;
+use Tests\Unit\HelpersTestCase;
+
+/**
+ * Verifies Helpers::hideTaxonomyMetaFields() — hiding the description/slug/
+ * parent fields on taxonomy add/edit screens and dropping the matching list
+ * table columns (previously copy-pasted hook trios in project controllers).
+ */
+class HideTaxonomyMetaFieldsTest extends HelpersTestCase {
+
+	/** @var array<int, array{hook: string, callback: callable}> */
+	private array $filters = [];
+
+	/** @var array<int, array{hook: string, callback: callable}> */
+	private array $actions = [];
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->filters = [];
+		$this->actions = [];
+		Functions\when( 'add_filter' )->alias( function ( $hook, $callback ) {
+			$this->filters[] = [ 'hook' => $hook, 'callback' => $callback ];
+		} );
+		Functions\when( 'add_action' )->alias( function ( $hook, $callback ) {
+			$this->actions[] = [ 'hook' => $hook, 'callback' => $callback ];
+		} );
+	}
+
+	private function hooksFor( array $registry, string $hook ): array {
+		return array_values( array_filter( $registry, fn( $r ) => $r['hook'] === $hook ) );
+	}
+
+	public function test_registers_column_filter_and_form_css_hooks_for_default_taxonomy(): void {
+		Helpers::hideTaxonomyMetaFields();
+
+		$this->assertCount( 1, $this->hooksFor( $this->filters, 'manage_edit-category_columns' ) );
+		$this->assertCount( 1, $this->hooksFor( $this->actions, 'category_edit_form' ) );
+		$this->assertCount( 1, $this->hooksFor( $this->actions, 'category_add_form' ) );
+	}
+
+	public function test_column_filter_drops_description_and_slug_but_keeps_the_rest(): void {
+		Helpers::hideTaxonomyMetaFields();
+
+		$callback = $this->hooksFor( $this->filters, 'manage_edit-category_columns' )[0]['callback'];
+		$columns = $callback( [
+			'cb' => '<input type="checkbox" />',
+			'name' => 'Name',
+			'description' => 'Description',
+			'slug' => 'Slug',
+			'posts' => 'Count',
+		] );
+
+		$this->assertSame( [ 'cb', 'name', 'posts' ], array_keys( $columns ) );
+	}
+
+	public function test_form_hook_emits_css_hiding_the_field_wrappers(): void {
+		Helpers::hideTaxonomyMetaFields();
+
+		$callback = $this->hooksFor( $this->actions, 'category_edit_form' )[0]['callback'];
+		ob_start();
+		$callback();
+		$css = ob_get_clean();
+
+		$this->assertStringContainsString( '.term-description-wrap', $css );
+		$this->assertStringContainsString( '.term-slug-wrap', $css );
+		$this->assertStringContainsString( '.term-parent-wrap', $css );
+		$this->assertStringContainsString( 'display: none', $css );
+	}
+
+	public function test_custom_taxonomy_and_field_subset(): void {
+		Helpers::hideTaxonomyMetaFields( 'project_tag', [ 'description' ] );
+
+		$this->assertCount( 1, $this->hooksFor( $this->filters, 'manage_edit-project_tag_columns' ) );
+
+		$css_callback = $this->hooksFor( $this->actions, 'project_tag_edit_form' )[0]['callback'];
+		ob_start();
+		$css_callback();
+		$css = ob_get_clean();
+		$this->assertStringContainsString( '.term-description-wrap', $css );
+		$this->assertStringNotContainsString( '.term-slug-wrap', $css );
+
+		$columns_callback = $this->hooksFor( $this->filters, 'manage_edit-project_tag_columns' )[0]['callback'];
+		$columns = $columns_callback( [ 'name' => 'Name', 'description' => 'D', 'slug' => 'S' ] );
+		$this->assertSame( [ 'name', 'slug' ], array_keys( $columns ), 'only the requested fields are dropped from columns' );
+	}
+
+	public function test_columns_can_be_kept_while_hiding_form_fields(): void {
+		Helpers::hideTaxonomyMetaFields( 'category', [ 'description', 'slug' ], false );
+
+		$this->assertCount( 0, $this->hooksFor( $this->filters, 'manage_edit-category_columns' ) );
+		$this->assertCount( 1, $this->hooksFor( $this->actions, 'category_edit_form' ) );
+	}
+}

--- a/tests/Unit/Helpers/RelabelPostTypeTest.php
+++ b/tests/Unit/Helpers/RelabelPostTypeTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Helpers;
+
+use Brain\Monkey\Functions;
+use Parisek\TimberKit\Helpers;
+use Tests\Unit\HelpersTestCase;
+
+/**
+ * Verifies Helpers::relabelPostType() — merging custom labels onto an already
+ * registered post type (the "rename the built-in `post` type" boilerplate
+ * previously copy-pasted into every project's article controller).
+ */
+class RelabelPostTypeTest extends HelpersTestCase {
+
+	private function postTypeObject(): object {
+		$object = new \stdClass();
+		$object->label = 'Posts';
+		$object->labels = new \stdClass();
+		$object->labels->name = 'Posts';
+		$object->labels->singular_name = 'Post';
+		$object->labels->add_new = 'Add New';
+		return $object;
+	}
+
+	public function test_merges_labels_onto_registered_post_type_after_init(): void {
+		$object = $this->postTypeObject();
+		Functions\when( 'did_action' )->justReturn( 1 );
+		Functions\when( 'get_post_type_object' )->justReturn( $object );
+
+		Helpers::relabelPostType( 'post', [
+			'name' => 'Články',
+			'singular_name' => 'Článek',
+		] );
+
+		$this->assertSame( 'Články', $object->labels->name );
+		$this->assertSame( 'Článek', $object->labels->singular_name );
+		$this->assertSame( 'Add New', $object->labels->add_new, 'labels not passed stay untouched' );
+		$this->assertSame( 'Články', $object->label, 'top-level label mirrors labels.name' );
+	}
+
+	public function test_label_untouched_when_name_not_among_overrides(): void {
+		$object = $this->postTypeObject();
+		Functions\when( 'did_action' )->justReturn( 1 );
+		Functions\when( 'get_post_type_object' )->justReturn( $object );
+
+		Helpers::relabelPostType( 'post', [ 'add_new' => 'Přidat článek' ] );
+
+		$this->assertSame( 'Přidat článek', $object->labels->add_new );
+		$this->assertSame( 'Posts', $object->label );
+	}
+
+	public function test_unknown_post_type_is_a_no_op(): void {
+		Functions\when( 'did_action' )->justReturn( 1 );
+		Functions\when( 'get_post_type_object' )->justReturn( null );
+
+		Helpers::relabelPostType( 'nonexistent', [ 'name' => 'X' ] );
+
+		$this->expectNotToPerformAssertions();
+	}
+
+	public function test_defers_to_init_hook_when_called_before_init(): void {
+		$object = $this->postTypeObject();
+		Functions\when( 'did_action' )->justReturn( 0 );
+		Functions\when( 'get_post_type_object' )->justReturn( $object );
+
+		$captured = [];
+		Functions\when( 'add_action' )->alias( function ( $hook, $callback, $priority = 10 ) use ( &$captured ) {
+			$captured[] = [ 'hook' => $hook, 'callback' => $callback, 'priority' => $priority ];
+		} );
+
+		Helpers::relabelPostType( 'post', [ 'name' => 'Články' ] );
+
+		$this->assertSame( 'Posts', $object->labels->name, 'nothing applied before init fires' );
+		$this->assertCount( 1, $captured );
+		$this->assertSame( 'init', $captured[0]['hook'] );
+		$this->assertSame( 999, $captured[0]['priority'], 'must run after post types register on default init priority' );
+
+		( $captured[0]['callback'] )();
+
+		$this->assertSame( 'Články', $object->labels->name );
+	}
+}

--- a/tests/Unit/StarterBase/RegisterBlockHooksTest.php
+++ b/tests/Unit/StarterBase/RegisterBlockHooksTest.php
@@ -91,6 +91,23 @@ class RegisterBlockHooksTest extends StarterBaseTestCase {
 		$this->assertNotEmpty( $wbo, 'flag on → WpmlBlockOverride::register() hooked on init' );
 	}
 
+	public function test_does_not_register_allowed_block_types_filter_when_restriction_disabled(): void {
+		$filters = [];
+		Functions\when( 'add_filter' )->alias( function ( $hook, ...$rest ) use ( &$filters ) {
+			$filters[] = $hook;
+		} );
+		Functions\when( 'add_action' )->justReturn( true );
+
+		$instance = $this->bareInstance();
+		$prop = new \ReflectionProperty( StarterBase::class, 'restrict_allowed_blocks' );
+		$prop->setValue( $instance, false );
+
+		$this->invokeRegisterBlockHooks( $instance );
+
+		$this->assertNotContains( 'allowed_block_types_all', $filters, 'restrict_allowed_blocks off → block allowlist filter must not be wired' );
+		$this->assertContains( 'render_block', $filters, 'other block hooks stay wired regardless of the flag' );
+	}
+
 	public function test_registers_clear_cache_on_options_save_at_priority_20(): void {
 		$actions = [];
 		Functions\when( 'add_action' )->alias( function ( $hook, $callback, $priority = 10, ...$rest ) use ( &$actions ) {

--- a/tests/Unit/StarterBase/RenderBlockPassthroughTest.php
+++ b/tests/Unit/StarterBase/RenderBlockPassthroughTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\StarterBase;
+
+use Tests\Unit\StarterBaseTestCase;
+
+/**
+ * Verifies the $render_block_passthrough_blocks escape hatch: listed block
+ * names (exact, `prefix/*` wildcard, or `*`) bypass the core-block wrapper
+ * in render_block() and are returned unchanged.
+ *
+ * Passthrough must short-circuit before any WP/Timber calls — these tests
+ * deliberately mock no WordPress functions beyond the test-case defaults,
+ * so reaching get_post_type()/Timber would fatal and fail the test.
+ */
+class RenderBlockPassthroughTest extends StarterBaseTestCase {
+
+	private function block( ?string $name ): array {
+		return [ 'blockName' => $name, 'parent' => null ];
+	}
+
+	public function test_exact_match_returns_content_unchanged(): void {
+		$base = $this->createStarterBase( [ 'render_block_passthrough_blocks' => [ 'core/quote' ] ] );
+
+		$this->assertSame( '<blockquote>q</blockquote>', $base->render_block( '<blockquote>q</blockquote>', $this->block( 'core/quote' ) ) );
+	}
+
+	public function test_prefix_wildcard_matches_namespaced_blocks(): void {
+		$base = $this->createStarterBase( [ 'render_block_passthrough_blocks' => [ 'wpforms/*' ] ] );
+
+		$this->assertSame( '<form>f</form>', $base->render_block( '<form>f</form>', $this->block( 'wpforms/form-selector' ) ) );
+	}
+
+	public function test_star_matches_every_block(): void {
+		$base = $this->createStarterBase( [ 'render_block_passthrough_blocks' => [ '*' ] ] );
+
+		$this->assertSame( '<p>p</p>', $base->render_block( '<p>p</p>', $this->block( 'core/paragraph' ) ) );
+	}
+
+	public function test_passthrough_wins_over_forced_contact_form_wrapping(): void {
+		$base = $this->createStarterBase( [ 'render_block_passthrough_blocks' => [ 'contact-form-7/contact-form-selector' ] ] );
+
+		$this->assertSame( '<div>cf7</div>', $base->render_block( '<div>cf7</div>', $this->block( 'contact-form-7/contact-form-selector' ) ) );
+	}
+
+	public function test_prefix_wildcard_does_not_match_other_namespaces(): void {
+		$base = $this->createStarterBase( [ 'render_block_passthrough_blocks' => [ 'wpforms/*' ] ] );
+
+		// acf/foo is a non-core block → falls through to the existing
+		// non-core early-out and comes back unchanged for that reason.
+		$this->assertSame( 'x', $base->render_block( 'x', $this->block( 'acf/foo' ) ) );
+	}
+
+	public function test_default_empty_list_keeps_existing_early_outs(): void {
+		$base = $this->createStarterBase();
+
+		// Nested block → unchanged (parent check).
+		$this->assertSame( 'n', $base->render_block( 'n', [ 'blockName' => 'core/paragraph', 'parent' => [ 'name' => 'core/group' ] ] ) );
+		// Non-core custom block → unchanged (namespace check).
+		$this->assertSame( 'c', $base->render_block( 'c', $this->block( 'acf/hero' ) ) );
+		// Layout block → unchanged (skip list).
+		$this->assertSame( 'g', $base->render_block( 'g', $this->block( 'core/group' ) ) );
+	}
+}

--- a/tests/Unit/StarterBase/TimberContextPrivacyPolicyTest.php
+++ b/tests/Unit/StarterBase/TimberContextPrivacyPolicyTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\StarterBase;
+
+use Brain\Monkey\Functions;
+use Tests\Unit\StarterBaseTestCase;
+
+/**
+ * Verifies the opt-in privacy-policy context population in timber_context():
+ * off by default, and when enabled it exposes get_privacy_policy_url() under
+ * the configurable (deliberately non-semantic) context key.
+ */
+class TimberContextPrivacyPolicyTest extends StarterBaseTestCase {
+
+	private function mockContextDependencies(): void {
+		Functions\when( 'get_home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'get_template_directory_uri' )->justReturn( 'https://example.com/wp-content/themes/t' );
+		Functions\when( 'is_front_page' )->justReturn( false );
+		Functions\when( 'is_plugin_active' )->justReturn( false );
+		Functions\when( 'get_bloginfo' )->justReturn( 'cs-CZ' );
+		Functions\when( 'get_search_query' )->justReturn( '' );
+		Functions\when( 'get_privacy_policy_url' )->justReturn( 'https://example.com/privacy' );
+	}
+
+	public function test_privacy_policy_key_absent_by_default(): void {
+		$this->mockContextDependencies();
+		$base = $this->createStarterBase( [ 'autopopulate_breadcrumb' => false ] );
+
+		$context = $base->timber_context( [] );
+
+		$this->assertArrayNotHasKey( 'ccnstL', $context, 'privacy-policy context is opt-in — must not appear while the flag is off (default)' );
+	}
+
+	public function test_flag_on_populates_default_key_with_privacy_policy_url(): void {
+		$this->mockContextDependencies();
+		$base = $this->createStarterBase( [
+			'autopopulate_breadcrumb' => false,
+			'context_privacy_policy' => true,
+		] );
+
+		$context = $base->timber_context( [] );
+
+		$this->assertSame( 'https://example.com/privacy', $context['ccnstL'] );
+	}
+
+	public function test_flag_on_honors_custom_context_key(): void {
+		$this->mockContextDependencies();
+		$base = $this->createStarterBase( [
+			'autopopulate_breadcrumb' => false,
+			'context_privacy_policy' => true,
+			'privacy_policy_context_key' => 'privacy_url',
+		] );
+
+		$context = $base->timber_context( [] );
+
+		$this->assertSame( 'https://example.com/privacy', $context['privacy_url'] );
+		$this->assertArrayNotHasKey( 'ccnstL', $context );
+	}
+}


### PR DESCRIPTION
## Summary
- Add `$restrict_allowed_blocks` flag (default `true`) to opt out of the `allowed_block_types_all` allowlist wiring for legacy-content sites — replaces no-op overrides found in 3 downstream projects
- Add `$render_block_passthrough_blocks` (default `[]`) — exact/wildcard/`*` block names that bypass the core-block wrapper in `render_block()` — replaces full `render_block()` overrides found in 7 downstream projects (WPForms/Envira/CF7)
- Add `$context_privacy_policy` flag (default `false`) + `$privacy_policy_context_key` (`ccnstL`) — opt-in `get_privacy_policy_url()` context population — replaces a manual line present in 20/20 audited downstream projects
- Add `Helpers::relabelPostType()` — post type relabel boilerplate found in 12 downstream projects
- Add `Helpers::hideTaxonomyMetaFields()` — category admin cleanup hook trio found in 8-10 downstream projects
- All behavior-changing additions follow the flag doctrine (default off / current behavior preserved)
- 19 new tests (840 total green), PHPStan level 8 clean, property suite green

Upstreams recurring `Base.php` patterns discovered in an audit of 20+ PORTA DESIGN WP projects.

## Changes
- src/Helpers.php (modified) — `relabelPostType()`, `hideTaxonomyMetaFields()`
- src/StarterBase.php (modified) — block-passthrough + privacy-policy context flags
- CHANGELOG.md (modified)
- README.md (modified)
- tests/Unit/Helpers/RelabelPostTypeTest.php (added)
- tests/Unit/Helpers/HideTaxonomyMetaFieldsTest.php (added)
- tests/Unit/StarterBase/RenderBlockPassthroughTest.php (added)
- tests/Unit/StarterBase/TimberContextPrivacyPolicyTest.php (added)
- tests/Unit/StarterBase/RegisterBlockHooksTest.php (modified)

🤖 Generated with PORTA skill for [Claude Code](https://claude.com/claude-code)
