### PR TITLE
feat!: keep WP Application Passwords available by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING (behavioral):** `StarterBase::$disable_application_passwords` now
+  defaults to `false` — WP Application Passwords stay **available** out of the
+  box. They are the authentication mechanism for REST/MCP integrations
+  (portadesign-mcp), which every project is expected to adopt. Sites that
+  relied on the old hardened default must opt back in explicitly:
+  `protected bool $disable_application_passwords = true;` in the theme `Base`.
+  The rest of the security-hardening surface is unchanged.
+
 ## [1.16.1] - 2026-07-07
 
 ### Fixed

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -195,8 +195,8 @@ class StarterBase extends Site {
 	/** @var bool Restrict REST API /wp/v2/users endpoint to authenticated users. */
 	protected bool $restrict_rest_users = true;
 
-	/** @var bool Disable WP Application Passwords (REST auth surface that is rarely used in practice). */
-	protected bool $disable_application_passwords = true;
+	/** @var bool Disable WP Application Passwords. Default off since 1.17 — Application Passwords are the auth mechanism for REST/MCP integrations (portadesign-mcp); set true on sites with no such integration to shrink the REST auth surface. */
+	protected bool $disable_application_passwords = false;
 
 	/** @var bool Block ?author=N URL enumeration that leaks usernames via canonical redirect. */
 	protected bool $block_author_enumeration = true;


### PR DESCRIPTION
**From-Project:** mairateam — enabling Application Passwords for the portadesign-mcp plugin required a per-project override of `disable_application_passwords`; the same need applies to every project adopting MCP.

**Why:** `StarterBase` ships `disable_application_passwords = true` as security hardening ("rarely used in practice"). That assumption no longer holds: Application Passwords are the authentication mechanism for REST/MCP integrations, which we now need fleet-wide. Keeping the hardened default would mean copy-pasting the override into every downstream theme.

**What:** Default flips to `false` — Application Passwords stay available out of the box. **Deliberate breaking (behavioral) change**; accepted trade-off. Sites with no MCP/REST integration opt back in with `protected bool $disable_application_passwords = true;` in their theme `Base`. No other hardening flag changes. CHANGELOG entry under Unreleased marks it BREAKING; suggest releasing as 1.17.0.

Tests: `RegisterSecurityHardeningHooksTest` sets the flag explicitly via reflection, so it is default-agnostic and keeps passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xUQ7PWZU4zbQUBP26pak6