### PR TITLE
feat(Health): Site Health board — check registry + security checks (#41 phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- Site Health board (phase 1 of #41): extensible health-check registry under `Parisek\TimberKit\Health\` (`HealthCheck` interface, `Result` value object, `CheckRegistry`, `SiteHealthAdapter`), seeded with five security checks (XML-RPC disabled, WP version hidden, author sitemap disabled, file editing disabled, REST users endpoint restricted via anonymous loopback). Opt-in via new `StarterBase::$site_health` flag (default `false`); projects customize through the `health_checks()` override (primary) or the `timber_kit_health_checks` filter (runs after the override). Read-only by design — the board verifies effective state against expectations declared in code and never writes.
+
 ## [1.17.0] - 2026-07-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -145,6 +145,38 @@ The class is `final` with three public static methods: `render()`, `isInserterPr
 
 `BlockRenderer::flushPostBlockCache($post_id)` is the handler `StarterBase` wires to `acf/save_post` at priority 20. When ACF saves a post, the cache group `acf_block_{$post_id}` is flushed — invalidating exactly the cached blocks tied to that post without touching others. The handler guards against non-numeric ids (ACF options-page strings, opaque `block_*` ids) and against environments without `wp_cache_supports('flush_group')`.
 
+### Site Health board
+
+Opt-in check-list of Porta recommended settings surfaced in Tools → Site Health
+(`$site_health` flag, default `false`). Read-only by design: the board verifies
+the real, effective state of each recommendation — it never writes anything,
+has no options page, and its "Actions" hints point to code fixes. The expected
+state lives versioned in code; Site Health only reports drift.
+
+Each check declares its verification method: `effect` (probe the real outcome,
+plugin-agnostic — survives plugin swaps), `config` (read stored config when
+there is no observable effect), or `both`. Seed set (security): XML-RPC
+disabled, WP version hidden, author sitemap disabled, file editing disabled,
+REST users endpoint restricted (anonymous loopback probe).
+
+Customize in the project `Base` class — conscious exceptions stay visible in
+code review:
+
+```php
+protected bool $site_health = true;
+
+protected function health_checks( array $checks ): array {
+    unset( $checks['rest_users_restricted'] ); // host blocks loopbacks — verified at the edge instead
+    $checks['my_check'] = new MyCheck();       // implements Parisek\TimberKit\Health\HealthCheck
+    return $checks;
+}
+```
+
+The `timber_kit_health_checks` filter runs after the override for mu-plugin /
+per-environment tweaks. Custom checks implement `Health\HealthCheck` (`id`,
+`label`, `category`, `method`, `run(): Result`) and return
+`Result::good()` / `Result::recommended()` / `Result::critical()`.
+
 ### WpmlBlockOverride
 
 Runtime override of Copy field values in ACF Gutenberg blocks for WPML-multilingual sites. Hooks `render_block_data` at priority 20 (after WPML's own handlers) and, for ACF blocks rendered in a non-default language, overwrites `attrs.data.<field>` for fields marked `wpml_cf_preferences = 1` (Copy) with the source-language post's value. Attachment IDs (image / file / gallery) are remapped to per-language duplicates via `wpml_object_id`.

--- a/src/Health/Check/AuthorSitemapDisabled.php
+++ b/src/Health/Check/AuthorSitemapDisabled.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit\Health\Check;
+
+use Parisek\TimberKit\Health\HealthCheck;
+use Parisek\TimberKit\Health\Result;
+
+/**
+ * Effect check: /wp-sitemap-users-1.xml lists author slugs (a username-
+ * enumeration vector) — verified by pushing a stub provider through the
+ * wp_sitemaps_add_provider filter under the "users" name.
+ */
+final class AuthorSitemapDisabled implements HealthCheck {
+
+	public function id(): string {
+		return 'author_sitemap_disabled';
+	}
+
+	public function label(): string {
+		return __( 'Author sitemap is disabled', 'timber-kit' );
+	}
+
+	public function category(): string {
+		return 'security';
+	}
+
+	public function method(): string {
+		return self::METHOD_EFFECT;
+	}
+
+	public function run(): Result {
+		if ( false === apply_filters( 'wp_sitemaps_enabled', true ) ) {
+			return Result::good( __( 'Core sitemaps are disabled entirely — no author sitemap is exposed.', 'timber-kit' ) );
+		}
+
+		$provider = apply_filters( 'wp_sitemaps_add_provider', new \stdClass(), 'users' );
+
+		if ( false === $provider ) {
+			return Result::good( __( 'The users sitemap provider is removed — author slugs are not enumerable via /wp-sitemap-users-1.xml.', 'timber-kit' ) );
+		}
+
+		return Result::recommended(
+			__( 'The author (users) sitemap is exposed and lists usernames. Enable the $disable_author_sitemap flag in the project Base class.', 'timber-kit' )
+		);
+	}
+}

--- a/src/Health/Check/AuthorSitemapDisabled.php
+++ b/src/Health/Check/AuthorSitemapDisabled.php
@@ -9,8 +9,9 @@ use Parisek\TimberKit\Health\Result;
 
 /**
  * Effect check: /wp-sitemap-users-1.xml lists author slugs (a username-
- * enumeration vector) — verified by pushing a stub provider through the
- * wp_sitemaps_add_provider filter under the "users" name.
+ * enumeration vector) — verified against the real provider registry via
+ * wp_get_sitemap_providers(), so third-party wp_sitemaps_add_provider
+ * callbacks only ever see genuine provider objects.
  */
 final class AuthorSitemapDisabled implements HealthCheck {
 
@@ -35,9 +36,9 @@ final class AuthorSitemapDisabled implements HealthCheck {
 			return Result::good( __( 'Core sitemaps are disabled entirely — no author sitemap is exposed.', 'timber-kit' ) );
 		}
 
-		$provider = apply_filters( 'wp_sitemaps_add_provider', new \stdClass(), 'users' );
+		$providers = wp_get_sitemap_providers();
 
-		if ( false === $provider ) {
+		if ( ! isset( $providers['users'] ) ) {
 			return Result::good( __( 'The users sitemap provider is removed — author slugs are not enumerable via /wp-sitemap-users-1.xml.', 'timber-kit' ) );
 		}
 

--- a/src/Health/Check/FileEditingDisabled.php
+++ b/src/Health/Check/FileEditingDisabled.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit\Health\Check;
+
+use Parisek\TimberKit\Health\HealthCheck;
+use Parisek\TimberKit\Health\Result;
+
+/**
+ * Config check: DISALLOW_FILE_EDIT has no probeable runtime effect short of
+ * loading the theme editor, so the constant itself is the source of truth.
+ */
+final class FileEditingDisabled implements HealthCheck {
+
+	public function id(): string {
+		return 'file_editing_disabled';
+	}
+
+	public function label(): string {
+		return __( 'Plugin/theme file editing is disabled', 'timber-kit' );
+	}
+
+	public function category(): string {
+		return 'security';
+	}
+
+	public function method(): string {
+		return self::METHOD_CONFIG;
+	}
+
+	public function run(): Result {
+		if ( defined( 'DISALLOW_FILE_EDIT' ) && DISALLOW_FILE_EDIT ) {
+			return Result::good( __( 'DISALLOW_FILE_EDIT is set — the wp-admin code editors are off.', 'timber-kit' ) );
+		}
+
+		return Result::recommended(
+			__( 'DISALLOW_FILE_EDIT is not set; wp-admin can edit PHP files. Enable the $disable_file_editing flag in the project Base class or define the constant in wp-config.php.', 'timber-kit' )
+		);
+	}
+}

--- a/src/Health/Check/RestUsersRestricted.php
+++ b/src/Health/Check/RestUsersRestricted.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit\Health\Check;
+
+use Parisek\TimberKit\Health\HealthCheck;
+use Parisek\TimberKit\Health\Result;
+
+/**
+ * Effect check via anonymous loopback request — the only honest way to see
+ * what an unauthenticated visitor gets from /wp/v2/users (an in-process REST
+ * dispatch would inherit the admin's logged-in context). Site Health tests
+ * run on demand in wp-admin, so the loopback cost is acceptable; core's own
+ * tests do the same.
+ */
+final class RestUsersRestricted implements HealthCheck {
+
+	public function id(): string {
+		return 'rest_users_restricted';
+	}
+
+	public function label(): string {
+		return __( 'REST users endpoint is restricted', 'timber-kit' );
+	}
+
+	public function category(): string {
+		return 'security';
+	}
+
+	public function method(): string {
+		return self::METHOD_EFFECT;
+	}
+
+	public function run(): Result {
+		$response = wp_remote_get( rest_url( 'wp/v2/users' ), array( 'timeout' => 5 ) );
+
+		if ( is_wp_error( $response ) ) {
+			return Result::recommended(
+				__( 'Could not verify the REST users endpoint — the loopback request failed. Check loopback connectivity on this host.', 'timber-kit' )
+			);
+		}
+
+		if ( 200 === (int) wp_remote_retrieve_response_code( $response ) ) {
+			return Result::critical(
+				__( 'The REST users endpoint (/wp/v2/users) lists users to anonymous visitors — usernames are enumerable. Enable the $restrict_rest_users flag in the project Base class.', 'timber-kit' )
+			);
+		}
+
+		return Result::good( __( 'The REST users endpoint rejects anonymous requests.', 'timber-kit' ) );
+	}
+}

--- a/src/Health/Check/WpVersionHidden.php
+++ b/src/Health/Check/WpVersionHidden.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit\Health\Check;
+
+use Parisek\TimberKit\Health\HealthCheck;
+use Parisek\TimberKit\Health\Result;
+
+/**
+ * Effect check: wp_head/feeds emit the generator through the the_generator
+ * filter — pushing a sentinel through it shows what would really be printed,
+ * without depending on which layer emptied it.
+ */
+final class WpVersionHidden implements HealthCheck {
+
+	public function id(): string {
+		return 'wp_version_hidden';
+	}
+
+	public function label(): string {
+		return __( 'WordPress version is hidden', 'timber-kit' );
+	}
+
+	public function category(): string {
+		return 'security';
+	}
+
+	public function method(): string {
+		return self::METHOD_EFFECT;
+	}
+
+	public function run(): Result {
+		$emitted = apply_filters( 'the_generator', 'generator-sentinel', 'xhtml' );
+
+		if ( '' === $emitted ) {
+			return Result::good( __( 'The generator meta tag is empty — the WordPress version is not disclosed in markup or feeds.', 'timber-kit' ) );
+		}
+
+		return Result::recommended(
+			__( 'The generator tag discloses the WordPress version. Enable the $remove_wp_generator flag in the project Base class.', 'timber-kit' )
+		);
+	}
+}

--- a/src/Health/Check/WpVersionHidden.php
+++ b/src/Health/Check/WpVersionHidden.php
@@ -9,8 +9,9 @@ use Parisek\TimberKit\Health\Result;
 
 /**
  * Effect check: wp_head/feeds emit the generator through the the_generator
- * filter — pushing a sentinel through it shows what would really be printed,
- * without depending on which layer emptied it.
+ * filter — running the real generator markup through it and looking for the
+ * actual version string shows what a visitor would really see, without
+ * depending on which layer emptied or rewrote it.
  */
 final class WpVersionHidden implements HealthCheck {
 
@@ -31,14 +32,15 @@ final class WpVersionHidden implements HealthCheck {
 	}
 
 	public function run(): Result {
-		$emitted = apply_filters( 'the_generator', 'generator-sentinel', 'xhtml' );
+		$emitted = apply_filters( 'the_generator', get_the_generator( 'xhtml' ), 'xhtml' );
+		$version = get_bloginfo( 'version' );
 
-		if ( '' === $emitted ) {
-			return Result::good( __( 'The generator meta tag is empty — the WordPress version is not disclosed in markup or feeds.', 'timber-kit' ) );
+		if ( is_string( $emitted ) && '' !== $version && str_contains( $emitted, $version ) ) {
+			return Result::recommended(
+				__( 'The generator tag discloses the WordPress version. Enable the $remove_wp_generator flag in the project Base class.', 'timber-kit' )
+			);
 		}
 
-		return Result::recommended(
-			__( 'The generator tag discloses the WordPress version. Enable the $remove_wp_generator flag in the project Base class.', 'timber-kit' )
-		);
+		return Result::good( __( 'The emitted generator output does not contain the WordPress version.', 'timber-kit' ) );
 	}
 }

--- a/src/Health/Check/XmlrpcDisabled.php
+++ b/src/Health/Check/XmlrpcDisabled.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit\Health\Check;
+
+use Parisek\TimberKit\Health\HealthCheck;
+use Parisek\TimberKit\Health\Result;
+
+/**
+ * Effect check: verifies the effective xmlrpc_enabled filter value, so it
+ * holds regardless of whether the kit flag, a WAF, or another plugin did
+ * the disabling.
+ */
+final class XmlrpcDisabled implements HealthCheck {
+
+	public function id(): string {
+		return 'xmlrpc_disabled';
+	}
+
+	public function label(): string {
+		return __( 'XML-RPC is disabled', 'timber-kit' );
+	}
+
+	public function category(): string {
+		return 'security';
+	}
+
+	public function method(): string {
+		return self::METHOD_EFFECT;
+	}
+
+	public function run(): Result {
+		if ( false === apply_filters( 'xmlrpc_enabled', true ) ) {
+			return Result::good( __( 'XML-RPC authenticated methods are disabled.', 'timber-kit' ) );
+		}
+
+		return Result::recommended(
+			__( 'XML-RPC is enabled. Porta recommends disabling it unless a service depends on it — enable the $disable_xmlrpc flag in the project Base class.', 'timber-kit' )
+		);
+	}
+}

--- a/src/Health/CheckRegistry.php
+++ b/src/Health/CheckRegistry.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit\Health;
+
+/**
+ * Collects health checks keyed by their stable id. Duplicate ids throw
+ * instead of silently overwriting — a collision means two features claim
+ * the same board slot and one of them would vanish unnoticed.
+ */
+final class CheckRegistry {
+
+	/** @var array<string, HealthCheck> */
+	private array $checks = array();
+
+	public function add( HealthCheck $check ): void {
+		$id = $check->id();
+		if ( isset( $this->checks[ $id ] ) ) {
+			throw new \InvalidArgumentException(
+				sprintf( 'Health check "%s" is already registered.', $id )
+			);
+		}
+		$this->checks[ $id ] = $check;
+	}
+
+	/**
+	 * @return array<string, HealthCheck>
+	 */
+	public function all(): array {
+		return $this->checks;
+	}
+}

--- a/src/Health/HealthCheck.php
+++ b/src/Health/HealthCheck.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit\Health;
+
+/**
+ * A single entry on the Porta recommended-settings board.
+ *
+ * Each check declares its verification method:
+ * - METHOD_EFFECT — probes the real outcome, plugin-agnostic (preferred:
+ *   survives plugin swaps, verifies results, not a vendor's checkbox).
+ * - METHOD_CONFIG — reads stored config when there is no observable effect.
+ * - METHOD_BOTH — cross-checks effect against config ("checkbox on but not
+ *   actually working").
+ */
+interface HealthCheck {
+
+	public const METHOD_EFFECT = 'effect';
+	public const METHOD_CONFIG = 'config';
+	public const METHOD_BOTH   = 'both';
+
+	/**
+	 * Stable slug, unique across the registry (e.g. "xmlrpc_disabled").
+	 */
+	public function id(): string;
+
+	/**
+	 * Human label shown as the Site Health test heading.
+	 */
+	public function label(): string;
+
+	/**
+	 * Board category: security|caching|seo|performance|mail|a11y|timber-kit.
+	 */
+	public function category(): string;
+
+	/**
+	 * One of the METHOD_* constants.
+	 */
+	public function method(): string;
+
+	public function run(): Result;
+}

--- a/src/Health/Result.php
+++ b/src/Health/Result.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit\Health;
+
+/**
+ * Outcome of a single health check, aligned with WP Site Health statuses.
+ *
+ * Constructor is private — static constructors are the only way in, so an
+ * invalid status string is unrepresentable by construction.
+ */
+final class Result {
+
+	public const GOOD        = 'good';
+	public const RECOMMENDED = 'recommended';
+	public const CRITICAL    = 'critical';
+
+	private function __construct(
+		private readonly string $status,
+		private readonly string $summary,
+		private readonly string $actions,
+	) {
+	}
+
+	public static function good( string $summary ): self {
+		return new self( self::GOOD, $summary, '' );
+	}
+
+	public static function recommended( string $summary, string $actions = '' ): self {
+		return new self( self::RECOMMENDED, $summary, $actions );
+	}
+
+	public static function critical( string $summary, string $actions = '' ): self {
+		return new self( self::CRITICAL, $summary, $actions );
+	}
+
+	public function status(): string {
+		return $this->status;
+	}
+
+	public function summary(): string {
+		return $this->summary;
+	}
+
+	/**
+	 * Optional HTML for Site Health's "Actions" area. Points to remediation
+	 * docs ("fix it in code like this") — never to an admin screen; the board
+	 * is read-only by design.
+	 */
+	public function actions(): string {
+		return $this->actions;
+	}
+}

--- a/src/Health/SiteHealthAdapter.php
+++ b/src/Health/SiteHealthAdapter.php
@@ -34,7 +34,14 @@ final class SiteHealthAdapter {
 			if ( ! $check instanceof HealthCheck ) {
 				continue;
 			}
-			$tests['direct'][ 'timber_kit_health_' . $check->id() ] = array(
+			$key = 'timber_kit_health_' . $check->id();
+			if ( isset( $tests['direct'][ $key ] ) ) {
+				// Registry uniqueness only covers the kit defaults; the override
+				// and the public filter can reintroduce a duplicate id. First
+				// registration wins — deterministic, and never a wp-admin fatal.
+				continue;
+			}
+			$tests['direct'][ $key ] = array(
 				'label' => $check->label(),
 				'test'  => static fn (): array => self::toSiteHealthResult( $check ),
 			);
@@ -55,12 +62,32 @@ final class SiteHealthAdapter {
 			'label'       => $check->label(),
 			'status'      => $result->status(),
 			'badge'       => array(
-				'label' => ucfirst( $check->category() ),
+				'label' => self::badgeLabel( $check->category() ),
 				'color' => 'blue',
 			),
 			'description' => '<p>' . esc_html( $result->summary() ) . '</p>',
-			'actions'     => $result->actions(),
+			// Checks can arrive via the public filter — treat their actions HTML
+			// as untrusted and reduce it to post-safe markup.
+			'actions'     => wp_kses_post( $result->actions() ),
 			'test'        => 'timber_kit_health_' . $check->id(),
 		);
+	}
+
+	/**
+	 * Translated badge label per board category; unknown categories fall back
+	 * to a capitalized slug.
+	 */
+	private static function badgeLabel( string $category ): string {
+		$labels = array(
+			'security'    => __( 'Security', 'timber-kit' ),
+			'caching'     => __( 'Caching', 'timber-kit' ),
+			'seo'         => __( 'SEO', 'timber-kit' ),
+			'performance' => __( 'Performance', 'timber-kit' ),
+			'mail'        => __( 'Mail', 'timber-kit' ),
+			'a11y'        => __( 'Accessibility', 'timber-kit' ),
+			'timber-kit'  => 'timber-kit',
+		);
+
+		return $labels[ $category ] ?? ucfirst( $category );
 	}
 }

--- a/src/Health/SiteHealthAdapter.php
+++ b/src/Health/SiteHealthAdapter.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit\Health;
+
+/**
+ * The ONLY coupling between the check registry and WP Site Health.
+ * Registry + checks stay framework-agnostic so a CLI adapter (fleet sweeps,
+ * CI gates) can consume the same checks later.
+ */
+final class SiteHealthAdapter {
+
+	/**
+	 * Merge checks into the `site_status_tests` array.
+	 *
+	 * `$checks` arrives through a public filter, so entries are untrusted —
+	 * anything that is not a HealthCheck is skipped rather than fataling
+	 * inside wp-admin.
+	 *
+	 * @param mixed                $tests  Value from the site_status_tests filter.
+	 * @param array<string, mixed> $checks Checks keyed by id.
+	 * @return array<string, mixed>
+	 */
+	public static function mapTests( mixed $tests, array $checks ): array {
+		if ( ! is_array( $tests ) ) {
+			$tests = array(
+				'direct' => array(),
+				'async'  => array(),
+			);
+		}
+
+		foreach ( $checks as $check ) {
+			if ( ! $check instanceof HealthCheck ) {
+				continue;
+			}
+			$tests['direct'][ 'timber_kit_health_' . $check->id() ] = array(
+				'label' => $check->label(),
+				'test'  => static fn (): array => self::toSiteHealthResult( $check ),
+			);
+		}
+
+		return $tests;
+	}
+
+	/**
+	 * Run one check and shape the outcome the way Site Health expects.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function toSiteHealthResult( HealthCheck $check ): array {
+		$result = $check->run();
+
+		return array(
+			'label'       => $check->label(),
+			'status'      => $result->status(),
+			'badge'       => array(
+				'label' => ucfirst( $check->category() ),
+				'color' => 'blue',
+			),
+			'description' => '<p>' . esc_html( $result->summary() ) . '</p>',
+			'actions'     => $result->actions(),
+			'test'        => 'timber_kit_health_' . $check->id(),
+		);
+	}
+}

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -23,6 +23,14 @@ use Parisek\Twig\CommonExtension;
 use Parisek\Twig\AttributeExtension;
 use Parisek\Twig\TypographyExtension;
 use Parisek\TimberKit\BlockRenderer;
+use Parisek\TimberKit\Health\Check\AuthorSitemapDisabled;
+use Parisek\TimberKit\Health\Check\FileEditingDisabled;
+use Parisek\TimberKit\Health\Check\RestUsersRestricted;
+use Parisek\TimberKit\Health\Check\WpVersionHidden;
+use Parisek\TimberKit\Health\Check\XmlrpcDisabled;
+use Parisek\TimberKit\Health\CheckRegistry;
+use Parisek\TimberKit\Health\HealthCheck;
+use Parisek\TimberKit\Health\SiteHealthAdapter;
 
 /**
  * Base class for WordPress themes using Timber/Twig templating.
@@ -407,6 +415,16 @@ class StarterBase extends Site {
 	protected bool $warn_duplicate_security_headers = true;
 
 	/**
+	 * Surface the Porta recommended-settings board in Tools → Site Health
+	 * (phase 1: security checks). Read-only — the board verifies effective
+	 * state against expectations declared in code; it never writes. Opt-in
+	 * because it adds admin-visible site_status_tests entries.
+	 *
+	 * @var bool
+	 */
+	protected bool $site_health = false;
+
+	/**
 	 * Whether to pass animated sources (animated AVIF / WebP / GIF) through the
 	 * resizer untouched. Default **true** — animated sources are detected (Imagick
 	 * frame count unioned with a structural byte-sniff, so even sources the backend
@@ -442,6 +460,7 @@ class StarterBase extends Site {
 		$this->registerSecurityHardeningHooks();
 		$this->registerCommentDisablingHooks();
 		$this->registerPerformanceHooks();
+		$this->registerSiteHealthHooks();
 
 		$this->setup_dev_media_proxy();
 		$this->setup_wpforms_config_bridge();
@@ -779,6 +798,68 @@ class StarterBase extends Site {
 			// pipeline, which flattens the animation — the legacy behaviour.
 			add_filter( 'timber_kit_resizer_skip_animated', '__return_false' );
 		}
+	}
+
+	/**
+	 * Register the Site Health board (gated by $site_health, default off).
+	 *
+	 * @return void
+	 */
+	private function registerSiteHealthHooks(): void {
+		if ( ! $this->site_health ) {
+			return;
+		}
+
+		add_filter( 'site_status_tests', array( $this, 'site_health_register_checks' ) );
+	}
+
+	/**
+	 * site_status_tests callback: build the check set and hand it to the
+	 * adapter. Order matters — the Base.php override runs first (the "home"
+	 * customization path, visible in project diffs), then the filter (uniform
+	 * low-level hook for mu-plugins / per-environment tweaks).
+	 *
+	 * @param mixed $tests Existing site_status_tests value.
+	 * @return array<string, mixed>
+	 */
+	public function site_health_register_checks( $tests ): array {
+		$registry = new CheckRegistry();
+		foreach ( $this->default_health_checks() as $check ) {
+			$registry->add( $check );
+		}
+
+		$checks = $this->health_checks( $registry->all() );
+		$checks = apply_filters( 'timber_kit_health_checks', $checks );
+
+		return SiteHealthAdapter::mapTests( $tests, is_array( $checks ) ? $checks : array() );
+	}
+
+	/**
+	 * The kit's seed check set. Split from health_checks() so a project
+	 * override always receives the full defaults to prune/extend.
+	 *
+	 * @return list<HealthCheck>
+	 */
+	protected function default_health_checks(): array {
+		return array(
+			new XmlrpcDisabled(),
+			new WpVersionHidden(),
+			new AuthorSitemapDisabled(),
+			new FileEditingDisabled(),
+			new RestUsersRestricted(),
+		);
+	}
+
+	/**
+	 * Extension point: override in the project Base class to add project
+	 * checks or drop defaults. Convention: every dropped check carries a
+	 * comment explaining why, so conscious exceptions survive code review.
+	 *
+	 * @param array<string, HealthCheck> $checks Default checks keyed by id.
+	 * @return array<string, HealthCheck>
+	 */
+	protected function health_checks( array $checks ): array {
+		return $checks;
 	}
 
 	/**

--- a/tests/Unit/Health/Check/AuthorSitemapDisabledTest.php
+++ b/tests/Unit/Health/Check/AuthorSitemapDisabledTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Health\Check;
+
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use Parisek\TimberKit\Health\Check\AuthorSitemapDisabled;
+use Parisek\TimberKit\Health\HealthCheck;
+use Tests\Unit\Health\HealthTestCase;
+
+class AuthorSitemapDisabledTest extends HealthTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Functions\when( '__' )->returnArg();
+	}
+
+	public function test_identity(): void {
+		$check = new AuthorSitemapDisabled();
+
+		$this->assertSame( 'author_sitemap_disabled', $check->id() );
+		$this->assertSame( 'security', $check->category() );
+		$this->assertSame( HealthCheck::METHOD_EFFECT, $check->method() );
+	}
+
+	public function test_good_when_users_provider_is_dropped(): void {
+		Filters\expectApplied( 'wp_sitemaps_add_provider' )->once()->andReturn( false );
+
+		$this->assertSame( 'good', ( new AuthorSitemapDisabled() )->run()->status() );
+	}
+
+	public function test_good_when_sitemaps_are_disabled_entirely(): void {
+		Filters\expectApplied( 'wp_sitemaps_enabled' )->once()->andReturn( false );
+
+		$this->assertSame( 'good', ( new AuthorSitemapDisabled() )->run()->status() );
+	}
+
+	public function test_recommended_when_users_provider_survives(): void {
+		// Both filters pass through by default: sitemaps on, provider kept.
+		$this->assertSame( 'recommended', ( new AuthorSitemapDisabled() )->run()->status() );
+	}
+}

--- a/tests/Unit/Health/Check/AuthorSitemapDisabledTest.php
+++ b/tests/Unit/Health/Check/AuthorSitemapDisabledTest.php
@@ -25,8 +25,8 @@ class AuthorSitemapDisabledTest extends HealthTestCase {
 		$this->assertSame( HealthCheck::METHOD_EFFECT, $check->method() );
 	}
 
-	public function test_good_when_users_provider_is_dropped(): void {
-		Filters\expectApplied( 'wp_sitemaps_add_provider' )->once()->andReturn( false );
+	public function test_good_when_users_provider_is_absent(): void {
+		Functions\when( 'wp_get_sitemap_providers' )->justReturn( [ 'posts' => new \stdClass() ] );
 
 		$this->assertSame( 'good', ( new AuthorSitemapDisabled() )->run()->status() );
 	}
@@ -37,8 +37,10 @@ class AuthorSitemapDisabledTest extends HealthTestCase {
 		$this->assertSame( 'good', ( new AuthorSitemapDisabled() )->run()->status() );
 	}
 
-	public function test_recommended_when_users_provider_survives(): void {
-		// Both filters pass through by default: sitemaps on, provider kept.
+	public function test_recommended_when_users_provider_is_registered(): void {
+		// wp_sitemaps_enabled passes through by default (sitemaps on).
+		Functions\when( 'wp_get_sitemap_providers' )->justReturn( [ 'posts' => new \stdClass(), 'users' => new \stdClass() ] );
+
 		$this->assertSame( 'recommended', ( new AuthorSitemapDisabled() )->run()->status() );
 	}
 }

--- a/tests/Unit/Health/Check/FileEditingDisabledTest.php
+++ b/tests/Unit/Health/Check/FileEditingDisabledTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Health\Check;
+
+use Brain\Monkey\Functions;
+use Parisek\TimberKit\Health\Check\FileEditingDisabled;
+use Parisek\TimberKit\Health\HealthCheck;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use Tests\Unit\Health\HealthTestCase;
+
+class FileEditingDisabledTest extends HealthTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Functions\when( '__' )->returnArg();
+	}
+
+	public function test_identity(): void {
+		$check = new FileEditingDisabled();
+
+		$this->assertSame( 'file_editing_disabled', $check->id() );
+		$this->assertSame( 'security', $check->category() );
+		$this->assertSame( HealthCheck::METHOD_CONFIG, $check->method() );
+	}
+
+	// DISALLOW_FILE_EDIT is process-global and other suite tests may define
+	// it — both run() paths isolate in their own process to stay order-proof.
+
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_recommended_when_constant_undefined(): void {
+		$this->assertSame( 'recommended', ( new FileEditingDisabled() )->run()->status() );
+	}
+
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_good_when_constant_true(): void {
+		define( 'DISALLOW_FILE_EDIT', true );
+
+		$this->assertSame( 'good', ( new FileEditingDisabled() )->run()->status() );
+	}
+}

--- a/tests/Unit/Health/Check/RestUsersRestrictedTest.php
+++ b/tests/Unit/Health/Check/RestUsersRestrictedTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Health\Check;
+
+use Brain\Monkey\Functions;
+use Parisek\TimberKit\Health\Check\RestUsersRestricted;
+use Parisek\TimberKit\Health\HealthCheck;
+use Tests\Unit\Health\HealthTestCase;
+
+class RestUsersRestrictedTest extends HealthTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'rest_url' )->alias( fn ( string $path ): string => 'https://example.com/wp-json/' . $path );
+	}
+
+	private function stubResponse( int $code ): void {
+		Functions\when( 'wp_remote_get' )->justReturn( [ 'response' => [ 'code' => $code ] ] );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( $code );
+	}
+
+	public function test_identity(): void {
+		$check = new RestUsersRestricted();
+
+		$this->assertSame( 'rest_users_restricted', $check->id() );
+		$this->assertSame( 'security', $check->category() );
+		$this->assertSame( HealthCheck::METHOD_EFFECT, $check->method() );
+	}
+
+	public function test_critical_when_anonymous_request_succeeds(): void {
+		$this->stubResponse( 200 );
+
+		$this->assertSame( 'critical', ( new RestUsersRestricted() )->run()->status() );
+	}
+
+	public function test_good_when_anonymous_request_is_rejected(): void {
+		$this->stubResponse( 401 );
+
+		$this->assertSame( 'good', ( new RestUsersRestricted() )->run()->status() );
+	}
+
+	public function test_recommended_when_loopback_fails(): void {
+		Functions\when( 'wp_remote_get' )->justReturn( 'error-object' );
+		Functions\when( 'is_wp_error' )->justReturn( true );
+
+		$this->assertSame( 'recommended', ( new RestUsersRestricted() )->run()->status() );
+	}
+}

--- a/tests/Unit/Health/Check/WpVersionHiddenTest.php
+++ b/tests/Unit/Health/Check/WpVersionHiddenTest.php
@@ -15,6 +15,8 @@ class WpVersionHiddenTest extends HealthTestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		Functions\when( '__' )->returnArg();
+		Functions\when( 'get_bloginfo' )->justReturn( '6.9' );
+		Functions\when( 'get_the_generator' )->justReturn( '<meta name="generator" content="WordPress 6.9" />' );
 	}
 
 	public function test_identity(): void {
@@ -31,7 +33,14 @@ class WpVersionHiddenTest extends HealthTestCase {
 		$this->assertSame( 'good', ( new WpVersionHidden() )->run()->status() );
 	}
 
-	public function test_recommended_when_generator_passes_through(): void {
+	public function test_recommended_when_generator_discloses_the_version(): void {
+		// the_generator passes the real markup through by default.
 		$this->assertSame( 'recommended', ( new WpVersionHidden() )->run()->status() );
+	}
+
+	public function test_good_when_generator_is_custom_without_version(): void {
+		Filters\expectApplied( 'the_generator' )->once()->andReturn( '<meta name="generator" content="My CMS" />' );
+
+		$this->assertSame( 'good', ( new WpVersionHidden() )->run()->status() );
 	}
 }

--- a/tests/Unit/Health/Check/WpVersionHiddenTest.php
+++ b/tests/Unit/Health/Check/WpVersionHiddenTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Health\Check;
+
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use Parisek\TimberKit\Health\Check\WpVersionHidden;
+use Parisek\TimberKit\Health\HealthCheck;
+use Tests\Unit\Health\HealthTestCase;
+
+class WpVersionHiddenTest extends HealthTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Functions\when( '__' )->returnArg();
+	}
+
+	public function test_identity(): void {
+		$check = new WpVersionHidden();
+
+		$this->assertSame( 'wp_version_hidden', $check->id() );
+		$this->assertSame( 'security', $check->category() );
+		$this->assertSame( HealthCheck::METHOD_EFFECT, $check->method() );
+	}
+
+	public function test_good_when_the_generator_filter_empties_output(): void {
+		Filters\expectApplied( 'the_generator' )->once()->andReturn( '' );
+
+		$this->assertSame( 'good', ( new WpVersionHidden() )->run()->status() );
+	}
+
+	public function test_recommended_when_generator_passes_through(): void {
+		$this->assertSame( 'recommended', ( new WpVersionHidden() )->run()->status() );
+	}
+}

--- a/tests/Unit/Health/Check/XmlrpcDisabledTest.php
+++ b/tests/Unit/Health/Check/XmlrpcDisabledTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Health\Check;
+
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use Parisek\TimberKit\Health\Check\XmlrpcDisabled;
+use Parisek\TimberKit\Health\HealthCheck;
+use Tests\Unit\Health\HealthTestCase;
+
+class XmlrpcDisabledTest extends HealthTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Functions\when( '__' )->returnArg();
+	}
+
+	public function test_identity(): void {
+		$check = new XmlrpcDisabled();
+
+		$this->assertSame( 'xmlrpc_disabled', $check->id() );
+		$this->assertSame( 'security', $check->category() );
+		$this->assertSame( HealthCheck::METHOD_EFFECT, $check->method() );
+	}
+
+	public function test_good_when_xmlrpc_filter_returns_false(): void {
+		Filters\expectApplied( 'xmlrpc_enabled' )->once()->with( true )->andReturn( false );
+
+		$this->assertSame( 'good', ( new XmlrpcDisabled() )->run()->status() );
+	}
+
+	public function test_recommended_when_xmlrpc_stays_enabled(): void {
+		// Brain\Monkey's apply_filters passes the value through by default.
+		$this->assertSame( 'recommended', ( new XmlrpcDisabled() )->run()->status() );
+	}
+}

--- a/tests/Unit/Health/CheckRegistryTest.php
+++ b/tests/Unit/Health/CheckRegistryTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Health;
+
+use Parisek\TimberKit\Health\CheckRegistry;
+use Parisek\TimberKit\Health\HealthCheck;
+use Parisek\TimberKit\Health\Result;
+
+class CheckRegistryTest extends HealthTestCase {
+
+	private function fakeCheck( string $id ): HealthCheck {
+		return new class( $id ) implements HealthCheck {
+			public function __construct( private readonly string $id ) {
+			}
+			public function id(): string {
+				return $this->id;
+			}
+			public function label(): string {
+				return 'Fake ' . $this->id;
+			}
+			public function category(): string {
+				return 'security';
+			}
+			public function method(): string {
+				return self::METHOD_EFFECT;
+			}
+			public function run(): Result {
+				return Result::good( 'ok' );
+			}
+		};
+	}
+
+	public function test_all_returns_checks_keyed_by_id_in_insertion_order(): void {
+		$registry = new CheckRegistry();
+		$first    = $this->fakeCheck( 'first' );
+		$second   = $this->fakeCheck( 'second' );
+
+		$registry->add( $first );
+		$registry->add( $second );
+
+		$this->assertSame( [ 'first' => $first, 'second' => $second ], $registry->all() );
+	}
+
+	public function test_duplicate_id_throws(): void {
+		$registry = new CheckRegistry();
+		$registry->add( $this->fakeCheck( 'dup' ) );
+
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'dup' );
+
+		$registry->add( $this->fakeCheck( 'dup' ) );
+	}
+
+	public function test_empty_registry_returns_empty_array(): void {
+		$this->assertSame( [], ( new CheckRegistry() )->all() );
+	}
+}

--- a/tests/Unit/Health/HealthTestCase.php
+++ b/tests/Unit/Health/HealthTestCase.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Health;
+
+use Brain\Monkey;
+use PHPUnit\Framework\TestCase;
+
+abstract class HealthTestCase extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+}

--- a/tests/Unit/Health/ResultTest.php
+++ b/tests/Unit/Health/ResultTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Health;
+
+use Parisek\TimberKit\Health\Result;
+
+class ResultTest extends HealthTestCase {
+
+	public function test_good_result_carries_status_and_summary(): void {
+		$result = Result::good( 'All fine.' );
+
+		$this->assertSame( Result::GOOD, $result->status() );
+		$this->assertSame( 'good', $result->status() );
+		$this->assertSame( 'All fine.', $result->summary() );
+		$this->assertSame( '', $result->actions() );
+	}
+
+	public function test_recommended_result_carries_optional_actions(): void {
+		$result = Result::recommended( 'Could be better.', '<a href="https://example.com">Fix it in code</a>' );
+
+		$this->assertSame( 'recommended', $result->status() );
+		$this->assertSame( 'Could be better.', $result->summary() );
+		$this->assertSame( '<a href="https://example.com">Fix it in code</a>', $result->actions() );
+	}
+
+	public function test_critical_result_defaults_to_empty_actions(): void {
+		$result = Result::critical( 'Broken.' );
+
+		$this->assertSame( 'critical', $result->status() );
+		$this->assertSame( '', $result->actions() );
+	}
+}

--- a/tests/Unit/Health/SiteHealthAdapterTest.php
+++ b/tests/Unit/Health/SiteHealthAdapterTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Health;
+
+use Brain\Monkey\Functions;
+use Parisek\TimberKit\Health\HealthCheck;
+use Parisek\TimberKit\Health\Result;
+use Parisek\TimberKit\Health\SiteHealthAdapter;
+
+class SiteHealthAdapterTest extends HealthTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Functions\when( 'esc_html' )->returnArg();
+	}
+
+	private function fakeCheck( string $id, Result $result ): HealthCheck {
+		return new class( $id, $result ) implements HealthCheck {
+			public function __construct(
+				private readonly string $id,
+				private readonly Result $result,
+			) {
+			}
+			public function id(): string {
+				return $this->id;
+			}
+			public function label(): string {
+				return 'Label ' . $this->id;
+			}
+			public function category(): string {
+				return 'security';
+			}
+			public function method(): string {
+				return self::METHOD_EFFECT;
+			}
+			public function run(): Result {
+				return $this->result;
+			}
+		};
+	}
+
+	public function test_map_tests_adds_direct_entries_prefixed_with_timber_kit_health(): void {
+		$tests = [ 'direct' => [ 'existing' => [ 'label' => 'x' ] ], 'async' => [] ];
+
+		$mapped = SiteHealthAdapter::mapTests(
+			$tests,
+			[ 'foo' => $this->fakeCheck( 'foo', Result::good( 'ok' ) ) ]
+		);
+
+		$this->assertArrayHasKey( 'existing', $mapped['direct'] );
+		$this->assertArrayHasKey( 'timber_kit_health_foo', $mapped['direct'] );
+		$this->assertSame( 'Label foo', $mapped['direct']['timber_kit_health_foo']['label'] );
+		$this->assertIsCallable( $mapped['direct']['timber_kit_health_foo']['test'] );
+	}
+
+	public function test_map_tests_normalizes_non_array_input(): void {
+		$mapped = SiteHealthAdapter::mapTests( null, [] );
+
+		$this->assertSame( [ 'direct' => [], 'async' => [] ], $mapped );
+	}
+
+	public function test_map_tests_skips_non_check_entries(): void {
+		$mapped = SiteHealthAdapter::mapTests(
+			[ 'direct' => [], 'async' => [] ],
+			[ 'bogus' => 'not a check', 'real' => $this->fakeCheck( 'real', Result::good( 'ok' ) ) ]
+		);
+
+		$this->assertArrayNotHasKey( 'timber_kit_health_bogus', $mapped['direct'] );
+		$this->assertArrayHasKey( 'timber_kit_health_real', $mapped['direct'] );
+	}
+
+	public function test_to_site_health_result_maps_result_to_wp_shape(): void {
+		$check = $this->fakeCheck( 'foo', Result::critical( 'Bad news.', '<a href="https://example.com">Docs</a>' ) );
+
+		$result = SiteHealthAdapter::toSiteHealthResult( $check );
+
+		$this->assertSame( 'Label foo', $result['label'] );
+		$this->assertSame( 'critical', $result['status'] );
+		$this->assertSame( [ 'label' => 'Security', 'color' => 'blue' ], $result['badge'] );
+		$this->assertSame( '<p>Bad news.</p>', $result['description'] );
+		$this->assertSame( '<a href="https://example.com">Docs</a>', $result['actions'] );
+		$this->assertSame( 'timber_kit_health_foo', $result['test'] );
+	}
+
+	public function test_registered_test_closure_returns_the_run_result(): void {
+		$mapped = SiteHealthAdapter::mapTests(
+			[ 'direct' => [], 'async' => [] ],
+			[ 'foo' => $this->fakeCheck( 'foo', Result::good( 'All fine.' ) ) ]
+		);
+
+		$outcome = $mapped['direct']['timber_kit_health_foo']['test']();
+
+		$this->assertSame( 'good', $outcome['status'] );
+		$this->assertSame( '<p>All fine.</p>', $outcome['description'] );
+	}
+}

--- a/tests/Unit/Health/SiteHealthAdapterTest.php
+++ b/tests/Unit/Health/SiteHealthAdapterTest.php
@@ -14,6 +14,8 @@ class SiteHealthAdapterTest extends HealthTestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		Functions\when( 'esc_html' )->returnArg();
+		Functions\when( 'wp_kses_post' )->returnArg();
+		Functions\when( '__' )->returnArg();
 	}
 
 	private function fakeCheck( string $id, Result $result ): HealthCheck {
@@ -69,6 +71,30 @@ class SiteHealthAdapterTest extends HealthTestCase {
 
 		$this->assertArrayNotHasKey( 'timber_kit_health_bogus', $mapped['direct'] );
 		$this->assertArrayHasKey( 'timber_kit_health_real', $mapped['direct'] );
+	}
+
+	public function test_map_tests_first_check_wins_on_duplicate_id(): void {
+		$mapped = SiteHealthAdapter::mapTests(
+			[ 'direct' => [], 'async' => [] ],
+			[
+				'a' => $this->fakeCheck( 'same', Result::good( 'first' ) ),
+				'b' => $this->fakeCheck( 'same', Result::critical( 'second' ) ),
+			]
+		);
+
+		$outcome = $mapped['direct']['timber_kit_health_same']['test']();
+
+		$this->assertSame( '<p>first</p>', $outcome['description'] );
+	}
+
+	public function test_actions_html_is_passed_through_wp_kses_post(): void {
+		Functions\when( 'wp_kses_post' )->alias( fn ( string $html ): string => str_replace( '<script>bad</script>', '', $html ) );
+
+		$check = $this->fakeCheck( 'foo', Result::critical( 'Bad.', '<script>bad</script><a href="https://example.com">Docs</a>' ) );
+
+		$result = SiteHealthAdapter::toSiteHealthResult( $check );
+
+		$this->assertSame( '<a href="https://example.com">Docs</a>', $result['actions'] );
 	}
 
 	public function test_to_site_health_result_maps_result_to_wp_shape(): void {

--- a/tests/Unit/StarterBase/RegisterSiteHealthHooksTest.php
+++ b/tests/Unit/StarterBase/RegisterSiteHealthHooksTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\StarterBase;
+
+use Brain\Monkey\Functions;
+use Parisek\TimberKit\StarterBase;
+use Tests\Unit\StarterBaseTestCase;
+
+/**
+ * Verifies that registerSiteHealthHooks() respects the $site_health flag
+ * (off = default = no hooks; on = site_status_tests filter registered).
+ */
+class RegisterSiteHealthHooksTest extends StarterBaseTestCase {
+
+	private function invokeRegisterSiteHealthHooks( StarterBase $instance ): void {
+		$method = ( new \ReflectionClass( StarterBase::class ) )->getMethod( 'registerSiteHealthHooks' );
+		$method->invoke( $instance );
+	}
+
+	private function bareInstance( bool $site_health ): StarterBase {
+		$instance = ( new \ReflectionClass( StarterBase::class ) )->newInstanceWithoutConstructor();
+		$prop     = ( new \ReflectionClass( StarterBase::class ) )->getProperty( 'site_health' );
+		$prop->setValue( $instance, $site_health );
+		return $instance;
+	}
+
+	public function test_no_hooks_when_flag_off(): void {
+		$filters = [];
+		Functions\when( 'add_filter' )->alias( function ( $hook, ...$rest ) use ( &$filters ) {
+			$filters[] = $hook;
+		} );
+
+		$this->invokeRegisterSiteHealthHooks( $this->bareInstance( false ) );
+
+		$this->assertEmpty( $filters );
+	}
+
+	public function test_site_status_tests_filter_registered_when_flag_on(): void {
+		$filters = [];
+		Functions\when( 'add_filter' )->alias( function ( $hook, ...$rest ) use ( &$filters ) {
+			$filters[] = $hook;
+		} );
+
+		$this->invokeRegisterSiteHealthHooks( $this->bareInstance( true ) );
+
+		$this->assertSame( [ 'site_status_tests' ], $filters );
+	}
+}

--- a/tests/Unit/StarterBase/SiteHealthRegisterChecksTest.php
+++ b/tests/Unit/StarterBase/SiteHealthRegisterChecksTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\StarterBase;
+
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use Parisek\TimberKit\StarterBase;
+use Tests\Unit\StarterBaseTestCase;
+
+class SiteHealthRegisterChecksTest extends StarterBaseTestCase {
+
+	private const DEFAULT_IDS = [
+		'timber_kit_health_xmlrpc_disabled',
+		'timber_kit_health_wp_version_hidden',
+		'timber_kit_health_author_sitemap_disabled',
+		'timber_kit_health_file_editing_disabled',
+		'timber_kit_health_rest_users_restricted',
+	];
+
+	protected function setUp(): void {
+		parent::setUp();
+		Functions\when( '__' )->returnArg();
+	}
+
+	public function test_default_checks_land_in_direct_tests(): void {
+		$base = $this->createStarterBase();
+
+		$tests = $base->site_health_register_checks( [ 'direct' => [], 'async' => [] ] );
+
+		foreach ( self::DEFAULT_IDS as $id ) {
+			$this->assertArrayHasKey( $id, $tests['direct'] );
+		}
+	}
+
+	public function test_health_checks_override_can_drop_a_default(): void {
+		Functions\when( 'add_action' )->justReturn( true );
+		Functions\when( 'add_filter' )->justReturn( true );
+
+		$base = new class extends StarterBase {
+			public function __construct() {
+				// Skip parent constructor to avoid hook registration.
+			}
+			protected function health_checks( array $checks ): array {
+				unset( $checks['xmlrpc_disabled'] );
+				return $checks;
+			}
+		};
+
+		$tests = $base->site_health_register_checks( [ 'direct' => [], 'async' => [] ] );
+
+		$this->assertArrayNotHasKey( 'timber_kit_health_xmlrpc_disabled', $tests['direct'] );
+		$this->assertArrayHasKey( 'timber_kit_health_wp_version_hidden', $tests['direct'] );
+	}
+
+	public function test_filter_runs_after_override_and_can_replace_the_set(): void {
+		Filters\expectApplied( 'timber_kit_health_checks' )->once()->andReturn( [] );
+
+		$base = $this->createStarterBase();
+
+		$tests = $base->site_health_register_checks( [ 'direct' => [], 'async' => [] ] );
+
+		foreach ( self::DEFAULT_IDS as $id ) {
+			$this->assertArrayNotHasKey( $id, $tests['direct'] );
+		}
+	}
+
+	public function test_non_array_filter_return_is_tolerated(): void {
+		Filters\expectApplied( 'timber_kit_health_checks' )->once()->andReturn( 'garbage' );
+
+		$base = $this->createStarterBase();
+
+		$tests = $base->site_health_register_checks( [ 'direct' => [], 'async' => [] ] );
+
+		$this->assertSame( [], $tests['direct'] );
+	}
+}


### PR DESCRIPTION
Implements phase 1 of #41 per the design refinement comment (code-first configuration, read-only board).

## What

- New `Parisek\TimberKit\Health\` sub-namespace: `HealthCheck` interface (declares `effect`/`config`/`both` verification method), `Result` value object (static constructors only — invalid status unrepresentable), `CheckRegistry` (unique ids, throws on collision), `SiteHealthAdapter` (the only Site Health touchpoint).
- Five security checks: XML-RPC disabled, WP version hidden, author sitemap disabled, file editing disabled (config), REST users endpoint restricted (anonymous loopback probe).
- `StarterBase::$site_health` flag, default `false` (feature-flag doctrine). Wiring: defaults → `health_checks()` Base.php override (primary customization path, visible in project diffs) → `timber_kit_health_checks` filter (uniform low-level hook) → adapter.

## Read-only by design

The board never writes: no options page, no DB toggles, no remediation buttons. Expected state lives versioned in code; Site Health reports drift. "Actions" hints point to code fixes.

## Testing on a real project

In the project `Base` class set `protected bool $site_health = true;`, then open Tools → Site Health → Status. Five "Security" badged entries appear; the REST users check performs a loopback request (falls back to `recommended` with an explanation when loopbacks are blocked).

## Follow-ups (tracked in #41)

- `timber-kit` self-diagnostics category (version currency, deprecated API usage, flag inventory via `debug_information`)
- CLI adapter (`wp timber-kit health`) for CI gates + fleet sweeps
- Migrate the two existing ad-hoc Site Health tests (`warn_duplicate_security_headers`, `resizer_format_health`) onto the registry
- Remaining categories (caching / SEO / mail / performance / a11y)

Closes nothing — #41 stays open as the tracking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJHq7Gez1NRq46Q7dwvra6