### PR TITLE
feat(Health): utf8mb4 charset audit + selective convert-utf8mb4 command (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- utf8mb4 charset audit (phase 1+2 of #72): new `utf8mb4_tables` Site Health check (category `database`) auditing prefix-scoped tables via `information_schema` — non-utf8mb4 tables (incl. the `utf8`→utf8mb3 alias), column-collation overrides, mixed utf8mb4 collations — with the database's dominant utf8mb4 collation suggested as the convert target. Plus `wp timber-kit convert-utf8mb4`: dry-run by default, `--apply` refuses to run without an explicit `--tables=<csv>` selection (or a conscious `--all`), target collation is the dominant one already in the DB (never hardcoded, `--collate=` overrides), and COMPACT/REDUNDANT tables with long indexed columns are flagged behind `--force` (767-byte index-prefix limit). Analysis lives in pure, unit-tested `Health\Db\CharsetAudit` + `Health\Db\ConversionPlan`.
+
 ## [1.18.0] - 2026-07-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -177,6 +177,28 @@ per-environment tweaks. Custom checks implement `Health\HealthCheck` (`id`,
 `label`, `category`, `method`, `run(): Result`) and return
 `Result::good()` / `Result::recommended()` / `Result::critical()`.
 
+#### utf8mb4 charset audit + conversion
+
+The `utf8mb4_tables` check (category `database`) audits every prefix-scoped
+table via `information_schema`: non-utf8mb4 tables (plugin tables keep their
+install-time charset forever), column-collation overrides, and mixed utf8mb4
+collations — the classic source of *Illegal mix of collations* errors and
+silent `?` degradation of 4-byte characters (emoji, some CJK).
+
+Remediation is a separate, explicit WP-CLI command that **never converts
+implicitly** — `--apply` requires selecting concrete tables:
+
+```bash
+wp timber-kit convert-utf8mb4                                  # dry-run plan
+wp timber-kit convert-utf8mb4 --apply --tables=wp_foo,wp_bar   # convert exactly these
+wp timber-kit convert-utf8mb4 --apply --all                    # conscious full convert
+```
+
+The target collation is the **dominant utf8mb4 collation already present in
+the database** (majority vote, tie-break toward core tables; `--collate=`
+overrides). Tables with COMPACT/REDUNDANT row formats and long indexed
+columns are flagged (767-byte index-prefix limit) and require `--force`.
+
 ### WpmlBlockOverride
 
 Runtime override of Copy field values in ACF Gutenberg blocks for WPML-multilingual sites. Hooks `render_block_data` at priority 20 (after WPML's own handlers) and, for ACF blocks rendered in a non-default language, overwrites `attrs.data.<field>` for fields marked `wpml_cf_preferences = 1` (Copy) with the source-language post's value. Attachment IDs (image / file / gallery) are remapped to per-language duplicates via `wpml_object_id`.

--- a/src/Cli/ConvertUtf8mb4Command.php
+++ b/src/Cli/ConvertUtf8mb4Command.php
@@ -26,6 +26,9 @@ class ConvertUtf8mb4Command {
 	 *
 	 * ## OPTIONS
 	 *
+	 * [--dry-run]
+	 * : Explicit alias of the default behavior — print the plan, change nothing.
+	 *
 	 * [--apply]
 	 * : Execute the conversion. Without it the command is a dry-run and only
 	 *   prints the plan. Requires --tables or --all.
@@ -74,7 +77,12 @@ class ConvertUtf8mb4Command {
 			return;
 		}
 
-		$plan = new ConversionPlan( $audit, $this->indexedColumns(), $target );
+		try {
+			$plan = new ConversionPlan( $audit, $this->indexedColumns(), $target );
+		} catch ( \InvalidArgumentException $e ) {
+			\WP_CLI::error( $e->getMessage() );
+			return;
+		}
 
 		if ( null === $plan->targetCollation() ) {
 			\WP_CLI::error( 'No utf8mb4 baseline exists in this database — pass --collate=<collation> explicitly.' );
@@ -98,7 +106,8 @@ class ConvertUtf8mb4Command {
 
 		\WP_CLI::log( sprintf( 'Target collation: %s', (string) $plan->targetCollation() ) );
 		foreach ( $entries as $entry ) {
-			\WP_CLI::log( sprintf( '  %s: %s -> %s', $entry['table'], $entry['from'], $entry['to'] ) );
+			$note = '' !== $entry['note'] ? sprintf( ' [%s]', $entry['note'] ) : '';
+			\WP_CLI::log( sprintf( '  %s: %s -> %s%s', $entry['table'], $entry['from'], $entry['to'], $note ) );
 			if ( '' !== $entry['warning'] ) {
 				\WP_CLI::warning( sprintf( '  %s: %s', $entry['table'], $entry['warning'] ) );
 			}

--- a/src/Cli/ConvertUtf8mb4Command.php
+++ b/src/Cli/ConvertUtf8mb4Command.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit\Cli;
+
+use Parisek\TimberKit\Health\Check\Utf8mb4Tables;
+use Parisek\TimberKit\Health\Db\ConversionPlan;
+
+/**
+ * `wp timber-kit convert-utf8mb4` — convert charset-debt tables to the
+ * database's dominant utf8mb4 collation.
+ *
+ * Thin adapter over {@see ConversionPlan}: detection and planning live in
+ * unit-tested pure classes; the WP_CLI I/O here is intentionally not
+ * unit-tested (same doctrine as PruneOriginalsCommand).
+ *
+ * Conversion is NEVER implicit: `--apply` refuses to run without an explicit
+ * `--tables=<csv>` selection (or a conscious `--all`), and refuses tables
+ * carrying index-prefix warnings unless `--force` acknowledges them.
+ */
+class ConvertUtf8mb4Command {
+
+	/**
+	 * Audit table charsets and convert explicitly selected tables to utf8mb4.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--apply]
+	 * : Execute the conversion. Without it the command is a dry-run and only
+	 *   prints the plan. Requires --tables or --all.
+	 *
+	 * [--tables=<csv>]
+	 * : Comma-separated list of tables to convert. Only tables present in the
+	 *   dry-run plan are accepted; anything else aborts before any ALTER runs.
+	 *
+	 * [--all]
+	 * : Convert every table in the plan. Deliberately explicit — omitting a
+	 *   selection never means "everything".
+	 *
+	 * [--collate=<collation>]
+	 * : Target utf8mb4 collation override. Default: the dominant utf8mb4
+	 *   collation already present in the database (tie-break toward core
+	 *   tables) — never a hardcoded constant.
+	 *
+	 * [--force]
+	 * : Proceed even when selected tables carry index-prefix warnings
+	 *   (COMPACT/REDUNDANT row format with long indexed columns).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp timber-kit convert-utf8mb4
+	 *     wp timber-kit convert-utf8mb4 --apply --tables=wp_aryo_activity_log
+	 *     wp timber-kit convert-utf8mb4 --apply --all --force
+	 *
+	 * @param array<int, string>    $args       Positional args (unused).
+	 * @param array<string, string> $assoc_args Associative args.
+	 * @return void
+	 */
+	public function __invoke( $args, $assoc_args ) {
+		global $wpdb;
+
+		$apply  = isset( $assoc_args['apply'] );
+		$all    = isset( $assoc_args['all'] );
+		$force  = isset( $assoc_args['force'] );
+		$target = isset( $assoc_args['collate'] ) ? (string) $assoc_args['collate'] : null;
+		$tables = isset( $assoc_args['tables'] )
+			? array_values( array_filter( array_map( 'trim', explode( ',', (string) $assoc_args['tables'] ) ) ) )
+			: array();
+
+		$audit = ( new Utf8mb4Tables() )->audit();
+		if ( null === $audit ) {
+			\WP_CLI::error( 'Database connection unavailable.' );
+			return;
+		}
+
+		$plan = new ConversionPlan( $audit, $this->indexedColumns(), $target );
+
+		if ( null === $plan->targetCollation() ) {
+			\WP_CLI::error( 'No utf8mb4 baseline exists in this database — pass --collate=<collation> explicitly.' );
+			return;
+		}
+
+		if ( array() !== $tables ) {
+			try {
+				$plan = $plan->select( $tables );
+			} catch ( \InvalidArgumentException $e ) {
+				\WP_CLI::error( $e->getMessage() );
+				return;
+			}
+		}
+
+		$entries = $plan->entries();
+		if ( array() === $entries ) {
+			\WP_CLI::success( 'Nothing to convert — all tables already match the target collation.' );
+			return;
+		}
+
+		\WP_CLI::log( sprintf( 'Target collation: %s', (string) $plan->targetCollation() ) );
+		foreach ( $entries as $entry ) {
+			\WP_CLI::log( sprintf( '  %s: %s -> %s', $entry['table'], $entry['from'], $entry['to'] ) );
+			if ( '' !== $entry['warning'] ) {
+				\WP_CLI::warning( sprintf( '  %s: %s', $entry['table'], $entry['warning'] ) );
+			}
+		}
+
+		if ( ! $apply ) {
+			\WP_CLI::log( 'Dry-run only. Re-run with --apply --tables=<csv> (or --apply --all) to convert.' );
+			return;
+		}
+
+		// Selection is first-class: --apply never converts implicitly.
+		if ( array() === $tables && ! $all ) {
+			\WP_CLI::error( 'Refusing to convert without an explicit selection. Pass --tables=<csv> for the tables you actually want, or --all to consciously convert the whole plan.' );
+			return;
+		}
+
+		if ( $plan->hasWarnings() && ! $force ) {
+			\WP_CLI::error( 'Selected tables carry index-prefix warnings — review them, then acknowledge with --force.' );
+			return;
+		}
+
+		foreach ( $plan->statements() as $statement ) {
+			\WP_CLI::log( $statement );
+			if ( false === $wpdb->query( $statement ) ) { // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- identifiers from information_schema, no user input.
+				\WP_CLI::error( sprintf( 'ALTER failed: %s', (string) $wpdb->last_error ) );
+				return;
+			}
+		}
+
+		\WP_CLI::success( sprintf( 'Converted %d table(s) to %s.', count( $plan->statements() ), (string) $plan->targetCollation() ) );
+	}
+
+	/**
+	 * Indexed text columns (no index sub-part) with their character lengths,
+	 * for the 767-byte index-prefix warning on COMPACT/REDUNDANT tables.
+	 *
+	 * @return list<array{table_name: string, column_name: string, max_len: int|null, sub_part: int|null}>
+	 */
+	private function indexedColumns(): array {
+		global $wpdb;
+
+		$like = $wpdb->esc_like( $wpdb->prefix ) . '%';
+
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT s.TABLE_NAME AS table_name, s.COLUMN_NAME AS column_name,'
+				. ' c.CHARACTER_MAXIMUM_LENGTH AS max_len, s.SUB_PART AS sub_part'
+				. ' FROM information_schema.STATISTICS s'
+				. ' JOIN information_schema.COLUMNS c'
+				. '   ON c.TABLE_SCHEMA = s.TABLE_SCHEMA AND c.TABLE_NAME = s.TABLE_NAME AND c.COLUMN_NAME = s.COLUMN_NAME'
+				. ' WHERE s.TABLE_SCHEMA = DATABASE() AND c.CHARACTER_MAXIMUM_LENGTH IS NOT NULL AND s.TABLE_NAME LIKE %s',
+				$like
+			),
+			ARRAY_A
+		);
+
+		if ( ! is_array( $rows ) ) {
+			return array();
+		}
+
+		return array_values( array_map(
+			static fn ( array $row ): array => array(
+				'table_name'  => (string) $row['table_name'],
+				'column_name' => (string) $row['column_name'],
+				'max_len'     => null === $row['max_len'] ? null : (int) $row['max_len'],
+				'sub_part'    => null === $row['sub_part'] ? null : (int) $row['sub_part'],
+			),
+			$rows
+		) );
+	}
+}

--- a/src/Health/Check/Utf8mb4Tables.php
+++ b/src/Health/Check/Utf8mb4Tables.php
@@ -95,6 +95,10 @@ final class Utf8mb4Tables implements HealthCheck {
 			return null;
 		}
 
+		// Fail closed: a denied/failed information_schema query must surface
+		// as "could not inspect", never as an empty (= clean) audit.
+		$wpdb->last_error = '';
+
 		$like = $wpdb->esc_like( $wpdb->prefix ) . '%';
 
 		$tables = $wpdb->get_results(
@@ -116,6 +120,10 @@ final class Utf8mb4Tables implements HealthCheck {
 			),
 			ARRAY_A
 		);
+
+		if ( '' !== self::lastError( $wpdb ) ) {
+			return null;
+		}
 
 		$table_rows = array();
 		foreach ( is_array( $tables ) ? $tables : array() as $row ) {
@@ -141,7 +149,22 @@ final class Utf8mb4Tables implements HealthCheck {
 			);
 		}
 
+		// Zero visible tables cannot happen on a working WordPress install
+		// (core tables always match the prefix) — treat it as an inspection
+		// failure, not as a clean bill of health.
+		if ( array() === $table_rows ) {
+			return null;
+		}
+
 		return new CharsetAudit( $table_rows, $column_rows, $wpdb->prefix );
+	}
+
+	/**
+	 * Read last_error through a call boundary — get_results() mutates it,
+	 * which static analysis cannot see after the reset above.
+	 */
+	private static function lastError( \wpdb $wpdb ): string {
+		return (string) $wpdb->last_error;
 	}
 
 	/**

--- a/src/Health/Check/Utf8mb4Tables.php
+++ b/src/Health/Check/Utf8mb4Tables.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit\Health\Check;
+
+use Parisek\TimberKit\Health\Db\CharsetAudit;
+use Parisek\TimberKit\Health\HealthCheck;
+use Parisek\TimberKit\Health\Result;
+
+/**
+ * Config check over information_schema (cheap, synchronous, no plugin
+ * coupling): every prefix-scoped table should be utf8mb4 with one uniform
+ * collation. Plugin tables keep their install-time charset forever, so
+ * utf8mb3 stragglers are near-universal historical debt — they degrade
+ * 4-byte characters to `?` and produce "illegal mix of collations" in JOINs.
+ */
+final class Utf8mb4Tables implements HealthCheck {
+
+	public function id(): string {
+		return 'utf8mb4_tables';
+	}
+
+	public function label(): string {
+		return __( 'Database tables use utf8mb4', 'timber-kit' );
+	}
+
+	public function category(): string {
+		return 'database';
+	}
+
+	public function method(): string {
+		return self::METHOD_CONFIG;
+	}
+
+	public function run(): Result {
+		$audit = $this->audit();
+
+		if ( null === $audit ) {
+			return Result::recommended(
+				__( 'Could not inspect table charsets — the database connection is unavailable.', 'timber-kit' )
+			);
+		}
+
+		if ( $audit->clean() ) {
+			return Result::good( __( 'All tables use utf8mb4 with a uniform collation.', 'timber-kit' ) );
+		}
+
+		$problems = array();
+		foreach ( $audit->offendingTables() as $charset => $tables ) {
+			$problems[] = sprintf( '%s: %s', $charset, self::listTables( $tables ) );
+		}
+		if ( array() !== $audit->mixedCollations() ) {
+			$parts = array();
+			foreach ( $audit->mixedCollations() as $collation => $tables ) {
+				$parts[] = sprintf( '%s (%d)', $collation, count( $tables ) );
+			}
+			$problems[] = sprintf(
+				/* translators: %s: comma-separated list of collations with table counts. */
+				__( 'mixed utf8mb4 collations: %s', 'timber-kit' ),
+				implode( ', ', $parts )
+			);
+		}
+		foreach ( $audit->columnOverrides() as $override ) {
+			$problems[] = sprintf( '%s.%s (%s)', $override['table'], $override['column'], $override['collation'] );
+		}
+
+		$dominant = $audit->dominantCollation();
+		$hint     = null !== $dominant
+			? sprintf(
+				/* translators: %s: target collation. */
+				__( 'Suggested target: %s. Preview the conversion with `wp timber-kit convert-utf8mb4 --dry-run`; conversion only ever runs on explicitly selected tables.', 'timber-kit' ),
+				$dominant
+			)
+			: __( 'No utf8mb4 baseline exists — pick a target collation explicitly via `wp timber-kit convert-utf8mb4 --collate=<collation>`.', 'timber-kit' );
+
+		return Result::recommended(
+			sprintf(
+				/* translators: 1: found problems, 2: remediation hint. */
+				__( 'Charset debt found — %1$s. %2$s', 'timber-kit' ),
+				implode( '; ', $problems ),
+				$hint
+			)
+		);
+	}
+
+	/**
+	 * Read prefix-scoped table + text-column rows and build the audit.
+	 * Null when $wpdb is not available (non-WP context).
+	 */
+	public function audit(): ?CharsetAudit {
+		global $wpdb;
+
+		if ( ! isset( $wpdb ) || ! is_object( $wpdb ) ) {
+			return null;
+		}
+
+		$like = $wpdb->esc_like( $wpdb->prefix ) . '%';
+
+		$tables = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT TABLE_NAME AS name, TABLE_COLLATION AS collation, ROW_FORMAT AS row_format'
+				. ' FROM information_schema.TABLES'
+				. " WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE = 'BASE TABLE' AND TABLE_NAME LIKE %s",
+				$like
+			),
+			ARRAY_A
+		);
+
+		$columns = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT TABLE_NAME AS table_name, COLUMN_NAME AS column_name, COLLATION_NAME AS collation'
+				. ' FROM information_schema.COLUMNS'
+				. ' WHERE TABLE_SCHEMA = DATABASE() AND COLLATION_NAME IS NOT NULL AND TABLE_NAME LIKE %s',
+				$like
+			),
+			ARRAY_A
+		);
+
+		return new CharsetAudit(
+			is_array( $tables ) ? $tables : array(),
+			is_array( $columns ) ? $columns : array(),
+			(string) $wpdb->prefix
+		);
+	}
+
+	/**
+	 * @param list<string> $tables
+	 */
+	private static function listTables( array $tables ): string {
+		$shown = array_slice( $tables, 0, 10 );
+		$rest  = count( $tables ) - count( $shown );
+		return implode( ', ', $shown ) . ( $rest > 0 ? sprintf( ' (+%d)', $rest ) : '' );
+	}
+}

--- a/src/Health/Check/Utf8mb4Tables.php
+++ b/src/Health/Check/Utf8mb4Tables.php
@@ -91,7 +91,7 @@ final class Utf8mb4Tables implements HealthCheck {
 	public function audit(): ?CharsetAudit {
 		global $wpdb;
 
-		if ( ! isset( $wpdb ) || ! is_object( $wpdb ) ) {
+		if ( ! $wpdb instanceof \wpdb ) {
 			return null;
 		}
 
@@ -117,11 +117,31 @@ final class Utf8mb4Tables implements HealthCheck {
 			ARRAY_A
 		);
 
-		return new CharsetAudit(
-			is_array( $tables ) ? $tables : array(),
-			is_array( $columns ) ? $columns : array(),
-			(string) $wpdb->prefix
-		);
+		$table_rows = array();
+		foreach ( is_array( $tables ) ? $tables : array() as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			$table_rows[] = array(
+				'name'       => (string) ( $row['name'] ?? '' ),
+				'collation'  => (string) ( $row['collation'] ?? '' ),
+				'row_format' => (string) ( $row['row_format'] ?? '' ),
+			);
+		}
+
+		$column_rows = array();
+		foreach ( is_array( $columns ) ? $columns : array() as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			$column_rows[] = array(
+				'table_name'  => (string) ( $row['table_name'] ?? '' ),
+				'column_name' => (string) ( $row['column_name'] ?? '' ),
+				'collation'   => (string) ( $row['collation'] ?? '' ),
+			);
+		}
+
+		return new CharsetAudit( $table_rows, $column_rows, $wpdb->prefix );
 	}
 
 	/**

--- a/src/Health/Db/CharsetAudit.php
+++ b/src/Health/Db/CharsetAudit.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit\Health\Db;
+
+/**
+ * Pure charset/collation analysis over information_schema-shaped rows.
+ * No WordPress dependencies — the Utf8mb4Tables check and the conversion
+ * CLI feed it and stay thin, so all decision logic is unit-testable.
+ */
+final class CharsetAudit {
+
+	/**
+	 * Core WP table basenames (without prefix) used as the tie-break anchor
+	 * when two utf8mb4 collations are equally common: converting stragglers
+	 * to anything other than the core tables' collation just moves the
+	 * "illegal mix of collations" error around.
+	 */
+	private const CORE_TABLES = array(
+		'commentmeta',
+		'comments',
+		'links',
+		'options',
+		'postmeta',
+		'posts',
+		'term_relationships',
+		'term_taxonomy',
+		'termmeta',
+		'terms',
+		'usermeta',
+		'users',
+	);
+
+	/**
+	 * @param list<array{name: string, collation: string, row_format?: string}>            $tables  Table rows.
+	 * @param list<array{table_name: string, column_name: string, collation: string}>      $columns Text-column rows.
+	 * @param string                                                                       $prefix  WP table prefix.
+	 */
+	public function __construct(
+		private readonly array $tables,
+		private readonly array $columns,
+		private readonly string $prefix = 'wp_',
+	) {
+	}
+
+	public function clean(): bool {
+		return array() === $this->offendingTables()
+			&& array() === $this->columnOverrides()
+			&& array() === $this->mixedCollations();
+	}
+
+	/**
+	 * Tables whose charset is not utf8mb4, grouped by offending charset
+	 * (charset keys and table lists sorted for stable output).
+	 *
+	 * @return array<string, list<string>>
+	 */
+	public function offendingTables(): array {
+		$grouped = array();
+		foreach ( $this->tables as $table ) {
+			$charset = self::charsetOf( $table['collation'] );
+			if ( 'utf8mb4' === $charset ) {
+				continue;
+			}
+			$grouped[ $charset ][] = $table['name'];
+		}
+		ksort( $grouped );
+		foreach ( $grouped as &$names ) {
+			sort( $names );
+		}
+		return $grouped;
+	}
+
+	/**
+	 * Columns whose collation deviates from their table's default — these
+	 * survive a table-level CONVERT and are easy to miss.
+	 *
+	 * @return list<array{table: string, column: string, collation: string}>
+	 */
+	public function columnOverrides(): array {
+		$table_collations = array();
+		foreach ( $this->tables as $table ) {
+			$table_collations[ $table['name'] ] = $table['collation'];
+		}
+
+		$overrides = array();
+		foreach ( $this->columns as $column ) {
+			$table_default = $table_collations[ $column['table_name'] ] ?? null;
+			if ( null === $table_default || $column['collation'] === $table_default ) {
+				continue;
+			}
+			$overrides[] = array(
+				'table'     => $column['table_name'],
+				'column'    => $column['column_name'],
+				'collation' => $column['collation'],
+			);
+		}
+		return $overrides;
+	}
+
+	/**
+	 * When more than one utf8mb4 collation is in use, every collation with
+	 * its tables (sorted) — mixed collations produce "illegal mix" errors in
+	 * JOINs even when everything is already utf8mb4. Empty when uniform.
+	 *
+	 * @return array<string, list<string>>
+	 */
+	public function mixedCollations(): array {
+		$by_collation = array();
+		foreach ( $this->tables as $table ) {
+			if ( 'utf8mb4' !== self::charsetOf( $table['collation'] ) ) {
+				continue;
+			}
+			$by_collation[ $table['collation'] ][] = $table['name'];
+		}
+		if ( count( $by_collation ) < 2 ) {
+			return array();
+		}
+		ksort( $by_collation );
+		foreach ( $by_collation as &$names ) {
+			sort( $names );
+		}
+		return $by_collation;
+	}
+
+	/**
+	 * Suggested convert target: the utf8mb4 collation already used by most
+	 * tables; ties break toward the collation core WP tables use. Null when
+	 * no utf8mb4 baseline exists (caller must supply a target explicitly).
+	 */
+	public function dominantCollation(): ?string {
+		$counts = array();
+		$core   = array();
+		foreach ( $this->tables as $table ) {
+			$collation = $table['collation'];
+			if ( 'utf8mb4' !== self::charsetOf( $collation ) ) {
+				continue;
+			}
+			$counts[ $collation ] = ( $counts[ $collation ] ?? 0 ) + 1;
+			if ( $this->isCoreTable( $table['name'] ) ) {
+				$core[ $collation ] = ( $core[ $collation ] ?? 0 ) + 1;
+			}
+		}
+		if ( array() === $counts ) {
+			return null;
+		}
+
+		$max        = max( $counts );
+		$candidates = array_keys( $counts, $max, true );
+		if ( 1 === count( $candidates ) ) {
+			return $candidates[0];
+		}
+
+		usort( $candidates, function ( string $a, string $b ) use ( $core ): int {
+			return ( $core[ $b ] ?? 0 ) <=> ( $core[ $a ] ?? 0 );
+		} );
+		return $candidates[0];
+	}
+
+	private function isCoreTable( string $name ): bool {
+		foreach ( self::CORE_TABLES as $base ) {
+			if ( $name === $this->prefix . $base ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Charset component of a collation name ("utf8mb4_unicode_ci" → "utf8mb4").
+	 * MySQL/MariaDB report the pre-8.0 alias "utf8" for utf8mb3 — normalized
+	 * here so both spellings group under one key.
+	 */
+	private static function charsetOf( string $collation ): string {
+		$charset = strstr( $collation, '_', true );
+		$charset = false === $charset ? $collation : $charset;
+		return 'utf8' === $charset ? 'utf8mb3' : $charset;
+	}
+}

--- a/src/Health/Db/CharsetAudit.php
+++ b/src/Health/Db/CharsetAudit.php
@@ -44,6 +44,34 @@ final class CharsetAudit {
 	) {
 	}
 
+	/**
+	 * Table name → collation, for plan building.
+	 *
+	 * @return array<string, string>
+	 */
+	public function tableCollations(): array {
+		$map = array();
+		foreach ( $this->tables as $table ) {
+			$map[ $table['name'] ] = $table['collation'];
+		}
+		return $map;
+	}
+
+	/**
+	 * Table name → ROW_FORMAT (only where the source rows carried one).
+	 *
+	 * @return array<string, string>
+	 */
+	public function rowFormats(): array {
+		$map = array();
+		foreach ( $this->tables as $table ) {
+			if ( isset( $table['row_format'] ) ) {
+				$map[ $table['name'] ] = $table['row_format'];
+			}
+		}
+		return $map;
+	}
+
 	public function clean(): bool {
 		return array() === $this->offendingTables()
 			&& array() === $this->columnOverrides()

--- a/src/Health/Db/ConversionPlan.php
+++ b/src/Health/Db/ConversionPlan.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit\Health\Db;
+
+/**
+ * Pure conversion planning over a CharsetAudit. Selection is first-class:
+ * the CLI never converts implicitly — a plan is narrowed to explicitly
+ * requested tables via select() before statements() is executed.
+ */
+final class ConversionPlan {
+
+	/**
+	 * Below this VARCHAR length a utf8mb4 index always fits the 767-byte
+	 * limit of COMPACT/REDUNDANT InnoDB row formats (191 * 4 = 764).
+	 */
+	private const SAFE_INDEX_CHARS = 191;
+
+	/**
+	 * @param CharsetAudit                                                                              $audit   Source audit.
+	 * @param list<array{table_name: string, column_name: string, max_len: int|null, sub_part: int|null}> $indexed Indexed text-column rows.
+	 * @param string|null                                                                               $target  Explicit target collation (falls back to the audit's dominant).
+	 * @param list<string>|null                                                                         $selection Narrowed table set (null = all).
+	 */
+	public function __construct(
+		private readonly CharsetAudit $audit,
+		private readonly array $indexed = array(),
+		private readonly ?string $target = null,
+		private readonly ?array $selection = null,
+	) {
+	}
+
+	/**
+	 * The collation conversions will target: explicit override, else the
+	 * audit's dominant utf8mb4 collation. Null means the caller must pass
+	 * one explicitly (no utf8mb4 baseline in the database).
+	 */
+	public function targetCollation(): ?string {
+		return $this->target ?? $this->audit->dominantCollation();
+	}
+
+	/**
+	 * Plan rows, sorted by table name: every non-utf8mb4 table plus every
+	 * utf8mb4 table whose collation differs from the target. `warning` is a
+	 * non-empty sentence when the table's row format could hit the 767-byte
+	 * index-prefix limit after conversion, '' otherwise.
+	 *
+	 * @return list<array{table: string, from: string, to: string, warning: string}>
+	 */
+	public function entries(): array {
+		$target = $this->targetCollation();
+		if ( null === $target ) {
+			return array();
+		}
+
+		$entries = array();
+		foreach ( $this->audit->tableCollations() as $name => $collation ) {
+			if ( $collation === $target ) {
+				continue;
+			}
+			if ( null !== $this->selection && ! in_array( $name, $this->selection, true ) ) {
+				continue;
+			}
+			$entries[] = array(
+				'table'   => $name,
+				'from'    => $collation,
+				'to'      => $target,
+				'warning' => $this->warningFor( $name ),
+			);
+		}
+		usort( $entries, static fn ( array $a, array $b ): int => strcmp( $a['table'], $b['table'] ) );
+		return $entries;
+	}
+
+	/**
+	 * Narrow the plan to explicitly requested tables. Unknown names (not part
+	 * of this plan) throw so a typo can never silently convert nothing — or
+	 * the wrong thing.
+	 *
+	 * @param list<string> $tables
+	 */
+	public function select( array $tables ): self {
+		$known   = array_column( $this->entries(), 'table' );
+		$unknown = array_diff( $tables, $known );
+		if ( array() !== $unknown ) {
+			throw new \InvalidArgumentException(
+				sprintf( 'Not in the conversion plan: %s', implode( ', ', $unknown ) )
+			);
+		}
+		return new self( $this->audit, $this->indexed, $this->target, array_values( $tables ) );
+	}
+
+	public function hasWarnings(): bool {
+		foreach ( $this->entries() as $entry ) {
+			if ( '' !== $entry['warning'] ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * @return list<string>
+	 */
+	public function statements(): array {
+		$statements = array();
+		foreach ( $this->entries() as $entry ) {
+			$statements[] = sprintf(
+				'ALTER TABLE `%s` CONVERT TO CHARACTER SET utf8mb4 COLLATE %s',
+				$entry['table'],
+				$entry['to']
+			);
+		}
+		return $statements;
+	}
+
+	private function warningFor( string $table ): string {
+		$row_format = $this->audit->rowFormats()[ $table ] ?? '';
+		if ( ! in_array( strtoupper( $row_format ), array( 'COMPACT', 'REDUNDANT' ), true ) ) {
+			return '';
+		}
+		foreach ( $this->indexed as $index ) {
+			if ( $index['table_name'] !== $table ) {
+				continue;
+			}
+			if ( null !== $index['sub_part'] ) {
+				continue;
+			}
+			if ( null !== $index['max_len'] && $index['max_len'] > self::SAFE_INDEX_CHARS ) {
+				return sprintf(
+					'%s row format with indexed column `%s` (%d chars) may exceed the 767-byte index prefix limit under utf8mb4.',
+					strtoupper( $row_format ),
+					$index['column_name'],
+					$index['max_len']
+				);
+			}
+		}
+		return '';
+	}
+}

--- a/src/Health/Db/ConversionPlan.php
+++ b/src/Health/Db/ConversionPlan.php
@@ -29,6 +29,13 @@ final class ConversionPlan {
 		private readonly ?string $target = null,
 		private readonly ?array $selection = null,
 	) {
+		// The target lands raw in ALTER TABLE statements — reject anything
+		// that is not shaped like a utf8mb4 collation before any SQL exists.
+		if ( null !== $target && 1 !== preg_match( '/^utf8mb4_[a-z0-9_]+$/i', $target ) ) {
+			throw new \InvalidArgumentException(
+				sprintf( 'Not a utf8mb4 collation: %s', $target )
+			);
+		}
 	}
 
 	/**
@@ -41,12 +48,15 @@ final class ConversionPlan {
 	}
 
 	/**
-	 * Plan rows, sorted by table name: every non-utf8mb4 table plus every
-	 * utf8mb4 table whose collation differs from the target. `warning` is a
-	 * non-empty sentence when the table's row format could hit the 767-byte
-	 * index-prefix limit after conversion, '' otherwise.
+	 * Plan rows, sorted by table name: every table whose default collation
+	 * differs from the target, plus every table carrying a column-collation
+	 * override off the target (CONVERT TO rewrites all text columns, so a
+	 * table-level statement remediates both). `warning` is a non-empty
+	 * sentence when the table's row format could hit the 767-byte
+	 * index-prefix limit after conversion, '' otherwise; `note` flags
+	 * tables that are planned (also) because of column overrides.
 	 *
-	 * @return list<array{table: string, from: string, to: string, warning: string}>
+	 * @return list<array{table: string, from: string, to: string, warning: string, note: string}>
 	 */
 	public function entries(): array {
 		$target = $this->targetCollation();
@@ -54,9 +64,17 @@ final class ConversionPlan {
 			return array();
 		}
 
+		$override_tables = array();
+		foreach ( $this->audit->columnOverrides() as $override ) {
+			if ( $override['collation'] !== $target ) {
+				$override_tables[ $override['table'] ] = true;
+			}
+		}
+
 		$entries = array();
 		foreach ( $this->audit->tableCollations() as $name => $collation ) {
-			if ( $collation === $target ) {
+			$has_override = isset( $override_tables[ $name ] );
+			if ( $collation === $target && ! $has_override ) {
 				continue;
 			}
 			if ( null !== $this->selection && ! in_array( $name, $this->selection, true ) ) {
@@ -67,6 +85,7 @@ final class ConversionPlan {
 				'from'    => $collation,
 				'to'      => $target,
 				'warning' => $this->warningFor( $name ),
+				'note'    => $has_override ? 'column collation overrides' : '',
 			);
 		}
 		usort( $entries, static fn ( array $a, array $b ): int => strcmp( $a['table'], $b['table'] ) );
@@ -108,7 +127,7 @@ final class ConversionPlan {
 		foreach ( $this->entries() as $entry ) {
 			$statements[] = sprintf(
 				'ALTER TABLE `%s` CONVERT TO CHARACTER SET utf8mb4 COLLATE %s',
-				$entry['table'],
+				str_replace( '`', '``', $entry['table'] ),
 				$entry['to']
 			);
 		}

--- a/src/Health/SiteHealthAdapter.php
+++ b/src/Health/SiteHealthAdapter.php
@@ -85,6 +85,7 @@ final class SiteHealthAdapter {
 			'performance' => __( 'Performance', 'timber-kit' ),
 			'mail'        => __( 'Mail', 'timber-kit' ),
 			'a11y'        => __( 'Accessibility', 'timber-kit' ),
+			'database'    => __( 'Database', 'timber-kit' ),
 			'timber-kit'  => 'timber-kit',
 		);
 

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -26,6 +26,7 @@ use Parisek\TimberKit\BlockRenderer;
 use Parisek\TimberKit\Health\Check\AuthorSitemapDisabled;
 use Parisek\TimberKit\Health\Check\FileEditingDisabled;
 use Parisek\TimberKit\Health\Check\RestUsersRestricted;
+use Parisek\TimberKit\Health\Check\Utf8mb4Tables;
 use Parisek\TimberKit\Health\Check\WpVersionHidden;
 use Parisek\TimberKit\Health\Check\XmlrpcDisabled;
 use Parisek\TimberKit\Health\CheckRegistry;
@@ -503,6 +504,7 @@ class StarterBase extends Site {
 		}
 
 		\WP_CLI::add_command( 'timber-kit prune-originals', \Parisek\TimberKit\Cli\PruneOriginalsCommand::class );
+		\WP_CLI::add_command( 'timber-kit convert-utf8mb4', \Parisek\TimberKit\Cli\ConvertUtf8mb4Command::class );
 	}
 
 	/**
@@ -847,6 +849,7 @@ class StarterBase extends Site {
 			new AuthorSitemapDisabled(),
 			new FileEditingDisabled(),
 			new RestUsersRestricted(),
+			new Utf8mb4Tables(),
 		);
 	}
 

--- a/tests/Unit/Health/Check/Utf8mb4TablesTest.php
+++ b/tests/Unit/Health/Check/Utf8mb4TablesTest.php
@@ -29,6 +29,11 @@ class Utf8mb4TablesTest extends HealthTestCase {
 		$GLOBALS['wpdb'] = new class( $tables, $columns ) extends \wpdb {
 			public string $prefix = 'wp_';
 
+			public string $last_error = '';
+
+			/** Simulates a query failure: real wpdb sets last_error DURING the query. */
+			public string $error_on_query = '';
+
 			public function __construct(
 				private readonly array $tables,
 				private readonly array $columns,
@@ -44,6 +49,10 @@ class Utf8mb4TablesTest extends HealthTestCase {
 			}
 
 			public function get_results( string $query, string $output = 'OBJECT' ): array {
+				if ( '' !== $this->error_on_query ) {
+					$this->last_error = $this->error_on_query;
+					return [];
+				}
 				return str_contains( $query, 'information_schema.COLUMNS' ) ? $this->columns : $this->tables;
 			}
 		};
@@ -92,5 +101,25 @@ class Utf8mb4TablesTest extends HealthTestCase {
 		unset( $GLOBALS['wpdb'] );
 
 		$this->assertSame( 'recommended', ( new Utf8mb4Tables() )->run()->status() );
+	}
+
+	public function test_recommended_when_query_errors_instead_of_false_good(): void {
+		$this->stubWpdb( [
+			[ 'name' => 'wp_posts', 'collation' => 'utf8mb4_unicode_ci', 'row_format' => 'DYNAMIC' ],
+		] );
+		$GLOBALS['wpdb']->error_on_query = 'SELECT command denied';
+
+		$result = ( new Utf8mb4Tables() )->run();
+
+		$this->assertSame( 'recommended', $result->status() );
+		$this->assertStringContainsString( 'inspect', $result->summary() );
+	}
+
+	public function test_recommended_when_no_tables_visible(): void {
+		$this->stubWpdb( [] );
+
+		$result = ( new Utf8mb4Tables() )->run();
+
+		$this->assertSame( 'recommended', $result->status() );
 	}
 }

--- a/tests/Unit/Health/Check/Utf8mb4TablesTest.php
+++ b/tests/Unit/Health/Check/Utf8mb4TablesTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Health\Check;
+
+use Brain\Monkey\Functions;
+use Parisek\TimberKit\Health\Check\Utf8mb4Tables;
+use Parisek\TimberKit\Health\HealthCheck;
+use Tests\Unit\Health\HealthTestCase;
+
+class Utf8mb4TablesTest extends HealthTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Functions\when( '__' )->returnArg();
+	}
+
+	protected function tearDown(): void {
+		unset( $GLOBALS['wpdb'] );
+		parent::tearDown();
+	}
+
+	/**
+	 * @param list<array<string, string>> $tables
+	 * @param list<array<string, string>> $columns
+	 */
+	private function stubWpdb( array $tables, array $columns = [] ): void {
+		$GLOBALS['wpdb'] = new class( $tables, $columns ) {
+			public string $prefix = 'wp_';
+
+			public function __construct(
+				private readonly array $tables,
+				private readonly array $columns,
+			) {
+			}
+
+			public function esc_like( string $text ): string {
+				return addcslashes( $text, '_%\\' );
+			}
+
+			public function prepare( string $query, mixed ...$args ): string {
+				return vsprintf( str_replace( '%s', "'%s'", $query ), $args );
+			}
+
+			public function get_results( string $query, string $output = 'OBJECT' ): array {
+				return str_contains( $query, 'information_schema.COLUMNS' ) ? $this->columns : $this->tables;
+			}
+		};
+	}
+
+	public function test_identity(): void {
+		$check = new Utf8mb4Tables();
+
+		$this->assertSame( 'utf8mb4_tables', $check->id() );
+		$this->assertSame( 'database', $check->category() );
+		$this->assertSame( HealthCheck::METHOD_CONFIG, $check->method() );
+	}
+
+	public function test_good_when_all_tables_uniform_utf8mb4(): void {
+		$this->stubWpdb( [
+			[ 'name' => 'wp_posts', 'collation' => 'utf8mb4_unicode_ci', 'row_format' => 'DYNAMIC' ],
+			[ 'name' => 'wp_options', 'collation' => 'utf8mb4_unicode_ci', 'row_format' => 'DYNAMIC' ],
+		] );
+
+		$this->assertSame( 'good', ( new Utf8mb4Tables() )->run()->status() );
+	}
+
+	public function test_recommended_when_a_table_is_not_utf8mb4(): void {
+		$this->stubWpdb( [
+			[ 'name' => 'wp_posts', 'collation' => 'utf8mb4_unicode_ci', 'row_format' => 'DYNAMIC' ],
+			[ 'name' => 'wp_aryo_activity_log', 'collation' => 'utf8mb3_general_ci', 'row_format' => 'COMPACT' ],
+		] );
+
+		$result = ( new Utf8mb4Tables() )->run();
+
+		$this->assertSame( 'recommended', $result->status() );
+		$this->assertStringContainsString( 'wp_aryo_activity_log', $result->summary() );
+		$this->assertStringContainsString( 'utf8mb4_unicode_ci', $result->summary() );
+	}
+
+	public function test_recommended_when_collations_are_mixed(): void {
+		$this->stubWpdb( [
+			[ 'name' => 'wp_posts', 'collation' => 'utf8mb4_unicode_ci', 'row_format' => 'DYNAMIC' ],
+			[ 'name' => 'wp_straggler', 'collation' => 'utf8mb4_unicode_520_ci', 'row_format' => 'DYNAMIC' ],
+		] );
+
+		$this->assertSame( 'recommended', ( new Utf8mb4Tables() )->run()->status() );
+	}
+
+	public function test_recommended_when_wpdb_unavailable(): void {
+		unset( $GLOBALS['wpdb'] );
+
+		$this->assertSame( 'recommended', ( new Utf8mb4Tables() )->run()->status() );
+	}
+}

--- a/tests/Unit/Health/Check/Utf8mb4TablesTest.php
+++ b/tests/Unit/Health/Check/Utf8mb4TablesTest.php
@@ -26,7 +26,7 @@ class Utf8mb4TablesTest extends HealthTestCase {
 	 * @param list<array<string, string>> $columns
 	 */
 	private function stubWpdb( array $tables, array $columns = [] ): void {
-		$GLOBALS['wpdb'] = new class( $tables, $columns ) {
+		$GLOBALS['wpdb'] = new class( $tables, $columns ) extends \wpdb {
 			public string $prefix = 'wp_';
 
 			public function __construct(

--- a/tests/Unit/Health/Db/CharsetAuditTest.php
+++ b/tests/Unit/Health/Db/CharsetAuditTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Health\Db;
+
+use Parisek\TimberKit\Health\Db\CharsetAudit;
+use Tests\Unit\Health\HealthTestCase;
+
+class CharsetAuditTest extends HealthTestCase {
+
+	/**
+	 * @param list<array{name: string, collation: string, row_format?: string}> $tables
+	 * @param list<array{table_name: string, column_name: string, collation: string}> $columns
+	 */
+	private function audit( array $tables, array $columns = [], string $prefix = 'wp_' ): CharsetAudit {
+		return new CharsetAudit( $tables, $columns, $prefix );
+	}
+
+	public function test_clean_when_everything_is_uniform_utf8mb4(): void {
+		$audit = $this->audit( [
+			[ 'name' => 'wp_posts', 'collation' => 'utf8mb4_unicode_ci' ],
+			[ 'name' => 'wp_options', 'collation' => 'utf8mb4_unicode_ci' ],
+		] );
+
+		$this->assertTrue( $audit->clean() );
+		$this->assertSame( [], $audit->offendingTables() );
+		$this->assertSame( [], $audit->columnOverrides() );
+		$this->assertSame( [], $audit->mixedCollations() );
+		$this->assertSame( 'utf8mb4_unicode_ci', $audit->dominantCollation() );
+	}
+
+	public function test_non_utf8mb4_table_is_offending_grouped_by_charset(): void {
+		$audit = $this->audit( [
+			[ 'name' => 'wp_posts', 'collation' => 'utf8mb4_unicode_ci' ],
+			[ 'name' => 'wp_aryo_activity_log', 'collation' => 'utf8mb3_general_ci' ],
+			[ 'name' => 'wp_legacy', 'collation' => 'latin1_swedish_ci' ],
+		] );
+
+		$this->assertFalse( $audit->clean() );
+		$this->assertSame(
+			[
+				'latin1'  => [ 'wp_legacy' ],
+				'utf8mb3' => [ 'wp_aryo_activity_log' ],
+			],
+			$audit->offendingTables()
+		);
+	}
+
+	public function test_utf8_alias_counts_as_utf8mb3(): void {
+		$audit = $this->audit( [
+			[ 'name' => 'wp_old', 'collation' => 'utf8_general_ci' ],
+		] );
+
+		$this->assertSame( [ 'utf8mb3' => [ 'wp_old' ] ], $audit->offendingTables() );
+	}
+
+	public function test_column_collation_deviating_from_table_default_is_reported(): void {
+		$audit = $this->audit(
+			[ [ 'name' => 'wp_posts', 'collation' => 'utf8mb4_unicode_ci' ] ],
+			[
+				[ 'table_name' => 'wp_posts', 'column_name' => 'post_title', 'collation' => 'utf8mb4_unicode_ci' ],
+				[ 'table_name' => 'wp_posts', 'column_name' => 'guid', 'collation' => 'utf8mb3_general_ci' ],
+			]
+		);
+
+		$this->assertFalse( $audit->clean() );
+		$this->assertSame(
+			[ [ 'table' => 'wp_posts', 'column' => 'guid', 'collation' => 'utf8mb3_general_ci' ] ],
+			$audit->columnOverrides()
+		);
+	}
+
+	public function test_mixed_utf8mb4_collations_are_reported(): void {
+		$audit = $this->audit( [
+			[ 'name' => 'wp_posts', 'collation' => 'utf8mb4_unicode_ci' ],
+			[ 'name' => 'wp_options', 'collation' => 'utf8mb4_unicode_ci' ],
+			[ 'name' => 'wp_straggler', 'collation' => 'utf8mb4_unicode_520_ci' ],
+		] );
+
+		$this->assertFalse( $audit->clean() );
+		$this->assertSame(
+			[
+				'utf8mb4_unicode_520_ci' => [ 'wp_straggler' ],
+				'utf8mb4_unicode_ci'     => [ 'wp_options', 'wp_posts' ],
+			],
+			$audit->mixedCollations()
+		);
+	}
+
+	public function test_dominant_collation_is_majority_vote_over_utf8mb4_tables(): void {
+		$audit = $this->audit( [
+			[ 'name' => 'wp_a', 'collation' => 'utf8mb4_unicode_520_ci' ],
+			[ 'name' => 'wp_b', 'collation' => 'utf8mb4_unicode_520_ci' ],
+			[ 'name' => 'wp_posts', 'collation' => 'utf8mb4_unicode_ci' ],
+			[ 'name' => 'wp_old', 'collation' => 'utf8mb3_general_ci' ],
+		] );
+
+		$this->assertSame( 'utf8mb4_unicode_520_ci', $audit->dominantCollation() );
+	}
+
+	public function test_dominant_collation_tie_breaks_toward_core_tables(): void {
+		$audit = $this->audit( [
+			[ 'name' => 'wp_plugin_x', 'collation' => 'utf8mb4_unicode_520_ci' ],
+			[ 'name' => 'wp_posts', 'collation' => 'utf8mb4_unicode_ci' ],
+		] );
+
+		$this->assertSame( 'utf8mb4_unicode_ci', $audit->dominantCollation() );
+	}
+
+	public function test_dominant_collation_null_without_any_utf8mb4_table(): void {
+		$audit = $this->audit( [
+			[ 'name' => 'wp_old', 'collation' => 'utf8mb3_general_ci' ],
+		] );
+
+		$this->assertNull( $audit->dominantCollation() );
+	}
+}

--- a/tests/Unit/Health/Db/ConversionPlanTest.php
+++ b/tests/Unit/Health/Db/ConversionPlanTest.php
@@ -89,6 +89,44 @@ class ConversionPlanTest extends HealthTestCase {
 		);
 	}
 
+	public function test_table_with_only_column_overrides_is_planned(): void {
+		$audit = new CharsetAudit(
+			[ [ 'name' => 'wp_posts', 'collation' => 'utf8mb4_unicode_ci', 'row_format' => 'DYNAMIC' ] ],
+			[ [ 'table_name' => 'wp_posts', 'column_name' => 'guid', 'collation' => 'utf8mb3_general_ci' ] ],
+			'wp_'
+		);
+
+		$entries = ( new ConversionPlan( $audit ) )->entries();
+
+		$this->assertSame( [ 'wp_posts' ], array_column( $entries, 'table' ) );
+		$this->assertStringContainsString( 'column', $entries[0]['note'] );
+	}
+
+	public function test_explicit_non_utf8mb4_target_collation_is_rejected(): void {
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'latin1_swedish_ci' );
+
+		new ConversionPlan( $this->audit(), [], 'latin1_swedish_ci' );
+	}
+
+	public function test_statements_escape_backticks_in_table_names(): void {
+		$audit = new CharsetAudit(
+			[
+				[ 'name' => 'wp_posts', 'collation' => 'utf8mb4_unicode_ci', 'row_format' => 'DYNAMIC' ],
+				[ 'name' => 'wp_weird`name', 'collation' => 'utf8mb3_general_ci', 'row_format' => 'DYNAMIC' ],
+			],
+			[],
+			'wp_'
+		);
+
+		$statements = ( new ConversionPlan( $audit ) )->statements();
+
+		$this->assertSame(
+			[ 'ALTER TABLE `wp_weird``name` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci' ],
+			$statements
+		);
+	}
+
 	public function test_has_warnings_reflects_selected_entries_only(): void {
 		$plan = $this->plan( [
 			[ 'table_name' => 'wp_aryo_activity_log', 'column_name' => 'hist_ip', 'max_len' => 255, 'sub_part' => null ],

--- a/tests/Unit/Health/Db/ConversionPlanTest.php
+++ b/tests/Unit/Health/Db/ConversionPlanTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Health\Db;
+
+use Parisek\TimberKit\Health\Db\CharsetAudit;
+use Parisek\TimberKit\Health\Db\ConversionPlan;
+use Tests\Unit\Health\HealthTestCase;
+
+class ConversionPlanTest extends HealthTestCase {
+
+	private function audit(): CharsetAudit {
+		return new CharsetAudit(
+			[
+				[ 'name' => 'wp_posts', 'collation' => 'utf8mb4_unicode_ci', 'row_format' => 'DYNAMIC' ],
+				[ 'name' => 'wp_aryo_activity_log', 'collation' => 'utf8mb3_general_ci', 'row_format' => 'COMPACT' ],
+				[ 'name' => 'wp_legacy', 'collation' => 'latin1_swedish_ci', 'row_format' => 'DYNAMIC' ],
+				[ 'name' => 'wp_straggler', 'collation' => 'utf8mb4_unicode_520_ci', 'row_format' => 'DYNAMIC' ],
+			],
+			[],
+			'wp_'
+		);
+	}
+
+	/**
+	 * @param list<array{table_name: string, column_name: string, max_len: int|null, sub_part: int|null}> $indexed
+	 */
+	private function plan( array $indexed = [] ): ConversionPlan {
+		return new ConversionPlan( $this->audit(), $indexed );
+	}
+
+	public function test_entries_cover_offending_and_mixed_collation_tables(): void {
+		$entries = $this->plan()->entries();
+
+		$this->assertSame(
+			[ 'wp_aryo_activity_log', 'wp_legacy', 'wp_straggler' ],
+			array_column( $entries, 'table' )
+		);
+		$this->assertSame( 'utf8mb3_general_ci', $entries[0]['from'] );
+		$this->assertSame( 'utf8mb4_unicode_ci', $entries[0]['to'] );
+	}
+
+	public function test_explicit_target_collation_overrides_dominant(): void {
+		$plan = new ConversionPlan( $this->audit(), [], 'utf8mb4_czech_ci' );
+
+		$this->assertSame( 'utf8mb4_czech_ci', $plan->entries()[0]['to'] );
+	}
+
+	public function test_warning_for_compact_row_format_with_long_indexed_varchar(): void {
+		$entries = $this->plan( [
+			[ 'table_name' => 'wp_aryo_activity_log', 'column_name' => 'hist_ip', 'max_len' => 255, 'sub_part' => null ],
+		] )->entries();
+
+		$by_table = array_column( $entries, 'warning', 'table' );
+
+		$this->assertNotSame( '', $by_table['wp_aryo_activity_log'] );
+		$this->assertSame( '', $by_table['wp_legacy'] );
+	}
+
+	public function test_no_warning_when_index_has_prefix_or_short_column(): void {
+		$entries = $this->plan( [
+			[ 'table_name' => 'wp_aryo_activity_log', 'column_name' => 'a', 'max_len' => 255, 'sub_part' => 100 ],
+			[ 'table_name' => 'wp_aryo_activity_log', 'column_name' => 'b', 'max_len' => 100, 'sub_part' => null ],
+		] )->entries();
+
+		$by_table = array_column( $entries, 'warning', 'table' );
+
+		$this->assertSame( '', $by_table['wp_aryo_activity_log'] );
+	}
+
+	public function test_select_filters_entries_and_rejects_unknown_tables(): void {
+		$plan = $this->plan();
+
+		$selected = $plan->select( [ 'wp_legacy' ] );
+		$this->assertSame( [ 'wp_legacy' ], array_column( $selected->entries(), 'table' ) );
+
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'wp_nonexistent' );
+		$plan->select( [ 'wp_legacy', 'wp_nonexistent' ] );
+	}
+
+	public function test_statements_emit_convert_to_dominant_collation(): void {
+		$statements = $this->plan()->select( [ 'wp_aryo_activity_log' ] )->statements();
+
+		$this->assertSame(
+			[ 'ALTER TABLE `wp_aryo_activity_log` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci' ],
+			$statements
+		);
+	}
+
+	public function test_has_warnings_reflects_selected_entries_only(): void {
+		$plan = $this->plan( [
+			[ 'table_name' => 'wp_aryo_activity_log', 'column_name' => 'hist_ip', 'max_len' => 255, 'sub_part' => null ],
+		] );
+
+		$this->assertTrue( $plan->hasWarnings() );
+		$this->assertFalse( $plan->select( [ 'wp_legacy' ] )->hasWarnings() );
+	}
+}

--- a/tests/Unit/StarterBase/SiteHealthRegisterChecksTest.php
+++ b/tests/Unit/StarterBase/SiteHealthRegisterChecksTest.php
@@ -17,6 +17,7 @@ class SiteHealthRegisterChecksTest extends StarterBaseTestCase {
 		'timber_kit_health_author_sitemap_disabled',
 		'timber_kit_health_file_editing_disabled',
 		'timber_kit_health_rest_users_restricted',
+		'timber_kit_health_utf8mb4_tables',
 	];
 
 	protected function setUp(): void {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,6 +20,10 @@ if ( ! defined( 'DAY_IN_SECONDS' ) ) {
 	define( 'DAY_IN_SECONDS', 86400 );
 }
 
+if ( ! defined( 'ARRAY_A' ) ) {
+	define( 'ARRAY_A', 'ARRAY_A' );
+}
+
 // Lightweight `wp_strip_all_tags` stub so production code that calls it
 // directly (e.g. Helpers::readTime) works without per-test Brain Monkey
 // mocks that leak across test classes via Patchwork.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -24,6 +24,14 @@ if ( ! defined( 'ARRAY_A' ) ) {
 	define( 'ARRAY_A', 'ARRAY_A' );
 }
 
+// Minimal wpdb stub so production code can guard with `instanceof \wpdb`
+// (mirrors the WP_Post / WP_Term stub approach below).
+if ( ! class_exists( 'wpdb' ) ) {
+	#[\AllowDynamicProperties]
+	class wpdb {
+	}
+}
+
 // Lightweight `wp_strip_all_tags` stub so production code that calls it
 // directly (e.g. Helpers::readTime) works without per-test Brain Monkey
 // mocks that leak across test classes via Patchwork.


### PR DESCRIPTION
Implements #72 (phase 1 detection + phase 2 conversion) with the selectivity requirement from the follow-up design session: **conversion never runs implicitly** — `--apply` requires an explicit `--tables=<csv>` selection or a conscious `--all`.

## What

- `Health\Db\CharsetAudit` — pure analysis: offending tables grouped by charset (incl. the `utf8` → utf8mb3 alias), column-collation overrides, mixed utf8mb4 collations, dominant-collation vote (tie-break toward core tables).
- `Health\Db\ConversionPlan` — pure planning: entries (from → to), first-class `select()` (unknown table names throw before any ALTER), 767-byte index-prefix warnings for COMPACT/REDUNDANT row formats, `statements()`.
- `Health\Check\Utf8mb4Tables` — Site Health check (category `database`, `config` method) reading `information_schema`, prefix-scoped, synchronous. Joins the #41 registry as a default check.
- `Cli\ConvertUtf8mb4Command` — `wp timber-kit convert-utf8mb4`: dry-run by default; `--apply` + `--tables`/`--all`; `--collate=` override when no utf8mb4 baseline exists; warnings gate behind `--force`. Thin adapter, I/O untested per PruneOriginalsCommand doctrine.

## Safety model

1. Default invocation is always a dry-run plan.
2. `--apply` without an explicit selection errors out — omitting a selection never means "everything".
3. Unknown table names abort before any statement runs.
4. Target collation is the dominant one already present in the DB (never hardcoded) — converting stragglers to anything else just moves the illegal-mix error around.

## Testing

TDD throughout: 20 new unit tests over the pure core + check ($wpdb stubbed); PHPStan level 8 clean; both suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJHq7Gez1NRq46Q7dwvra6