### PR TITLE
feat: Breeze cache flush on nav menu save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- Full Breeze page-cache flush on nav menu save (#76): new `StarterBase::$clear_cache_on_menu_update` flag wiring `wp_update_nav_menu` → `clear_cache_on_menu_update()`, mirroring the existing options-save flush (`breeze_clear_all_cache`, guarded by `has_action()` so it no-ops without Breeze). Menus render on every page, so a site-wide flush is the correct scope. Default **on** — a deliberate exception to the default-off flag doctrine, consistent with the unconditional options-save flush it mirrors; opt out with `false` in the project's `Base`.
+
 ## [1.19.0] - 2026-07-11
 
 ### Added

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -350,6 +350,22 @@ class StarterBase extends Site {
 	protected bool $wpml_block_override = false;
 
 	/**
+	 * Clear the whole Breeze page cache when a nav menu is saved
+	 * (`wp_update_nav_menu`), mirroring the existing options-save behavior in
+	 * {@see clear_cache_on_options_save()}. Menus render on every page, so a
+	 * menu edit leaves the entire page cache stale — a full flush is the only
+	 * correct scope.
+	 *
+	 * Default ON — a deliberate exception to the default-off flag doctrine:
+	 * the options-save flush this mirrors runs unconditionally today, and a
+	 * stale menu on every cached page is strictly worse than one extra flush.
+	 * No-ops without Breeze. Opt out with `false` in the project's `Base`.
+	 *
+	 * @var bool
+	 */
+	protected bool $clear_cache_on_menu_update = true;
+
+	/**
 	 * ACF Datastore ({@see https://www.advancedcustomfields.com/resources/acf-settings-enable_datastore/}).
 	 *
 	 * Opt-in (default off). Switches how ACF saves field values — through the
@@ -658,6 +674,9 @@ class StarterBase extends Site {
 		add_filter( 'run_wptexturize', '__return_false' );
 		// CF7 autop disable
 		add_filter( 'wpcf7_autop_or_not', '__return_false' );
+		if ( $this->clear_cache_on_menu_update ) {
+			add_action( 'wp_update_nav_menu', array( $this, 'clear_cache_on_menu_update' ) );
+		}
 	}
 
 	/**
@@ -2155,6 +2174,24 @@ class StarterBase extends Site {
 			return;
 		}
 
+		if ( has_action( 'breeze_clear_all_cache' ) ) {
+			do_action( 'breeze_clear_all_cache' );
+		}
+	}
+
+	/**
+	 * Clear Breeze cache when a nav menu is saved.
+	 *
+	 * Menus render on every page, so the flush is intentionally site-wide —
+	 * same scope as {@see clear_cache_on_options_save()}. Gated behind the
+	 * `$clear_cache_on_menu_update` flag (default on).
+	 *
+	 * Hooked to `wp_update_nav_menu`.
+	 *
+	 * @param int $menu_id The saved menu's ID (unused — flush is site-wide).
+	 * @return void
+	 */
+	public function clear_cache_on_menu_update( $menu_id ) {
 		if ( has_action( 'breeze_clear_all_cache' ) ) {
 			do_action( 'breeze_clear_all_cache' );
 		}

--- a/tests/Unit/StarterBase/ClearCacheOnMenuUpdateTest.php
+++ b/tests/Unit/StarterBase/ClearCacheOnMenuUpdateTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\StarterBase;
+
+use Brain\Monkey\Functions;
+use Tests\Unit\StarterBaseTestCase;
+
+class ClearCacheOnMenuUpdateTest extends StarterBaseTestCase {
+
+	private \Parisek\TimberKit\StarterBase $base;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->base = $this->createStarterBase();
+	}
+
+	public function test_clears_cache_on_menu_update(): void {
+		Functions\when( 'has_action' )->justReturn( true );
+		$dispatched = [];
+		Functions\when( 'do_action' )->alias( function ( $action ) use ( &$dispatched ) {
+			$dispatched[] = $action;
+		} );
+
+		$this->base->clear_cache_on_menu_update( 5 );
+
+		$this->assertContains( 'breeze_clear_all_cache', $dispatched );
+	}
+
+	public function test_skips_when_breeze_not_active(): void {
+		Functions\when( 'has_action' )->justReturn( false );
+		$dispatched = [];
+		Functions\when( 'do_action' )->alias( function ( $action ) use ( &$dispatched ) {
+			$dispatched[] = $action;
+		} );
+
+		$this->base->clear_cache_on_menu_update( 5 );
+
+		$this->assertEmpty( $dispatched );
+	}
+}

--- a/tests/Unit/StarterBase/RegisterMiscHooksTest.php
+++ b/tests/Unit/StarterBase/RegisterMiscHooksTest.php
@@ -47,6 +47,40 @@ class RegisterMiscHooksTest extends StarterBaseTestCase {
 		$this->assertSame( '__return_false', $callbacks['wpcf7_autop_or_not'] );
 	}
 
+	public function test_registers_menu_cache_clear_by_default(): void {
+		$actions = [];
+		Functions\when( 'add_action' )->alias( function ( $hook, $callback, ...$rest ) use ( &$actions ) {
+			$actions[] = [ 'hook' => $hook, 'callback' => $callback ];
+		} );
+		Functions\when( 'add_filter' )->justReturn( true );
+
+		$this->invokeRegisterMiscHooks( $this->bareInstance() );
+
+		$menuActions = array_filter(
+			$actions,
+			fn( $a ) => $a['hook'] === 'wp_update_nav_menu'
+				&& is_array( $a['callback'] )
+				&& $a['callback'][1] === 'clear_cache_on_menu_update'
+		);
+		$this->assertCount( 1, $menuActions );
+	}
+
+	public function test_does_not_register_menu_cache_clear_when_flag_disabled(): void {
+		$actions = [];
+		Functions\when( 'add_action' )->alias( function ( $hook, $callback, ...$rest ) use ( &$actions ) {
+			$actions[] = [ 'hook' => $hook, 'callback' => $callback ];
+		} );
+		Functions\when( 'add_filter' )->justReturn( true );
+
+		$instance = $this->bareInstance();
+		$prop     = new \ReflectionProperty( StarterBase::class, 'clear_cache_on_menu_update' );
+		$prop->setValue( $instance, false );
+
+		$this->invokeRegisterMiscHooks( $instance );
+
+		$this->assertNotContains( 'wp_update_nav_menu', array_column( $actions, 'hook' ) );
+	}
+
 	public function test_registers_exactly_two_filters(): void {
 		$filters = [];
 		Functions\when( 'add_filter' )->alias( function ( $hook, ...$rest ) use ( &$filters ) {


### PR DESCRIPTION
## Summary
- Adds `StarterBase::$clear_cache_on_menu_update` flag (default ON — a deliberate exception to the default-off doctrine, mirroring the unconditional options-save flush), wiring `wp_update_nav_menu` to `clear_cache_on_menu_update()`.
- `clear_cache_on_menu_update()` fires `breeze_clear_all_cache`, guarded by `has_action()` so it no-ops without Breeze installed.
- Menus render on every page, so a site-wide cache flush is the correct scope when a nav menu is saved.

Closes #76

## Test plan
- `ClearCacheOnMenuUpdateTest`: verifies cache flush fires, and no-ops without Breeze.
- `RegisterMiscHooksTest`: verifies the hook is wired by default, and not wired when the flag is disabled.
- Full suite: 914 tests green.
- PHPStan level 8: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)