### PR TITLE
feat: split bare codecs string from mime type in the video source API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Video source API redesigned: bare `codecs` split from the mime type** (supersedes the 1.20.0 API, which had no consumers). `Helpers::videoSourceType()` (combined `video/mp4; codecs="…"` string) is replaced by `Helpers::videoCodecs()` returning the bare RFC 6381 string (`av01.0.01M.08`) or null; `VideoCodecs::sourceType()` is renamed to `VideoCodecs::codecsString()` and returns the bare value. `Helpers::formatVideoSources()` entries are now `{src, type, codecs}` with `type` a plain comparable mime. Rationale: the mime stays printable in double-quoted attributes and comparable in templates, and the codecs value is independently inspectable; templates compose `type='{{ type }}{% if codecs %}; codecs="{{ codecs }}"{% endif %}'`. Attachment-meta cache key moves to `_timber_kit_video_codecs` (`none` sentinel for negative results).
+
 ## [1.20.0] - 2026-07-14
 
 ### Added

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -241,58 +241,52 @@ class Helpers {
 	}
 
 	/**
-	 * Resolve a video attachment's `<source type>` value.
+	 * Resolve a video attachment's bare RFC 6381 codecs string.
 	 *
-	 * AV1 MP4 attachments include their RFC 6381 codec string when it can be
-	 * derived from the local file. Other videos fall back to their stored
-	 * WordPress/ACF mime type, then `video/mp4`.
+	 * Returns e.g. `av01.0.01M.08` for AV1 MP4 attachments (derived from the
+	 * file's `av1C` box), or null when no codecs string applies (non-AV1 MP4,
+	 * WebM, unresolvable file). Deliberately separate from the mime type: the
+	 * mime stays a plain comparable value and the codecs value stays
+	 * independently inspectable; templates compose the attribute themselves —
+	 * `type='video/mp4; codecs="…"'`, single-quoted because the composed
+	 * value embeds double quotes.
 	 *
-	 * The computed value is cached in attachment meta on first use. This v1
-	 * cache is intentionally simple: replacing the underlying file does not
-	 * invalidate the meta automatically, so callers must clear
-	 * `_timber_kit_video_source_type` when regenerating attachments in place.
+	 * The computed value is cached in attachment meta on first use (`none`
+	 * sentinel for negative results). This v1 cache is intentionally simple:
+	 * replacing the underlying file does not invalidate the meta
+	 * automatically, so callers must clear `_timber_kit_video_codecs` when
+	 * regenerating attachments in place.
 	 *
 	 * @param int|array<string,mixed> $attachment Attachment ID or ACF file-field array.
 	 */
-	public static function videoSourceType( int|array $attachment ): string {
+	public static function videoCodecs( int|array $attachment ): ?string {
 		$attachment_id = is_int( $attachment ) ? $attachment : ( isset( $attachment['ID'] ) && is_numeric( $attachment['ID'] ) ? (int) $attachment['ID'] : 0 );
-		$array_mime = is_array( $attachment ) && isset( $attachment['mime_type'] ) ? (string) $attachment['mime_type'] : '';
-
-		if ( $attachment_id > 0 ) {
-			$cached = get_post_meta( $attachment_id, '_timber_kit_video_source_type', true );
-			if ( is_string( $cached ) && '' !== $cached ) {
-				return $cached;
-			}
+		if ( $attachment_id <= 0 ) {
+			return null;
 		}
 
-		$path = $attachment_id > 0 ? get_attached_file( $attachment_id ) : false;
-		$type = is_string( $path ) ? VideoCodecs::sourceType( $path ) : null;
-
-		if ( null === $type ) {
-			$type = '' !== $array_mime ? $array_mime : '';
+		$cached = get_post_meta( $attachment_id, '_timber_kit_video_codecs', true );
+		if ( is_string( $cached ) && '' !== $cached ) {
+			return 'none' === $cached ? null : $cached;
 		}
 
-		if ( '' === $type && $attachment_id > 0 ) {
-			$post_mime = get_post_mime_type( $attachment_id );
-			$type = is_string( $post_mime ) && '' !== $post_mime ? $post_mime : '';
-		}
+		$path = get_attached_file( $attachment_id );
+		$codecs = is_string( $path ) ? VideoCodecs::codecsString( $path ) : null;
 
-		if ( '' === $type ) {
-			$type = 'video/mp4';
-		}
+		update_post_meta( $attachment_id, '_timber_kit_video_codecs', $codecs ?? 'none' );
 
-		if ( $attachment_id > 0 ) {
-			update_post_meta( $attachment_id, '_timber_kit_video_source_type', $type );
-		}
-
-		return $type;
+		return $codecs;
 	}
 
 	/**
 	 * Normalise ordered ACF video variants into `<source>` dictionaries.
 	 *
+	 * `type` is the variant's plain mime (default `video/mp4`); `codecs` is
+	 * the bare RFC 6381 string from {@see videoCodecs()} or null. Templates
+	 * compose the attribute: `type='{{ type }}{% if codecs %}; codecs="{{ codecs }}"{% endif %}'`.
+	 *
 	 * @param array<int, array<string,mixed>|null|false> $variants Ordered ACF file arrays.
-	 * @return array<int, array{src: string, type: string}>
+	 * @return array<int, array{src: string, type: string, codecs: string|null}>
 	 */
 	public static function formatVideoSources( array $variants ): array {
 		$sources = [];
@@ -302,9 +296,12 @@ class Helpers {
 				continue;
 			}
 
+			$mime = isset( $variant['mime_type'] ) && '' !== (string) $variant['mime_type'] ? (string) $variant['mime_type'] : 'video/mp4';
+
 			$sources[] = [
 				'src' => (string) $variant['url'],
-				'type' => self::videoSourceType( $variant ),
+				'type' => $mime,
+				'codecs' => self::videoCodecs( $variant ),
 			];
 		}
 

--- a/src/VideoCodecs.php
+++ b/src/VideoCodecs.php
@@ -11,16 +11,21 @@ declare(strict_types=1);
 namespace Parisek\TimberKit;
 
 /**
- * Derives RFC 6381 video source type strings from local media files.
+ * Derives bare RFC 6381 codecs strings from local media files.
  */
 class VideoCodecs {
 
 	private const AV1_CONFIGURATION_BOX_BYTES = 4;
 
 	/**
-	 * Parse a local video file and return a source `type` value when known.
+	 * Parse a local video file and return its bare codecs string when known.
+	 *
+	 * Returns e.g. `av01.0.01M.08` for AV1-in-MP4; null for anything the
+	 * parser doesn't cover (non-AV1 MP4, WebM, unreadable/garbage input).
+	 * Callers compose the `<source type>` attribute themselves:
+	 * `video/mp4; codecs="<value>"`.
 	 */
-	public static function sourceType( string $path ): ?string {
+	public static function codecsString( string $path ): ?string {
 		if ( ! is_file( $path ) || ! is_readable( $path ) ) {
 			return null;
 		}
@@ -127,7 +132,7 @@ class VideoCodecs {
 		$depth = ! $high_bitdepth ? '08' : ( $twelve_bit ? '12' : '10' );
 
 		return sprintf(
-			'video/mp4; codecs="av01.%d.%02d%s.%s"',
+			'av01.%d.%02d%s.%s',
 			$seq_profile,
 			$seq_level_idx_0,
 			$seq_tier_0 ? 'H' : 'M',

--- a/tests/Unit/Helpers/VideoCodecsHelperTest.php
+++ b/tests/Unit/Helpers/VideoCodecsHelperTest.php
@@ -8,19 +8,30 @@ use Brain\Monkey\Functions;
 use Parisek\TimberKit\Helpers;
 use Tests\Unit\HelpersTestCase;
 
-class VideoSourceTypeTest extends HelpersTestCase {
+class VideoCodecsHelperTest extends HelpersTestCase {
 
-	private const CACHE_KEY = '_timber_kit_video_source_type';
+	private const CACHE_KEY = '_timber_kit_video_codecs';
 
-	public function test_cache_hit_returns_stored_source_type_without_recompute(): void {
+	public function test_cache_hit_returns_stored_codecs_without_recompute(): void {
 		Functions\expect( 'get_post_meta' )
 			->once()
 			->with( 10, self::CACHE_KEY, true )
-			->andReturn( 'video/mp4; codecs="av01.0.00M.08"' );
+			->andReturn( 'av01.0.00M.08' );
 		Functions\expect( 'get_attached_file' )->never();
 		Functions\expect( 'update_post_meta' )->never();
 
-		$this->assertSame( 'video/mp4; codecs="av01.0.00M.08"', Helpers::videoSourceType( 10 ) );
+		$this->assertSame( 'av01.0.00M.08', Helpers::videoCodecs( 10 ) );
+	}
+
+	public function test_cached_none_sentinel_maps_to_null_without_recompute(): void {
+		Functions\expect( 'get_post_meta' )
+			->once()
+			->with( 14, self::CACHE_KEY, true )
+			->andReturn( 'none' );
+		Functions\expect( 'get_attached_file' )->never();
+		Functions\expect( 'update_post_meta' )->never();
+
+		$this->assertNull( Helpers::videoCodecs( 14 ) );
 	}
 
 	public function test_cache_miss_computes_and_stores_parser_result_for_id(): void {
@@ -31,15 +42,14 @@ class VideoSourceTypeTest extends HelpersTestCase {
 			->with( 11, self::CACHE_KEY, true )
 			->andReturn( '' );
 		Functions\expect( 'get_attached_file' )->once()->with( 11 )->andReturn( $path );
-		Functions\expect( 'get_post_mime_type' )->never();
 		Functions\expect( 'update_post_meta' )
 			->once()
-			->with( 11, self::CACHE_KEY, 'video/mp4; codecs="av01.0.00M.10"' );
+			->with( 11, self::CACHE_KEY, 'av01.0.00M.10' );
 
-		$this->assertSame( 'video/mp4; codecs="av01.0.00M.10"', Helpers::videoSourceType( 11 ) );
+		$this->assertSame( 'av01.0.00M.10', Helpers::videoCodecs( 11 ) );
 	}
 
-	public function test_array_input_uses_array_mime_as_fallback_and_stores_it(): void {
+	public function test_non_av1_file_returns_null_and_stores_none_sentinel(): void {
 		$attachment = [
 			'ID' => 12,
 			'url' => 'https://example.test/uploads/h264.mp4',
@@ -54,30 +64,26 @@ class VideoSourceTypeTest extends HelpersTestCase {
 			->once()
 			->with( 12 )
 			->andReturn( dirname( __DIR__, 2 ) . '/Fixtures/video/h264.mp4' );
-		Functions\expect( 'get_post_mime_type' )->never();
-		Functions\expect( 'update_post_meta' )->once()->with( 12, self::CACHE_KEY, 'video/mp4' );
+		Functions\expect( 'update_post_meta' )->once()->with( 12, self::CACHE_KEY, 'none' );
 
-		$this->assertSame( 'video/mp4', Helpers::videoSourceType( $attachment ) );
+		$this->assertNull( Helpers::videoCodecs( $attachment ) );
 	}
 
-	public function test_id_input_falls_back_to_post_mime_and_then_default(): void {
-		Functions\expect( 'get_post_meta' )
-			->once()
-			->with( 13, self::CACHE_KEY, true )
-			->andReturn( [] );
-		Functions\expect( 'get_attached_file' )->once()->with( 13 )->andReturn( false );
-		Functions\expect( 'get_post_mime_type' )->once()->with( 13 )->andReturn( false );
-		Functions\expect( 'update_post_meta' )->once()->with( 13, self::CACHE_KEY, 'video/mp4' );
+	public function test_input_without_resolvable_id_returns_null_without_meta_access(): void {
+		Functions\expect( 'get_post_meta' )->never();
+		Functions\expect( 'get_attached_file' )->never();
+		Functions\expect( 'update_post_meta' )->never();
 
-		$this->assertSame( 'video/mp4', Helpers::videoSourceType( 13 ) );
+		$this->assertNull( Helpers::videoCodecs( [ 'url' => 'https://example.test/uploads/no-id.mp4' ] ) );
+		$this->assertNull( Helpers::videoCodecs( 0 ) );
 	}
 
-	public function test_format_video_sources_preserves_order_and_drops_empty_items(): void {
+	public function test_format_video_sources_preserves_order_drops_empty_and_splits_type_from_codecs(): void {
 		$variants = [
 			null,
 			[
 				'ID' => 21,
-				'url' => 'https://example.test/uploads/desktop.mp4',
+				'url' => 'https://example.test/uploads/desktop-av1.mp4',
 				'mime_type' => 'video/mp4',
 			],
 			[],
@@ -102,12 +108,14 @@ class VideoSourceTypeTest extends HelpersTestCase {
 		$this->assertSame(
 			[
 				[
-					'src' => 'https://example.test/uploads/desktop.mp4',
-					'type' => 'video/mp4; codecs="av01.0.00M.08"',
+					'src' => 'https://example.test/uploads/desktop-av1.mp4',
+					'type' => 'video/mp4',
+					'codecs' => 'av01.0.00M.08',
 				],
 				[
 					'src' => 'https://example.test/uploads/mobile.webm',
 					'type' => 'video/webm',
+					'codecs' => null,
 				],
 			],
 			Helpers::formatVideoSources( $variants )

--- a/tests/Unit/VideoCodecsTest.php
+++ b/tests/Unit/VideoCodecsTest.php
@@ -15,8 +15,8 @@ class VideoCodecsTest extends TestCase {
 	 */
 	public static function provideFixtureCodecs(): array {
 		return [
-			'av1 8-bit mp4' => [ 'av1-8bit.mp4', 'video/mp4; codecs="av01.0.00M.08"' ],
-			'av1 10-bit mp4' => [ 'av1-10bit.mp4', 'video/mp4; codecs="av01.0.00M.10"' ],
+			'av1 8-bit mp4' => [ 'av1-8bit.mp4', 'av01.0.00M.08' ],
+			'av1 10-bit mp4' => [ 'av1-10bit.mp4', 'av01.0.00M.10' ],
 			'h264 mp4' => [ 'h264.mp4', null ],
 			'av1 webm' => [ 'av1.webm', null ],
 			'truncated mp4' => [ 'truncated.mp4', null ],
@@ -27,7 +27,7 @@ class VideoCodecsTest extends TestCase {
 	public function test_parses_fixture_codecs( string $filename, ?string $expected ): void {
 		$this->assertSame(
 			$expected,
-			VideoCodecs::sourceType( dirname( __DIR__ ) . '/Fixtures/video/' . $filename )
+			VideoCodecs::codecsString( dirname( __DIR__ ) . '/Fixtures/video/' . $filename )
 		);
 	}
 
@@ -38,8 +38,8 @@ class VideoCodecsTest extends TestCase {
 		} );
 
 		try {
-			$this->assertNull( VideoCodecs::sourceType( dirname( __DIR__ ) . '/Fixtures/video/missing.mp4' ) );
-			$this->assertNull( VideoCodecs::sourceType( __FILE__ ) );
+			$this->assertNull( VideoCodecs::codecsString( dirname( __DIR__ ) . '/Fixtures/video/missing.mp4' ) );
+			$this->assertNull( VideoCodecs::codecsString( __FILE__ ) );
 		} finally {
 			restore_error_handler();
 			error_reporting( $prevLevel );


### PR DESCRIPTION
Redesigns the video source API introduced in 1.20.0 (#81) while it has no consumers — parisek/timber-kit#82 discussion follow-up.

## Summary
- `Helpers::videoCodecs( int|array ): ?string` replaces `Helpers::videoSourceType()` — returns the bare RFC 6381 codecs string (`av01.0.01M.08`) or null; meta-cached under `_timber_kit_video_codecs` with a `none` sentinel for negatives.
- `VideoCodecs::codecsString()` replaces `VideoCodecs::sourceType()` — pure parser now returns the bare value.
- `Helpers::formatVideoSources()` entries are `{src, type, codecs}`: `type` stays a plain comparable mime (safe in double-quoted attributes), `codecs` is separately inspectable.
- Templates compose the attribute: `type='{{ type }}{% if codecs %}; codecs="{{ codecs }}"{% endif %}'`.

## Why
Keeping the codecs inside `type` broke `type == 'video/mp4'` comparisons and double-quoted attributes (embedded quotes) — both hit in mairateam. Splitting removes those hazards and makes the codec value checkable as data.

## Verification
- `composer test`: 972 tests, 1730 assertions, green, notice/deprecation-free
- `composer phpstan`: level 8, no errors

1.20.0's `videoSourceType` had zero consumers (verified — only mairateam's open PR, updated in lockstep), so this ships as a MINOR with an explicit changelog note rather than a major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8i5DsHnZ2LEuDjS1DDpBr