### PR TITLE
feat: Drupal-style update runner — component-level data migrations with run-once registry (wp timber-kit updates)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- Drupal-style update runner (`wp timber-kit updates status|run`) for run-once content/data migrations discovered from theme-wide and component-local `updates/NNNN-slug.php` files. Updates use `<component>:<NNNN>` ids, record completions in the autoload-off `timber_kit_updates_applied` option, support `--dry-run`, `--component`, and `--only`, and include WPML-aware block transforms that fan out across translations; intended as the WordPress/Timber `drush updb` analog for deploy-time data shape changes.
+
 ## [1.21.0] - 2026-07-14
 
 ### Changed

--- a/src/Cli/UpdatesCommand.php
+++ b/src/Cli/UpdatesCommand.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit\Cli;
+
+use Parisek\TimberKit\Updates\UpdateDiscovery;
+use Parisek\TimberKit\Updates\UpdateRegistry;
+use Parisek\TimberKit\Updates\UpdateRunner;
+
+/**
+ * `wp timber-kit updates` — run component-local content/data migrations once.
+ */
+class UpdatesCommand {
+
+	/**
+	 * List discovered updates and registry state.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp timber-kit updates status
+	 *
+	 * @param array<int, string>    $args       Positional args (unused).
+	 * @param array<string, string> $assoc_args Associative args (unused).
+	 * @return void
+	 */
+	public function status( $args, $assoc_args ): void {
+		$discovery = ( new UpdateDiscovery() )->discover();
+		$registry  = new UpdateRegistry();
+		$applied   = $registry->all();
+
+		$rows = [];
+		foreach ( $discovery->updates as $update ) {
+			$rows[] = [
+				'id'          => $update['id'],
+				'description' => $update['description'],
+				'state'       => isset( $applied[ $update['id'] ] ) ? $applied[ $update['id'] ]['applied'] : 'pending',
+				'path'        => $update['path'],
+			];
+		}
+
+		foreach ( $discovery->errors as $index => $error ) {
+			$rows[] = [
+				'id'          => 'error:' . ( $index + 1 ),
+				'description' => $error,
+				'state'       => 'error',
+				'path'        => '',
+			];
+		}
+
+		$this->table( $rows, [ 'id', 'description', 'state', 'path' ] );
+
+		if ( [] !== $discovery->errors ) {
+			\WP_CLI::error( 'Update discovery reported errors.' );
+			return;
+		}
+	}
+
+	/**
+	 * Run pending updates once.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--dry-run]
+	 * : Execute update callbacks without writing registry entries. Helpers skip
+	 *   content writes where supported and log would-be output.
+	 *
+	 * [--component=<name>]
+	 * : Run pending updates only for one component.
+	 *
+	 * [--only=<id>]
+	 * : Run one pending update id, e.g. `card:0001`. Already-applied updates
+	 *   are still skipped; delete the registry entry manually to re-run.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp timber-kit updates run --dry-run
+	 *     wp timber-kit updates run --component=card
+	 *     wp timber-kit updates run --only=theme:0001
+	 *
+	 * @param array<int, string>    $args       Positional args (unused).
+	 * @param array<string, string> $assoc_args Associative args.
+	 * @return void
+	 */
+	public function run( $args, $assoc_args ): void {
+		$result = ( new UpdateRunner() )->run(
+			dryRun: isset( $assoc_args['dry-run'] ),
+			component: isset( $assoc_args['component'] ) ? (string) $assoc_args['component'] : null,
+			only: isset( $assoc_args['only'] ) ? (string) $assoc_args['only'] : null
+		);
+
+		foreach ( $result['discovery_errors'] as $error ) {
+			\WP_CLI::warning( $error );
+		}
+		if ( [] !== $result['discovery_errors'] ) {
+			\WP_CLI::error( 'Refusing to run updates until discovery errors are fixed.' );
+			return;
+		}
+
+		foreach ( $result['executed'] as $entry ) {
+			\WP_CLI::log( sprintf( '%s completed in %d ms.', $entry['id'], $entry['duration_ms'] ) );
+			if ( is_array( $entry['summary'] ) ) {
+				\WP_CLI::log( sprintf( '  %s', wp_json_encode( $entry['summary'] ) ) );
+			}
+		}
+
+		foreach ( $result['failed'] as $failure ) {
+			\WP_CLI::error( sprintf( '%s failed: %s', $failure['id'], $failure['message'] ) );
+			return;
+		}
+
+		if ( [] === $result['executed'] ) {
+			\WP_CLI::success( 'No pending updates.' );
+			return;
+		}
+
+		\WP_CLI::success( sprintf( 'Executed %d update(s).', count( $result['executed'] ) ) );
+	}
+
+	/**
+	 * @param list<array<string, string>> $rows
+	 * @param list<string>               $fields
+	 */
+	private function table( array $rows, array $fields ): void {
+		if ( class_exists( '\WP_CLI\Utils' ) ) {
+			// @phpstan-ignore-next-line WP-CLI is intentionally optional in this library.
+			\WP_CLI\Utils\format_items( 'table', $rows, $fields );
+			return;
+		}
+
+		\WP_CLI::log( implode( "\t", $fields ) );
+		foreach ( $rows as $row ) {
+			\WP_CLI::log( implode( "\t", array_map( static fn ( string $field ): string => $row[ $field ] ?? '', $fields ) ) );
+		}
+	}
+}

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -539,6 +539,7 @@ class StarterBase extends Site {
 
 		\WP_CLI::add_command( 'timber-kit prune-originals', \Parisek\TimberKit\Cli\PruneOriginalsCommand::class );
 		\WP_CLI::add_command( 'timber-kit convert-utf8mb4', \Parisek\TimberKit\Cli\ConvertUtf8mb4Command::class );
+		\WP_CLI::add_command( 'timber-kit updates', \Parisek\TimberKit\Cli\UpdatesCommand::class );
 	}
 
 	/**

--- a/src/Updates/AppliedUpdatesRegistry.php
+++ b/src/Updates/AppliedUpdatesRegistry.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit\Updates;
+
+interface AppliedUpdatesRegistry {
+
+	public function isApplied( string $id ): bool;
+
+	public function markApplied( string $id, int $duration_ms ): void;
+
+	/**
+	 * @return array<string, array{applied: string, duration_ms: int}>
+	 */
+	public function all(): array;
+}

--- a/src/Updates/DiscoveryResult.php
+++ b/src/Updates/DiscoveryResult.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit\Updates;
+
+/**
+ * @phpstan-type UpdateDefinition array{id: string, component: string, number: int, description: string, path: string, run: callable}
+ */
+class DiscoveryResult {
+
+	/**
+	 * @param list<UpdateDefinition> $updates
+	 * @param list<string>           $errors
+	 */
+	public function __construct(
+		public readonly array $updates,
+		public readonly array $errors = []
+	) {}
+}

--- a/src/Updates/UpdateContext.php
+++ b/src/Updates/UpdateContext.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit\Updates;
+
+class UpdateContext {
+
+	/** @var callable(string): void|null */
+	private $logger;
+
+	/**
+	 * @param (callable(string): void)|null $logger
+	 */
+	public function __construct( private readonly bool $dry_run, ?callable $logger = null ) {
+		$this->logger = $logger;
+	}
+
+	public function isDryRun(): bool {
+		return $this->dry_run;
+	}
+
+	public function log( string $message ): void {
+		if ( null !== $this->logger ) {
+			( $this->logger )( $message );
+			return;
+		}
+
+		if ( class_exists( '\WP_CLI' ) ) {
+			\WP_CLI::log( $message );
+			return;
+		}
+
+		error_log( $message );
+	}
+
+	/**
+	 * @param callable(array<string, mixed>, \WP_Post, string): (array<string, mixed>|null) $transform
+	 * @param list<int>                                                               $post_ids
+	 * @return array{scanned: int, changed: int, skipped: int, errors: list<string>}
+	 */
+	public function transformBlocks( string $block_name, callable $transform, array $post_ids ): array {
+		$summary = [ 'scanned' => 0, 'changed' => 0, 'skipped' => 0, 'errors' => [] ];
+
+		foreach ( $post_ids as $post_id ) {
+			$post = get_post( $post_id );
+			if ( ! $post instanceof \WP_Post ) {
+				$summary['errors'][] = sprintf( 'Post #%d: not found', $post_id );
+				continue;
+			}
+
+			foreach ( $this->translationsFor( $post ) as $translation ) {
+				++$summary['scanned'];
+				$changed = $this->transformPostBlocks( $translation['post'], $translation['lang'], $block_name, $transform );
+				if ( null === $changed ) {
+					++$summary['skipped'];
+					continue;
+				}
+
+				++$summary['changed'];
+				if ( $this->dry_run ) {
+					$this->log( sprintf( 'Dry-run post #%d: %s', $translation['post']->ID, substr( $changed, 0, 500 ) ) );
+					continue;
+				}
+
+				$result = wp_update_post(
+					[
+						'ID'           => $translation['post']->ID,
+						'post_content' => $changed,
+					],
+					true
+				);
+				if ( $result instanceof \WP_Error ) {
+					$summary['errors'][] = sprintf( 'Post #%d: %s', $translation['post']->ID, $result->get_error_message() );
+				}
+			}
+		}
+
+		return $summary;
+	}
+
+	public function mapAttachment( int $attachment_id, string $lang ): int {
+		$mapped = apply_filters( 'wpml_object_id', $attachment_id, 'attachment', true, $lang );
+
+		return null === $mapped ? $attachment_id : (int) $mapped;
+	}
+
+	/**
+	 * @return list<array{post: \WP_Post, lang: string}>
+	 */
+	private function translationsFor( \WP_Post $post ): array {
+		$element_type = 'post_' . $post->post_type;
+		$trid         = apply_filters( 'wpml_element_trid', null, $post->ID, $element_type );
+		if ( null === $trid ) {
+			return [ [ 'post' => $post, 'lang' => '' ] ];
+		}
+
+		$translations = apply_filters( 'wpml_get_element_translations', null, $trid, $element_type );
+		if ( ! is_array( $translations ) ) {
+			return [ [ 'post' => $post, 'lang' => '' ] ];
+		}
+
+		$posts = [];
+		foreach ( $translations as $translation ) {
+			$element_id = is_object( $translation ) && isset( $translation->element_id ) ? (int) $translation->element_id : 0;
+			if ( $element_id <= 0 ) {
+				continue;
+			}
+
+			$translated_post = get_post( $element_id );
+			if ( ! $translated_post instanceof \WP_Post ) {
+				continue;
+			}
+
+			$lang = is_object( $translation ) && isset( $translation->language_code ) ? (string) $translation->language_code : '';
+			$posts[] = [ 'post' => $translated_post, 'lang' => $lang ];
+		}
+
+		return [] === $posts ? [ [ 'post' => $post, 'lang' => '' ] ] : $posts;
+	}
+
+	/**
+	 * @param callable(array<string, mixed>, \WP_Post, string): (array<string, mixed>|null) $transform
+	 */
+	private function transformPostBlocks( \WP_Post $post, string $lang, string $block_name, callable $transform ): ?string {
+		$blocks  = parse_blocks( $post->post_content );
+		$changed = $this->transformBlockList( $blocks, $block_name, $transform, $post, $lang );
+
+		return $changed ? serialize_blocks( $blocks ) : null;
+	}
+
+	/**
+	 * @param array<mixed>                                                         $blocks
+	 * @param callable(array<string, mixed>, \WP_Post, string): (array<string, mixed>|null) $transform
+	 */
+	private function transformBlockList( array &$blocks, string $block_name, callable $transform, \WP_Post $post, string $lang ): bool {
+		$changed = false;
+
+		foreach ( $blocks as &$block ) {
+			if ( isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+				$changed = $this->transformBlockList( $block['innerBlocks'], $block_name, $transform, $post, $lang ) || $changed;
+			}
+
+			if ( ( $block['blockName'] ?? null ) !== $block_name ) {
+				continue;
+			}
+
+			$data = $block['attrs']['data'] ?? [];
+			if ( ! is_array( $data ) ) {
+				$data = [];
+			}
+
+			$next = $transform( $data, $post, $lang );
+			if ( null === $next || $next === $data ) {
+				continue;
+			}
+
+			$block['attrs']['data'] = $next;
+			$changed = true;
+		}
+		unset( $block );
+
+		return $changed;
+	}
+}

--- a/src/Updates/UpdateDiscovery.php
+++ b/src/Updates/UpdateDiscovery.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit\Updates;
+
+class UpdateDiscovery {
+
+	/**
+	 * Discover update files from the active stylesheet directory and the
+	 * `timberkit_update_paths` filter.
+	 */
+	public function discover(): DiscoveryResult {
+		$theme_dir = get_stylesheet_directory();
+		$patterns  = $this->defaultPatterns( (string) $theme_dir );
+
+		$patterns = apply_filters( 'timberkit_update_paths', $patterns );
+		if ( ! is_array( $patterns ) ) {
+			$patterns = [];
+		}
+
+		return $this->discoverPatterns(
+			array_values( array_filter( array_map( 'strval', $patterns ) ) ),
+			(string) $theme_dir
+		);
+	}
+
+	public function discoverInTheme( string $theme_dir ): DiscoveryResult {
+		return $this->discoverPatterns( $this->defaultPatterns( $theme_dir ), $theme_dir );
+	}
+
+	/**
+	 * @param list<string> $patterns
+	 */
+	public function discoverPatterns( array $patterns, ?string $theme_dir = null ): DiscoveryResult {
+		$files = [];
+		foreach ( $patterns as $pattern ) {
+			$matches = glob( $pattern );
+			if ( false === $matches ) {
+				continue;
+			}
+			foreach ( $matches as $path ) {
+				if ( is_file( $path ) ) {
+					$files[] = $path;
+				}
+			}
+		}
+
+		sort( $files, SORT_STRING );
+
+		$updates = [];
+		$errors  = [];
+		$seen    = [];
+
+		foreach ( $files as $path ) {
+			$meta = $this->parsePath( $path, $theme_dir );
+			if ( null === $meta ) {
+				continue;
+			}
+
+			$id = $meta['component'] . ':' . $meta['number_padded'];
+			if ( isset( $seen[ $id ] ) ) {
+				$errors[] = sprintf( 'Duplicate update id %s: %s and %s', $id, $seen[ $id ], $path );
+				continue;
+			}
+			$seen[ $id ] = $path;
+
+			try {
+				$returned = require $path;
+			} catch ( \Throwable $throwable ) {
+				$errors[] = sprintf( 'Malformed update file %s: %s', $path, $throwable->getMessage() );
+				continue;
+			}
+			if (
+				! is_array( $returned )
+				|| ! isset( $returned['description'], $returned['run'] )
+				|| ! is_string( $returned['description'] )
+				|| ! is_callable( $returned['run'] )
+			) {
+				$errors[] = sprintf( 'Malformed update file %s: expected description string and run callable.', $path );
+				continue;
+			}
+
+			$updates[] = [
+				'id'          => $id,
+				'component'   => $meta['component'],
+				'number'      => $meta['number'],
+				'description' => $returned['description'],
+				'path'        => $path,
+				'run'         => $returned['run'],
+			];
+		}
+
+		usort(
+			$updates,
+			static fn ( array $a, array $b ): int => [ $a['component'], $a['number'] ] <=> [ $b['component'], $b['number'] ]
+		);
+
+		return new DiscoveryResult( $updates, $errors );
+	}
+
+	/**
+	 * @return list<string>
+	 */
+	private function defaultPatterns( string $theme_dir ): array {
+		$theme_dir = rtrim( $theme_dir, '/' );
+
+		return [
+			$theme_dir . '/updates/*.php',
+			$theme_dir . '/templates/component/*/updates/*.php',
+			$theme_dir . '/static/templates/component/*/updates/*.php',
+		];
+	}
+
+	/**
+	 * @return array{component: string, number: int, number_padded: string}|null
+	 */
+	private function parsePath( string $path, ?string $theme_dir ): ?array {
+		$filename = basename( $path );
+		if ( 1 !== preg_match( '/^(\d{4})-[a-z0-9][a-z0-9-]*\.php$/', $filename, $matches ) ) {
+			return null;
+		}
+
+		$updates_dir = dirname( $path );
+		$parent      = dirname( $updates_dir );
+		$component   = basename( $parent );
+
+		if ( null !== $theme_dir && rtrim( $parent, '/' ) === rtrim( $theme_dir, '/' ) ) {
+			$component = 'theme';
+		}
+
+		return [
+			'component'     => $component,
+			'number'        => (int) $matches[1],
+			'number_padded' => $matches[1],
+		];
+	}
+}

--- a/src/Updates/UpdateRegistry.php
+++ b/src/Updates/UpdateRegistry.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit\Updates;
+
+class UpdateRegistry implements AppliedUpdatesRegistry {
+
+	private const OPTION = 'timber_kit_updates_applied';
+
+	/** @var callable(): \DateTimeImmutable */
+	private $clock;
+
+	/**
+	 * @param (callable(): \DateTimeImmutable)|null $clock
+	 */
+	public function __construct( ?callable $clock = null ) {
+		$this->clock = $clock ?? static fn (): \DateTimeImmutable => new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) );
+	}
+
+	public function isApplied( string $id ): bool {
+		return isset( $this->all()[ $id ] );
+	}
+
+	public function markApplied( string $id, int $duration_ms ): void {
+		$all        = $this->all();
+		$clock      = $this->clock;
+		$all[ $id ] = [
+			'applied'     => $clock()->format( \DateTimeInterface::ATOM ),
+			'duration_ms' => $duration_ms,
+		];
+
+		update_option( self::OPTION, $all, false );
+	}
+
+	/**
+	 * @return array<string, array{applied: string, duration_ms: int}>
+	 */
+	public function all(): array {
+		$value = get_option( self::OPTION, [] );
+		if ( ! is_array( $value ) ) {
+			return [];
+		}
+
+		$clean = [];
+		foreach ( $value as $id => $entry ) {
+			if ( is_string( $id ) && is_array( $entry ) && isset( $entry['applied'], $entry['duration_ms'] ) ) {
+				$clean[ $id ] = [
+					'applied'     => (string) $entry['applied'],
+					'duration_ms' => (int) $entry['duration_ms'],
+				];
+			}
+		}
+
+		return $clean;
+	}
+}

--- a/src/Updates/UpdateRunner.php
+++ b/src/Updates/UpdateRunner.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit\Updates;
+
+class UpdateRunner {
+
+	/** @var callable(): DiscoveryResult */
+	private $discover;
+
+	/** @var callable(string): void|null */
+	private $logger;
+
+	/**
+	 * @param (callable(): DiscoveryResult)|null $discover
+	 * @param (callable(string): void)|null      $logger
+	 */
+	public function __construct(
+		?callable $discover = null,
+		private readonly AppliedUpdatesRegistry $registry = new UpdateRegistry(),
+		?callable $logger = null
+	) {
+		$this->discover = $discover ?? static fn (): DiscoveryResult => ( new UpdateDiscovery() )->discover();
+		$this->logger   = $logger;
+	}
+
+	/**
+	 * @return array{
+	 *     executed: list<array{id: string, duration_ms: int, summary: mixed}>,
+	 *     skipped: list<array{id: string, reason: string}>,
+	 *     failed: list<array{id: string, message: string, duration_ms: int}>,
+	 *     discovery_errors: list<string>
+	 * }
+	 */
+	public function run( bool $dryRun = false, ?string $component = null, ?string $only = null ): array {
+		$discovery = ( $this->discover )();
+		$result    = [
+			'executed'         => [],
+			'skipped'          => [],
+			'failed'           => [],
+			'discovery_errors' => $discovery->errors,
+		];
+
+		if ( [] !== $discovery->errors ) {
+			return $result;
+		}
+
+		$updates = $discovery->updates;
+		usort(
+			$updates,
+			static fn ( array $a, array $b ): int => [ $a['component'], $a['number'] ] <=> [ $b['component'], $b['number'] ]
+		);
+
+		foreach ( $updates as $update ) {
+			$skip_reason = $this->skipReason( $update, $component, $only );
+			if ( null === $skip_reason && $this->registry->isApplied( $update['id'] ) ) {
+				$skip_reason = 'applied';
+			}
+
+			if ( null !== $skip_reason ) {
+				$result['skipped'][] = [ 'id' => $update['id'], 'reason' => $skip_reason ];
+				continue;
+			}
+
+			$start = hrtime( true );
+			try {
+				$summary = $this->callUpdate( $update['run'], new UpdateContext( $dryRun ) );
+			} catch ( \Throwable $throwable ) {
+				$duration_ms = (int) round( ( hrtime( true ) - $start ) / 1_000_000 );
+				$message     = sprintf( '%s failed: %s', $update['id'], $throwable->getMessage() );
+				$this->log( $message );
+				$result['failed'][] = [ 'id' => $update['id'], 'message' => $throwable->getMessage(), 'duration_ms' => $duration_ms ];
+				break;
+			}
+
+			$duration_ms = (int) round( ( hrtime( true ) - $start ) / 1_000_000 );
+			if ( ! $dryRun ) {
+				$this->registry->markApplied( $update['id'], $duration_ms );
+			}
+
+			$result['executed'][] = [
+				'id'          => $update['id'],
+				'duration_ms' => $duration_ms,
+				'summary'     => $summary,
+			];
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @param array{id: string, component: string} $update
+	 */
+	private function skipReason( array $update, ?string $component, ?string $only ): ?string {
+		if ( null !== $component && $update['component'] !== $component ) {
+			return 'component';
+		}
+
+		if ( null !== $only && $update['id'] !== $only ) {
+			return 'only';
+		}
+
+		return null;
+	}
+
+	private function callUpdate( callable $run, UpdateContext $context ): mixed {
+		$reflection = \Closure::fromCallable( $run );
+		$callable   = new \ReflectionFunction( $reflection );
+
+		return 0 === $callable->getNumberOfParameters() ? $run() : $run( $context );
+	}
+
+	private function log( string $message ): void {
+		if ( null !== $this->logger ) {
+			( $this->logger )( $message );
+			return;
+		}
+
+		if ( class_exists( '\WP_CLI' ) ) {
+			\WP_CLI::warning( $message );
+			return;
+		}
+
+		error_log( $message );
+	}
+}

--- a/tests/Unit/Updates/UpdateContextTest.php
+++ b/tests/Unit/Updates/UpdateContextTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Updates;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Parisek\TimberKit\Updates\UpdateContext;
+use PHPUnit\Framework\TestCase;
+
+class UpdateContextTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	public function test_transform_blocks_updates_single_language_post(): void {
+		$writes = [];
+		Functions\when( 'get_post' )->justReturn( new \WP_Post( [ 'ID' => 10, 'post_type' => 'page', 'post_content' => '<!-- old -->' ] ) );
+		Functions\when( 'apply_filters' )->alias( static fn ( string $filter, mixed $default ) => $default );
+		Functions\when( 'parse_blocks' )->justReturn( [
+			[ 'blockName' => 'acf/card', 'attrs' => [ 'data' => [ 'title' => 'Old' ] ], 'innerBlocks' => [] ],
+		] );
+		Functions\when( 'serialize_blocks' )->alias( static fn ( array $blocks ): string => (string) json_encode( $blocks ) );
+		Functions\when( 'wp_update_post' )->alias(
+			function ( array $post, bool $wp_error ) use ( &$writes ): int {
+				$writes[] = compact( 'post', 'wp_error' );
+				return (int) $post['ID'];
+			}
+		);
+
+		$summary = ( new UpdateContext( false ) )->transformBlocks(
+			'acf/card',
+			static fn ( array $data ): array => [ 'title' => $data['title'] . '!' ],
+			[ 10 ]
+		);
+
+		$this->assertSame( [ 'scanned' => 1, 'changed' => 1, 'skipped' => 0, 'errors' => [] ], $summary );
+		$this->assertTrue( $writes[0]['wp_error'] );
+		$this->assertStringContainsString( 'Old!', $writes[0]['post']['post_content'] );
+	}
+
+	public function test_transform_blocks_fans_out_wpml_translations_with_languages(): void {
+		$seen = [];
+		Functions\when( 'get_post' )->alias( static fn ( int $id ): \WP_Post => new \WP_Post( [ 'ID' => $id, 'post_type' => 'page', 'post_content' => '' ] ) );
+		Functions\when( 'apply_filters' )->alias(
+			static function ( string $filter, mixed $default, mixed ...$args ): mixed {
+				if ( 'wpml_element_trid' === $filter ) {
+					return 99;
+				}
+				if ( 'wpml_get_element_translations' === $filter ) {
+					return [
+						'en' => (object) [ 'element_id' => 10, 'language_code' => 'en' ],
+						'cs' => (object) [ 'element_id' => 11, 'language_code' => 'cs' ],
+					];
+				}
+				return $default;
+			}
+		);
+		Functions\when( 'parse_blocks' )->justReturn( [
+			[ 'blockName' => 'acf/card', 'attrs' => [ 'data' => [ 'seen' => false ] ], 'innerBlocks' => [] ],
+		] );
+		Functions\when( 'serialize_blocks' )->alias( static fn ( array $blocks ): string => (string) json_encode( $blocks ) );
+		Functions\when( 'wp_update_post' )->justReturn( 1 );
+
+		$summary = ( new UpdateContext( false ) )->transformBlocks(
+			'acf/card',
+			function ( array $data, \WP_Post $post, string $lang ) use ( &$seen ): array {
+				$seen[] = [ $post->ID, $lang ];
+				return [ 'seen' => true ];
+			},
+			[ 10 ]
+		);
+
+		$this->assertSame( [ [ 10, 'en' ], [ 11, 'cs' ] ], $seen );
+		$this->assertSame( 2, $summary['changed'] );
+	}
+
+	public function test_null_transform_and_dry_run_do_not_write(): void {
+		$logs = [];
+		Functions\when( 'get_post' )->justReturn( new \WP_Post( [ 'ID' => 10, 'post_type' => 'page', 'post_content' => '' ] ) );
+		Functions\when( 'apply_filters' )->alias( static fn ( string $filter, mixed $default ) => $default );
+		Functions\when( 'parse_blocks' )->justReturn( [
+			[ 'blockName' => 'acf/card', 'attrs' => [ 'data' => [ 'title' => 'Old' ] ], 'innerBlocks' => [] ],
+		] );
+		Functions\when( 'serialize_blocks' )->alias( static fn ( array $blocks ): string => (string) json_encode( $blocks ) );
+		Functions\expect( 'wp_update_post' )->never();
+
+		$noChange = ( new UpdateContext( false ) )->transformBlocks( 'acf/card', static fn (): null => null, [ 10 ] );
+		$dryRun   = ( new UpdateContext( true, function ( string $message ) use ( &$logs ): void { $logs[] = $message; } ) )
+			->transformBlocks( 'acf/card', static fn ( array $data ): array => [ 'title' => 'New' ], [ 10 ] );
+
+		$this->assertSame( 1, $noChange['skipped'] );
+		$this->assertSame( 1, $dryRun['changed'] );
+		$this->assertStringContainsString( 'Dry-run post #10', $logs[0] );
+	}
+
+	public function test_wp_update_post_error_is_collected(): void {
+		Functions\when( 'get_post' )->justReturn( new \WP_Post( [ 'ID' => 10, 'post_type' => 'page', 'post_content' => '' ] ) );
+		Functions\when( 'apply_filters' )->alias( static fn ( string $filter, mixed $default ) => $default );
+		Functions\when( 'parse_blocks' )->justReturn( [
+			[ 'blockName' => 'acf/card', 'attrs' => [ 'data' => [ 'title' => 'Old' ] ], 'innerBlocks' => [] ],
+		] );
+		Functions\when( 'serialize_blocks' )->justReturn( '<!-- new -->' );
+		Functions\when( 'wp_update_post' )->justReturn( new \WP_Error( 'bad', 'Could not update' ) );
+
+		$summary = ( new UpdateContext( false ) )->transformBlocks( 'acf/card', static fn (): array => [ 'title' => 'New' ], [ 10 ] );
+
+		$this->assertSame( [ 'Post #10: Could not update' ], $summary['errors'] );
+	}
+
+	public function test_map_attachment_uses_wpml_mapping_or_falls_back_to_input(): void {
+		Functions\when( 'apply_filters' )->alias(
+			static fn ( string $filter, mixed $default, mixed ...$args ): mixed => 'wpml_object_id' === $filter ? 456 : $default
+		);
+
+		$this->assertSame( 456, ( new UpdateContext( false ) )->mapAttachment( 123, 'cs' ) );
+	}
+}

--- a/tests/Unit/Updates/UpdateDiscoveryTest.php
+++ b/tests/Unit/Updates/UpdateDiscoveryTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Updates;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Parisek\TimberKit\Updates\UpdateDiscovery;
+use PHPUnit\Framework\TestCase;
+
+class UpdateDiscoveryTest extends TestCase {
+
+	private string $root;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+		$this->root = sys_get_temp_dir() . '/timber-kit-updates-' . bin2hex( random_bytes( 4 ) );
+		mkdir( $this->root, 0777, true );
+	}
+
+	protected function tearDown(): void {
+		$this->removeDirectory( $this->root );
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	public function test_discovers_ids_across_default_roots_in_component_then_number_order(): void {
+		$this->writeUpdate( 'updates/0002-theme-step.php', 'Theme step' );
+		$this->writeUpdate( 'templates/component/card/updates/0001-card-step.php', 'Card step' );
+		$this->writeUpdate( 'static/templates/component/alert/updates/0003-alert-step.php', 'Alert step' );
+
+		$result = ( new UpdateDiscovery() )->discoverInTheme( $this->root );
+
+		$this->assertSame( [ 'alert:0003', 'card:0001', 'theme:0002' ], array_column( $result->updates, 'id' ) );
+		$this->assertSame( [], $result->errors );
+		$this->assertStringEndsWith( '0001-card-step.php', $result->updates[1]['path'] );
+	}
+
+	public function test_flags_duplicate_numbers_within_the_same_component(): void {
+		$this->writeUpdate( 'templates/component/card/updates/0001-first.php', 'First' );
+		$this->writeUpdate( 'templates/component/card/updates/0001-second.php', 'Second' );
+
+		$result = ( new UpdateDiscovery() )->discoverInTheme( $this->root );
+
+		$this->assertCount( 1, $result->errors );
+		$this->assertStringContainsString( 'Duplicate update id card:0001', $result->errors[0] );
+	}
+
+	public function test_collects_malformed_files_as_errors(): void {
+		$this->writeFile( 'updates/0001-bad.php', '<?php return ["description" => "Missing run"];' );
+
+		$result = ( new UpdateDiscovery() )->discoverInTheme( $this->root );
+
+		$this->assertSame( [], $result->updates );
+		$this->assertCount( 1, $result->errors );
+		$this->assertStringContainsString( 'Malformed update file', $result->errors[0] );
+	}
+
+	public function test_filter_override_can_add_scan_patterns(): void {
+		$this->writeUpdate( 'custom/promo/updates/0004-promo.php', 'Promo' );
+		Functions\when( 'get_stylesheet_directory' )->justReturn( $this->root );
+		Functions\when( 'apply_filters' )->alias(
+			fn ( string $filter, array $patterns ): array => 'timberkit_update_paths' === $filter
+				? [ $this->root . '/custom/*/updates/*.php' ]
+				: $patterns
+		);
+
+		$result = ( new UpdateDiscovery() )->discover();
+
+		$this->assertSame( [ 'promo:0004' ], array_column( $result->updates, 'id' ) );
+	}
+
+	private function writeUpdate( string $relative, string $description ): void {
+		$this->writeFile(
+			$relative,
+			'<?php return ["description" => ' . var_export( $description, true ) . ', "run" => static function (): void {}];'
+		);
+	}
+
+	private function writeFile( string $relative, string $contents ): void {
+		$path = $this->root . '/' . $relative;
+		$dir  = dirname( $path );
+		if ( ! is_dir( $dir ) ) {
+			mkdir( $dir, 0777, true );
+		}
+		file_put_contents( $path, $contents );
+	}
+
+	private function removeDirectory( string $dir ): void {
+		if ( ! is_dir( $dir ) ) {
+			return;
+		}
+		foreach ( array_diff( scandir( $dir ) ?: [], [ '.', '..' ] ) as $entry ) {
+			$path = $dir . '/' . $entry;
+			is_dir( $path ) ? $this->removeDirectory( $path ) : unlink( $path );
+		}
+		rmdir( $dir );
+	}
+}

--- a/tests/Unit/Updates/UpdateRegistryTest.php
+++ b/tests/Unit/Updates/UpdateRegistryTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Updates;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Parisek\TimberKit\Updates\UpdateRegistry;
+use PHPUnit\Framework\TestCase;
+
+class UpdateRegistryTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	public function test_reads_applied_registry_and_marks_with_injected_clock(): void {
+		$stored = [ 'theme:0001' => [ 'applied' => '2026-07-14T10:00:00+00:00', 'duration_ms' => 12 ] ];
+		$writes = [];
+
+		Functions\when( 'get_option' )->alias( fn () => $stored );
+		Functions\when( 'update_option' )->alias(
+			function ( string $key, array $value, bool $autoload ) use ( &$writes ): bool {
+				$writes[] = compact( 'key', 'value', 'autoload' );
+				return true;
+			}
+		);
+
+		$registry = new UpdateRegistry( static fn (): \DateTimeImmutable => new \DateTimeImmutable( '2026-07-14 12:34:56', new \DateTimeZone( 'UTC' ) ) );
+
+		$this->assertTrue( $registry->isApplied( 'theme:0001' ) );
+		$this->assertFalse( $registry->isApplied( 'theme:0002' ) );
+
+		$registry->markApplied( 'theme:0002', 34 );
+
+		$this->assertSame( 'timber_kit_updates_applied', $writes[0]['key'] );
+		$this->assertFalse( $writes[0]['autoload'] );
+		$this->assertSame( '2026-07-14T12:34:56+00:00', $writes[0]['value']['theme:0002']['applied'] );
+		$this->assertSame( 34, $writes[0]['value']['theme:0002']['duration_ms'] );
+	}
+}

--- a/tests/Unit/Updates/UpdateRunnerTest.php
+++ b/tests/Unit/Updates/UpdateRunnerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Updates;
+
+use Parisek\TimberKit\Updates\DiscoveryResult;
+use Parisek\TimberKit\Updates\AppliedUpdatesRegistry;
+use Parisek\TimberKit\Updates\UpdateRunner;
+use PHPUnit\Framework\TestCase;
+
+class UpdateRunnerTest extends TestCase {
+
+	public function test_runs_pending_in_order_and_marks_successes(): void {
+		$events = [];
+		$updates = [
+			$this->update( 'card:0002', static function () use ( &$events ): void { $events[] = 'card:0002'; } ),
+			$this->update( 'alert:0001', static function () use ( &$events ): void { $events[] = 'alert:0001'; } ),
+		];
+		$runner = new UpdateRunner(
+			static fn (): DiscoveryResult => new DiscoveryResult( $updates ),
+			new MemoryRegistry()
+		);
+
+		$result = $runner->run();
+
+		$this->assertSame( [ 'alert:0001', 'card:0002' ], $events );
+		$this->assertSame( [ 'alert:0001', 'card:0002' ], array_column( $result['executed'], 'id' ) );
+	}
+
+	public function test_skips_applied_and_respects_component_and_only_scopes(): void {
+		$registry = new MemoryRegistry( [ 'card:0001' => [ 'applied' => 'then', 'duration_ms' => 1 ] ] );
+		$runner   = new UpdateRunner(
+			fn (): DiscoveryResult => new DiscoveryResult( [
+				$this->update( 'card:0001', static function (): void {} ),
+				$this->update( 'card:0002', static function (): void {} ),
+				$this->update( 'hero:0001', static function (): void {} ),
+			] ),
+			$registry
+		);
+
+		$result = $runner->run( component: 'card', only: 'card:0001' );
+
+		$this->assertSame( [], $result['executed'] );
+		$this->assertSame( [ 'card:0001', 'card:0002', 'hero:0001' ], array_column( $result['skipped'], 'id' ) );
+	}
+
+	public function test_failure_aborts_rest_and_does_not_mark_failed_update(): void {
+		$events = [];
+		$registry = new MemoryRegistry();
+		$updates = [
+			$this->update( 'card:0001', static function () use ( &$events ): void { $events[] = 'first'; throw new \RuntimeException( 'boom' ); } ),
+			$this->update( 'card:0002', static function () use ( &$events ): void { $events[] = 'second'; } ),
+		];
+		$runner = new UpdateRunner(
+			static fn (): DiscoveryResult => new DiscoveryResult( $updates ),
+			$registry,
+			static function (): void {}
+		);
+
+		$result = $runner->run();
+
+		$this->assertSame( [ 'first' ], $events );
+		$this->assertSame( 'card:0001', $result['failed'][0]['id'] );
+		$this->assertFalse( $registry->isApplied( 'card:0001' ) );
+	}
+
+	public function test_dry_run_marks_nothing(): void {
+		$registry = new MemoryRegistry();
+		$runner = new UpdateRunner(
+			fn (): DiscoveryResult => new DiscoveryResult( [
+				$this->update( 'card:0001', static function (): void {} ),
+			] ),
+			$registry
+		);
+
+		$runner->run( dryRun: true );
+
+		$this->assertFalse( $registry->isApplied( 'card:0001' ) );
+	}
+
+	/**
+	 * @return array{id: string, component: string, number: int, description: string, path: string, run: callable}
+	 */
+	private function update( string $id, callable $run ): array {
+		[ $component, $number ] = explode( ':', $id );
+
+		return [
+			'id'          => $id,
+			'component'   => $component,
+			'number'      => (int) $number,
+			'description' => $id,
+			'path'        => '/tmp/' . $id . '.php',
+			'run'         => $run,
+		];
+	}
+}
+
+class MemoryRegistry implements AppliedUpdatesRegistry {
+
+	/** @param array<string, array{applied: string, duration_ms: int}> $applied */
+	public function __construct( private array $applied = [] ) {}
+
+	public function isApplied( string $id ): bool {
+		return isset( $this->applied[ $id ] );
+	}
+
+	public function markApplied( string $id, int $duration_ms ): void {
+		$this->applied[ $id ] = [ 'applied' => 'now', 'duration_ms' => $duration_ms ];
+	}
+
+	/** @return array<string, array{applied: string, duration_ms: int}> */
+	public function all(): array {
+		return $this->applied;
+	}
+}


### PR DESCRIPTION
Closes #79.

## Summary
- **Discovery** (`Updates\UpdateDiscovery`): scans `<theme>/updates/` + `<theme>/[static/]templates/component/*/updates/` for `NNNN-<slug>.php` files returning `['description', 'run' => callable(UpdateContext)]`; update ID = `<component>:<NNNN>` (`theme` for theme-wide). Paths filterable via `timberkit_update_paths`; duplicates/malformed files collected as errors, never fatal.
- **Registry** (`Updates\UpdateRegistry`): single autoload-off option `timber_kit_updates_applied` (`id => {applied, duration_ms}`), injectable clock.
- **UpdateContext**: `transformBlocks(block_name, transform, post_ids)` — parse_blocks walk (incl. nested innerBlocks), automatic WPML fan-out over all translations via trid (single-language no-op without WPML), per-post summary, dry-run logs instead of writes, wp_update_post errors collected; `mapAttachment(id, lang)` via `wpml_object_id`; `isDryRun()` / `log()`.
- **Runner**: pending updates in (component, NNNN) order; a Throwable aborts the whole run and leaves the update unmarked (nothing runs on top of a half-applied predecessor); registry marked only on clean non-dry-run completion; `--component=` / `--only=` scoping.
- **CLI** (`wp timber-kit updates status|run [--dry-run] [--component=] [--only=]`) — thin WP_CLI layer per repo convention, registered in StarterBase.

## Verification
- `composer test`: 986 tests, 1763 assertions, green, notice/deprecation-free
- `composer phpstan`: level 8, no errors

First consumer: mairateam `creative-slider:0001` (portadesign/mairateam#41 rollout — CS/EN homepage block migration), authored right after this releases.

Developed via Codex loop from the issue spec with design decisions finalized inline; reviewed and independently verified by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8i5DsHnZ2LEuDjS1DDpBr