### PR TITLE
feat: native always-on video enrichment in formatFields (codecs + sources cascade)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- Native always-on video enrichment in `formatFields`: formatted video file values now include additive `codecs` keys, and repeater rows carrying a video now receive an additive `sources` cascade. Existing keys stay unchanged, `sources` never overwrites an existing key, and this supersedes the opt-in flag design discussed in #82.
+
 ## [1.22.0] - 2026-07-14
 
 ### Added

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -149,7 +149,7 @@ class Helpers {
 	 * @param object|array|int|string $file     File value as returned by ACF.
 	 * @param int|null                $post_id  Post ID the field belongs to (unused, kept for API parity).
 	 * @param array|null              $field    ACF field definition array (unused, kept for API parity).
-	 * @return array{id: int|null, src: string, type: string, subtype: string, filename: string, filesize: string, alt: string, caption: string, description: string, preview: array}|string
+	 * @return array{id: int|null, src: string, type: string, subtype: string, filename: string, filesize: string, alt: string, caption: string, description: string, preview: array, codecs: string|null}|string
 	 *               Associative file data array, or an empty string when the
 	 *               file cannot be resolved.
 	 */
@@ -215,6 +215,7 @@ class Helpers {
 			'caption' => $attachment['caption'] ?? '',
 			'description' => $attachment['description'] ?? '',
 			'preview' => $preview, // empty array if not a PDF or no preview
+			'codecs' => ( ! empty( $attachment['ID'] ) && str_starts_with( (string) ( $attachment['mime_type'] ?? '' ), 'video/' ) ) ? self::videoCodecs( (int) $attachment['ID'] ) : null,
 		];
 	}
 
@@ -228,7 +229,7 @@ class Helpers {
 	 * @param object|array|int|string $file     Video value as returned by ACF.
 	 * @param int|null                $post_id  Post ID the field belongs to (unused, kept for API parity).
 	 * @param array|null              $field    ACF field definition array (unused, kept for API parity).
-	 * @return array{id: int|null, src: string, type: string, width: int|null, height: int|null, alt: string, caption: string, description: string}|false|null
+	 * @return array{id: int|null, src: string, type: string, width: int|null, height: int|null, alt: string, caption: string, description: string, codecs: string|null}|false|null
 	 *               Single video data array, false if the list was empty, or
 	 *               null when the input is not countable.
 	 */
@@ -237,6 +238,9 @@ class Helpers {
 		$video = self::formatImage( $file, $post_id, $field );
 		// disable nested array
 		$video = is_countable( $video ) ? reset( $video ) : null;
+		if ( is_array( $video ) && [] !== $video ) {
+			$video['codecs'] = ( ! empty( $video['id'] ) && str_starts_with( (string) ( $video['type'] ?? '' ), 'video/' ) ) ? self::videoCodecs( (int) $video['id'] ) : null;
+		}
 		return $video;
 	}
 
@@ -306,6 +310,37 @@ class Helpers {
 		}
 
 		return $sources;
+	}
+
+	/**
+	 * Add an ordered video source cascade to a formatted repeater row.
+	 *
+	 * @param array<string,mixed> $row Formatted repeater row.
+	 * @return array<string,mixed>
+	 */
+	private static function appendVideoSources( array $row ): array {
+		if ( array_key_exists( 'sources', $row ) || empty( $row['video'] ) || ! is_array( $row['video'] ) || empty( $row['video']['src'] ) ) {
+			return $row;
+		}
+
+		$sources = [];
+		foreach ( [ 'video_preview_av1', 'video_preview', 'video' ] as $key ) {
+			if ( empty( $row[ $key ] ) || ! is_array( $row[ $key ] ) || empty( $row[ $key ]['src'] ) ) {
+				continue;
+			}
+
+			$sources[] = [
+				'src' => (string) $row[ $key ]['src'],
+				'type' => isset( $row[ $key ]['type'] ) && '' !== (string) $row[ $key ]['type'] ? (string) $row[ $key ]['type'] : 'video/mp4',
+				'codecs' => isset( $row[ $key ]['codecs'] ) && is_string( $row[ $key ]['codecs'] ) ? $row[ $key ]['codecs'] : null,
+			];
+		}
+
+		if ( [] !== $sources ) {
+			$row['sources'] = $sources;
+		}
+
+		return $row;
 	}
 
 	/**
@@ -1213,6 +1248,9 @@ class Helpers {
 								$sub_fields[ $sub_key ]['value'] = $sub_value;
 								$sub_value = self::fieldFormatter( $sub_fields[ $sub_key ], $post_id, $is_preview );
 							}
+						}
+						if ( 'repeater' === $field['type'] && is_array( $value ) ) {
+							$value = self::appendVideoSources( $value );
 						}
 					} else {
 						if ( isset( $sub_fields[ $key ] ) ) {

--- a/tests/Unit/Helpers/FieldFormatterTest.php
+++ b/tests/Unit/Helpers/FieldFormatterTest.php
@@ -177,6 +177,12 @@ class FieldFormatterTest extends HelpersTestCase {
 	public function test_gallery_with_mixed_types(): void {
 		Functions\when( 'size_format' )->justReturn( '2 MB' );
 		Functions\when( 'wp_get_attachment_image_src' )->justReturn( false );
+		Functions\expect( 'get_post_meta' )
+			->once()
+			->with( 3, '_timber_kit_video_codecs', true )
+			->andReturn( 'none' );
+		Functions\expect( 'get_attached_file' )->never();
+		Functions\expect( 'update_post_meta' )->never();
 
 		$field = [
 			'type'  => 'gallery',
@@ -230,6 +236,7 @@ class FieldFormatterTest extends HelpersTestCase {
 		// video item gets formatted by formatVideo (unwrapped from nested array)
 		$this->assertSame( 3, $result[2]['id'] );
 		$this->assertSame( 'video/mp4', $result[2]['type'] );
+		$this->assertNull( $result[2]['codecs'] );
 	}
 
 	// --- Wysiwyg ---
@@ -658,6 +665,83 @@ class FieldFormatterTest extends HelpersTestCase {
 		$this->assertSame( 42, $result[0]['photo'][0]['id'] );
 	}
 
+	public function test_repeater_with_video_row_appends_sources_after_sub_field_formatting(): void {
+		$field = [
+			'type'       => 'repeater',
+			'sub_fields' => [
+				[ 'name' => 'video_preview_av1', 'type' => 'file' ],
+				[ 'name' => 'video_preview', 'type' => 'file' ],
+				[ 'name' => 'video', 'type' => 'file' ],
+			],
+			'value'      => [
+				[
+					'video_preview_av1' => [
+						'ID'          => 31,
+						'url'         => 'https://example.com/preview-av1.mp4',
+						'mime_type'   => 'video/mp4',
+						'subtype'     => 'mp4',
+						'filename'    => 'preview-av1.mp4',
+						'filesize'    => 1024,
+						'alt'         => '',
+						'caption'     => '',
+						'description' => '',
+					],
+					'video_preview'     => [
+						'ID'          => 32,
+						'url'         => 'https://example.com/preview.mp4',
+						'mime_type'   => 'video/mp4',
+						'subtype'     => 'mp4',
+						'filename'    => 'preview.mp4',
+						'filesize'    => 1024,
+						'alt'         => '',
+						'caption'     => '',
+						'description' => '',
+					],
+					'video'             => [
+						'ID'          => 33,
+						'url'         => 'https://example.com/full.mp4',
+						'mime_type'   => 'video/mp4',
+						'subtype'     => 'mp4',
+						'filename'    => 'full.mp4',
+						'filesize'    => 1024,
+						'alt'         => '',
+						'caption'     => '',
+						'description' => '',
+					],
+				],
+			],
+		];
+
+		Functions\when( 'size_format' )->justReturn( '1 KB' );
+		Functions\when( 'wp_get_attachment_image_src' )->justReturn( false );
+		Functions\expect( 'get_post_meta' )
+			->times( 3 )
+			->andReturn( 'av01.0.00M.08', 'none', 'none' );
+
+		$result = Helpers::fieldFormatter( $field );
+
+		$this->assertSame(
+			[
+				[
+					'src' => 'https://example.com/preview-av1.mp4',
+					'type' => 'video/mp4',
+					'codecs' => 'av01.0.00M.08',
+				],
+				[
+					'src' => 'https://example.com/preview.mp4',
+					'type' => 'video/mp4',
+					'codecs' => null,
+				],
+				[
+					'src' => 'https://example.com/full.mp4',
+					'type' => 'video/mp4',
+					'codecs' => null,
+				],
+			],
+			$result[0]['sources']
+		);
+	}
+
 	public function test_group_with_assoc_value(): void {
 		// Group with associative value (isAssoc returns true) — uses the else branch
 		$field = [
@@ -676,6 +760,32 @@ class FieldFormatterTest extends HelpersTestCase {
 
 		$this->assertSame( 'Hello', $result['heading'] );
 		$this->assertSame( 'World', $result['content'] );
+	}
+
+	public function test_group_assoc_value_does_not_append_video_sources(): void {
+		$field = [
+			'type'       => 'group',
+			'sub_fields' => [
+				[ 'name' => 'video_preview_av1', 'type' => 'text' ],
+				[ 'name' => 'video', 'type' => 'text' ],
+			],
+			'value'      => [
+				'video_preview_av1' => [
+					'src' => 'https://example.com/preview-av1.mp4',
+					'type' => 'video/mp4',
+					'codecs' => 'av01.0.00M.08',
+				],
+				'video'             => [
+					'src' => 'https://example.com/full.mp4',
+					'type' => 'video/mp4',
+					'codecs' => null,
+				],
+			],
+		];
+
+		$result = Helpers::fieldFormatter( $field );
+
+		$this->assertArrayNotHasKey( 'sources', $result );
 	}
 
 	public function test_group_with_sequential_rows(): void {

--- a/tests/Unit/Helpers/FormatFileTest.php
+++ b/tests/Unit/Helpers/FormatFileTest.php
@@ -41,6 +41,8 @@ class FormatFileTest extends HelpersTestCase {
 		$this->assertSame( 'pdf', $result['subtype'] );
 		$this->assertSame( 'doc.pdf', $result['filename'] );
 		$this->assertSame( '100 KB', $result['filesize'] );
+		$this->assertArrayHasKey( 'codecs', $result );
+		$this->assertNull( $result['codecs'] );
 	}
 
 	public function test_object_input(): void {
@@ -172,6 +174,69 @@ class FormatFileTest extends HelpersTestCase {
 		$result = Helpers::formatFile( $file );
 
 		$this->assertSame( [], $result['preview'] );
+	}
+
+	public function test_video_file_includes_av1_codecs(): void {
+		$file = [
+			'ID'          => 20,
+			'url'         => 'https://example.com/clip-av1.mp4',
+			'mime_type'   => 'video/mp4',
+			'subtype'     => 'mp4',
+			'filename'    => 'clip-av1.mp4',
+			'filesize'    => 1024,
+			'alt'         => '',
+			'caption'     => '',
+			'description' => '',
+		];
+
+		Functions\expect( 'get_post_meta' )
+			->once()
+			->with( 20, '_timber_kit_video_codecs', true )
+			->andReturn( '' );
+		Functions\expect( 'get_attached_file' )
+			->once()
+			->with( 20 )
+			->andReturn( dirname( __DIR__, 2 ) . '/Fixtures/video/av1-8bit.mp4' );
+		Functions\expect( 'update_post_meta' )
+			->once()
+			->with( 20, '_timber_kit_video_codecs', 'av01.0.00M.08' );
+
+		$result = Helpers::formatFile( $file );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'av01.0.00M.08', $result['codecs'] );
+	}
+
+	public function test_non_av1_video_file_includes_null_codecs(): void {
+		$file = [
+			'ID'          => 21,
+			'url'         => 'https://example.com/clip-h264.mp4',
+			'mime_type'   => 'video/mp4',
+			'subtype'     => 'mp4',
+			'filename'    => 'clip-h264.mp4',
+			'filesize'    => 1024,
+			'alt'         => '',
+			'caption'     => '',
+			'description' => '',
+		];
+
+		Functions\expect( 'get_post_meta' )
+			->once()
+			->with( 21, '_timber_kit_video_codecs', true )
+			->andReturn( '' );
+		Functions\expect( 'get_attached_file' )
+			->once()
+			->with( 21 )
+			->andReturn( dirname( __DIR__, 2 ) . '/Fixtures/video/h264.mp4' );
+		Functions\expect( 'update_post_meta' )
+			->once()
+			->with( 21, '_timber_kit_video_codecs', 'none' );
+
+		$result = Helpers::formatFile( $file );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'codecs', $result );
+		$this->assertNull( $result['codecs'] );
 	}
 
 	public function test_non_numeric_filesize_returns_empty_string(): void {

--- a/tests/Unit/Helpers/FormatVideoTest.php
+++ b/tests/Unit/Helpers/FormatVideoTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Helpers;
 
+use Brain\Monkey\Functions;
 use Parisek\TimberKit\Helpers;
 use Tests\Unit\HelpersTestCase;
 
@@ -21,6 +22,13 @@ class FormatVideoTest extends HelpersTestCase {
 			'description' => '',
 		];
 
+		Functions\expect( 'get_post_meta' )
+			->once()
+			->with( 5, '_timber_kit_video_codecs', true )
+			->andReturn( 'none' );
+		Functions\expect( 'get_attached_file' )->never();
+		Functions\expect( 'update_post_meta' )->never();
+
 		$result = Helpers::formatVideo( $video );
 
 		// formatVideo unwraps the nested array from formatImage
@@ -28,6 +36,38 @@ class FormatVideoTest extends HelpersTestCase {
 		$this->assertSame( 5, $result['id'] );
 		$this->assertSame( 'https://example.com/video.mp4', $result['src'] );
 		$this->assertSame( 'video/mp4', $result['type'] );
+		$this->assertArrayHasKey( 'codecs', $result );
+		$this->assertNull( $result['codecs'] );
+	}
+
+	public function test_video_includes_av1_codecs_after_unwrap(): void {
+		$video = [
+			'ID'          => 15,
+			'url'         => 'https://example.com/video-av1.mp4',
+			'mime_type'   => 'video/mp4',
+			'width'       => 1920,
+			'height'      => 1080,
+			'alt'         => '',
+			'caption'     => '',
+			'description' => '',
+		];
+
+		Functions\expect( 'get_post_meta' )
+			->once()
+			->with( 15, '_timber_kit_video_codecs', true )
+			->andReturn( '' );
+		Functions\expect( 'get_attached_file' )
+			->once()
+			->with( 15 )
+			->andReturn( dirname( __DIR__, 2 ) . '/Fixtures/video/av1-8bit.mp4' );
+		Functions\expect( 'update_post_meta' )
+			->once()
+			->with( 15, '_timber_kit_video_codecs', 'av01.0.00M.08' );
+
+		$result = Helpers::formatVideo( $video );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'av01.0.00M.08', $result['codecs'] );
 	}
 
 	public function test_object_input(): void {
@@ -41,6 +81,13 @@ class FormatVideoTest extends HelpersTestCase {
 			'caption'        => '',
 			'description'    => '',
 		];
+
+		Functions\expect( 'get_post_meta' )
+			->once()
+			->with( 5, '_timber_kit_video_codecs', true )
+			->andReturn( 'none' );
+		Functions\expect( 'get_attached_file' )->never();
+		Functions\expect( 'update_post_meta' )->never();
 
 		$result = Helpers::formatVideo( $video );
 

--- a/tests/Unit/Helpers/VideoCodecsHelperTest.php
+++ b/tests/Unit/Helpers/VideoCodecsHelperTest.php
@@ -12,6 +12,17 @@ class VideoCodecsHelperTest extends HelpersTestCase {
 
 	private const CACHE_KEY = '_timber_kit_video_codecs';
 
+	/**
+	 * @param array<string,mixed> $row
+	 * @return array<string,mixed>
+	 */
+	private function appendVideoSources( array $row ): array {
+		$method = new \ReflectionMethod( Helpers::class, 'appendVideoSources' );
+		$method->setAccessible( true );
+
+		return $method->invoke( null, $row );
+	}
+
 	public function test_cache_hit_returns_stored_codecs_without_recompute(): void {
 		Functions\expect( 'get_post_meta' )
 			->once()
@@ -120,5 +131,102 @@ class VideoCodecsHelperTest extends HelpersTestCase {
 			],
 			Helpers::formatVideoSources( $variants )
 		);
+	}
+
+	public function test_append_video_sources_builds_ordered_sources_from_formatted_row_variants(): void {
+		$row = [
+			'video_preview_av1' => [
+				'src' => 'https://example.test/preview-av1.mp4',
+				'type' => 'video/mp4',
+				'codecs' => 'av01.0.00M.08',
+			],
+			'video_preview' => [
+				'src' => 'https://example.test/preview.mp4',
+				'type' => 'video/mp4',
+				'codecs' => null,
+			],
+			'video' => [
+				'src' => 'https://example.test/full.mp4',
+				'type' => 'video/mp4',
+				'codecs' => null,
+			],
+		];
+
+		$this->assertSame(
+			[
+				[
+					'src' => 'https://example.test/preview-av1.mp4',
+					'type' => 'video/mp4',
+					'codecs' => 'av01.0.00M.08',
+				],
+				[
+					'src' => 'https://example.test/preview.mp4',
+					'type' => 'video/mp4',
+					'codecs' => null,
+				],
+				[
+					'src' => 'https://example.test/full.mp4',
+					'type' => 'video/mp4',
+					'codecs' => null,
+				],
+			],
+			$this->appendVideoSources( $row )['sources']
+		);
+	}
+
+	public function test_append_video_sources_skips_missing_variants_and_defaults_type(): void {
+		$row = [
+			'video_preview_av1' => [],
+			'video_preview' => [
+				'src' => '',
+				'type' => 'video/mp4',
+			],
+			'video' => [
+				'src' => 'https://example.test/full.mp4',
+				'codecs' => null,
+			],
+		];
+
+		$this->assertSame(
+			[
+				[
+					'src' => 'https://example.test/full.mp4',
+					'type' => 'video/mp4',
+					'codecs' => null,
+				],
+			],
+			$this->appendVideoSources( $row )['sources']
+		);
+	}
+
+	public function test_append_video_sources_leaves_rows_without_video_untouched(): void {
+		$row = [
+			'video_preview_av1' => [
+				'src' => 'https://example.test/preview-av1.mp4',
+				'type' => 'video/mp4',
+				'codecs' => 'av01.0.00M.08',
+			],
+		];
+
+		$this->assertSame( $row, $this->appendVideoSources( $row ) );
+	}
+
+	public function test_append_video_sources_never_overwrites_existing_sources_key(): void {
+		$row = [
+			'sources' => [
+				[
+					'src' => 'https://example.test/custom.webm',
+					'type' => 'video/webm',
+					'codecs' => null,
+				],
+			],
+			'video' => [
+				'src' => 'https://example.test/full.mp4',
+				'type' => 'video/mp4',
+				'codecs' => null,
+			],
+		];
+
+		$this->assertSame( $row, $this->appendVideoSources( $row ) );
 	}
 }


### PR DESCRIPTION
Owner decision superseding the opt-in-flag design from #82: video enrichment works automatically for every project — no per-project hooks, no StarterBase flag.

## Summary
- `formatFile()` / `formatVideo()` additively include `codecs` (bare RFC 6381 string from `Helpers::videoCodecs()`, meta-cached av1C parse; null for non-AV1/non-video). Key always present — stable shape.
- `fieldFormatter()` repeater rows carrying a `video` get a computed `sources` cascade `[{src, type, codecs}]` in `video_preview_av1` → `video_preview` → `video` order, missing variants skipped, **never overwriting an existing `sources` key**; runs before the `field_formatter_repeater` filter so projects can still post-process. Group (associative) path untouched.
- Purely ADDITIVE — `type` and every existing key stay byte-identical, so the feature-flag doctrine does not apply: existing consumers cannot observe any change unless they read the new keys.

## Verification
- `composer test`: 995 tests, 1781 assertions, green, notice/deprecation-free
- `composer phpstan`: level 8, no errors

First consumer: mairateam creative-slider (portadesign/mairateam#41) — after this releases, the project needs zero wiring (its former Base hooks are already removed).

Closes #82 (superseded — the additive design removes the hazards that motivated the flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8i5DsHnZ2LEuDjS1DDpBr