### PR TITLE
fix(updates): wp_slash content before wp_update_post — migrations corrupted JSON escapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `UpdateContext::transformBlocks()` now passes `wp_slash()`ed content to `wp_update_post()`. Without it, `wp_update_post()`'s internal `wp_unslash()` stripped every backslash from the serialized block JSON, so `\u003c`/`\u0026` escapes in ACF block attributes rendered as literal `u003c`/`u0026` text on the front end after any block-data migration (hit in production on mairateam, 2026-07-15). Regression test included.
+
 ## [1.23.0] - 2026-07-14
 
 ### Added

--- a/src/Updates/UpdateContext.php
+++ b/src/Updates/UpdateContext.php
@@ -66,7 +66,11 @@ class UpdateContext {
 				$result = wp_update_post(
 					[
 						'ID'           => $translation['post']->ID,
-						'post_content' => $changed,
+						// wp_update_post() runs wp_unslash() on its input; raw
+						// serialized block JSON would lose every backslash
+						// (\\u003c escapes render as literal "u003c" on the
+						// front end), so the content must go in slashed.
+						'post_content' => wp_slash( $changed ),
 					],
 					true
 				);

--- a/tests/Unit/Updates/UpdateContextTest.php
+++ b/tests/Unit/Updates/UpdateContextTest.php
@@ -47,6 +47,39 @@ class UpdateContextTest extends TestCase {
 		$this->assertStringContainsString( 'Old!', $writes[0]['post']['post_content'] );
 	}
 
+	public function test_transform_blocks_slashes_content_before_wp_update_post(): void {
+		// Regression (mairateam 2026-07-15): wp_update_post() unslashes
+		// post_content, so serialized block JSON written without wp_slash()
+		// loses every backslash - \u003c escapes render as literal "u003c"
+		// on the front end. The runner must hand wp_update_post slashed content.
+		$writes = [];
+		Functions\when( 'get_post' )->justReturn( new \WP_Post( [ 'ID' => 10, 'post_type' => 'page', 'post_content' => '<!-- old -->' ] ) );
+		Functions\when( 'apply_filters' )->alias( static fn ( string $filter, mixed $default ) => $default );
+		Functions\when( 'parse_blocks' )->justReturn( [
+			[ 'blockName' => 'acf/card', 'attrs' => [ 'data' => [ 'title' => 'Old' ] ], 'innerBlocks' => [] ],
+		] );
+		Functions\when( 'serialize_blocks' )->justReturn( '<!-- wp:acf/card {"perex":"a \\u003cstrong\\u003eb\\u003c/strong\\u003e"} /-->' );
+		Functions\when( 'wp_slash' )->alias( static fn ( string $value ): string => addslashes( $value ) );
+		Functions\when( 'wp_update_post' )->alias(
+			function ( array $post, bool $wp_error ) use ( &$writes ): int {
+				$writes[] = $post;
+				return (int) $post['ID'];
+			}
+		);
+
+		( new UpdateContext( false ) )->transformBlocks(
+			'acf/card',
+			static fn ( array $data ): array => [ 'title' => 'New' ],
+			[ 10 ]
+		);
+
+		$this->assertSame(
+			addslashes( '<!-- wp:acf/card {"perex":"a \\u003cstrong\\u003eb\\u003c/strong\\u003e"} /-->' ),
+			$writes[0]['post_content'],
+			'post_content must be wp_slash()ed so wp_update_post\'s unslash restores the original'
+		);
+	}
+
 	public function test_transform_blocks_fans_out_wpml_translations_with_languages(): void {
 		$seen = [];
 		Functions\when( 'get_post' )->alias( static fn ( int $id ): \WP_Post => new \WP_Post( [ 'ID' => $id, 'post_type' => 'page', 'post_content' => '' ] ) );


### PR DESCRIPTION
## Root cause

`UpdateContext::transformBlocks()` handed the freshly serialized block content straight to `wp_update_post()`, which runs `wp_unslash()` on its input (form-submission legacy). Every backslash in the serialized JSON was stripped: `\u003cstrong\u003e` became literal `u003cstrongu003e`, `\u0026` became `u0026`, `\r\n` became `rn` — visible as raw escape text on the front end of every post a migration touched.

## Production hit (2026-07-15, mairateam)

`creative-slider:0001` corrupted the CS + EN homepage (testimonial `<strong>`, hero `<br>` titles, `&` in tab labels). Repaired in place from pre-migration revisions; this PR fixes the cause.

## Fix

`'post_content' => wp_slash( $changed )` — one line, plus a regression test asserting the write payload reaching `wp_update_post()` is slashed (Brain Monkey's `wp_slash` stub is real `addslashes`, so the assertion exercises the actual round-trip contract). 996 tests green, PHPStan clean.

## Follow-up thought (not in this PR)

The runner could also *detect* this class of bug defensively: after a live write, re-read the post and compare against the intended content — a mismatch means some filter mangled it. Worth an issue if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2hV35qsSg1hXN1nnEReqs