### PR TITLE
feat(wpml): keep theme domain authoritative (exclude from String Translation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- `$wpml_theme_domain_authoritative` StarterBase flag (**default on**, same deliberate exception as `$wpml_skip_empty_translation_job_fields`): keeps the theme's gettext text-domain authoritative over WPML String Translation by runtime-injecting it into `icl_sitepress_settings['st']['wpml_st_auto_reg_excluded_contexts']` via a filter on `option_icl_sitepress_settings` — no `update_option()` write, nothing persisted. Without it, WPML ST scans the theme's compiled `.mo`, registers every string, and compiles its own overriding `wp-content/languages/wpml/<domain>-<locale>.mo` that WPML's Just-In-Time MO loader serves instead of the theme's own `.mo` — so editing the theme's `.po` and rebuilding has no visible effect, the corrected string keeps rendering its stale WPML-compiled value (hit in production on fellows, 2026-07-20). No-ops without WPML. Opt out with `false` in the project's `Base` if a project wants translators managing theme strings through WPML ST instead of the `.po`/`.mo` pipeline.
+
 ## [1.25.0] - 2026-07-16
 
 ### Added

--- a/src/Cli/WpmlCleanupThemeDomainCommand.php
+++ b/src/Cli/WpmlCleanupThemeDomainCommand.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit\Cli;
+
+use Parisek\TimberKit\Wpml\ThemeDomainCleanupPlan;
+
+/**
+ * `wp timber-kit wpml-cleanup-theme-domain` — purge leftover WPML String
+ * Translation rows and compiled translation files for a text domain that
+ * `$wpml_theme_domain_authoritative` has excluded from ST.
+ *
+ * Once a project runs with `$wpml_theme_domain_authoritative` ON (the
+ * default — see
+ * {@see \Parisek\TimberKit\StarterBase::wpml_exclude_theme_domain_from_st()}),
+ * WPML stops registering new strings for the theme's domain and stops
+ * compiling an overriding `.mo` for it. Rows String Translation had already
+ * registered *before* the exclusion took effect are left behind: inert
+ * (WPML's Just-In-Time MO loader skips the excluded domain, and ST no
+ * longer surfaces them to translators) but still occupying
+ * `icl_strings` / `icl_string_translations` / `icl_string_positions`, plus
+ * whatever compiled `.mo` / `.l10n.php` / `.json` files WPML already wrote
+ * to `wp-content/languages/wpml/`. This command removes both, so the
+ * theme's own `.po`/`.mo` pair is unambiguously the only place translators
+ * and developers need to look.
+ *
+ * Verified against a real site (fellows): 102 `icl_strings`,
+ * 69 `icl_string_translations`, and 27 `icl_string_positions` rows existed
+ * for the theme's domain, all safely removable once the domain was
+ * excluded — the numbers this command's own report line format is modelled
+ * on.
+ *
+ * Thin adapter over {@see ThemeDomainCleanupPlan}: counting and the
+ * has-work / report decision are computed by a unit-tested pure class fed
+ * with already-queried numbers and an already-globbed file list; the
+ * WP_CLI I/O, SQL DELETEs, and filesystem unlinks here are intentionally
+ * not unit-tested (same doctrine as the other `Cli/*` commands).
+ */
+class WpmlCleanupThemeDomainCommand {
+
+	/**
+	 * Remove leftover WPML String Translation rows and compiled translation
+	 * files for a text domain excluded via `$wpml_theme_domain_authoritative`.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--domain=<domain>]
+	 * : Text domain to clean up. Default: the active theme's `TextDomain` —
+	 *   the same domain `$wpml_theme_domain_authoritative` excludes.
+	 *
+	 * [--dry-run]
+	 * : Count and report what would be removed. Deletes nothing.
+	 *
+	 * [--yes]
+	 * : Skip the confirmation prompt before a real (non-dry-run) deletion.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp timber-kit wpml-cleanup-theme-domain --dry-run
+	 *     wp timber-kit wpml-cleanup-theme-domain
+	 *     wp timber-kit wpml-cleanup-theme-domain --domain=fellows --yes
+	 *
+	 * @param array<int, string>    $args       Positional args (unused).
+	 * @param array<string, string> $assoc_args Associative args.
+	 * @return void
+	 */
+	public function __invoke( $args, $assoc_args ) {
+		global $wpdb;
+
+		if ( ! $this->stringTranslationActive() ) {
+			\WP_CLI::error( 'WPML String Translation is not active — icl_strings table not found.' );
+			return;
+		}
+
+		$domain = isset( $assoc_args['domain'] ) && '' !== trim( (string) $assoc_args['domain'] )
+			? trim( (string) $assoc_args['domain'] )
+			: $this->defaultDomain();
+
+		if ( '' === $domain ) {
+			\WP_CLI::error( 'No text domain resolved — pass --domain=<domain> explicitly.' );
+			return;
+		}
+
+		$dry_run = isset( $assoc_args['dry-run'] );
+
+		$string_count = (int) $wpdb->get_var(
+			$wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}icl_strings WHERE context = %s", $domain ) // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is $wpdb->prefix, value goes through prepare().
+		);
+		$translation_count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->prefix}icl_string_translations t" // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is $wpdb->prefix, value goes through prepare().
+				. " JOIN {$wpdb->prefix}icl_strings s ON s.id = t.string_id WHERE s.context = %s",
+				$domain
+			)
+		);
+		$position_count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->prefix}icl_string_positions p" // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is $wpdb->prefix, value goes through prepare().
+				. " JOIN {$wpdb->prefix}icl_strings s ON s.id = p.string_id WHERE s.context = %s",
+				$domain
+			)
+		);
+
+		$compiled_files = $this->compiledFiles( $domain );
+
+		$plan = new ThemeDomainCleanupPlan( $domain, $string_count, $translation_count, $position_count, $compiled_files );
+
+		foreach ( $plan->reportLines() as $line ) {
+			\WP_CLI::log( $line );
+		}
+
+		if ( ! $plan->hasWork() ) {
+			\WP_CLI::success( 'Nothing to clean up — domain is already clear.' );
+			return;
+		}
+
+		if ( $dry_run ) {
+			\WP_CLI::log( 'Dry-run only. Re-run without --dry-run to delete.' );
+			return;
+		}
+
+		\WP_CLI::confirm(
+			sprintf( 'Delete these WPML String Translation rows and compiled files for "%s"?', $domain ),
+			$assoc_args
+		);
+
+		// Children before parent — icl_string_translations / icl_string_positions
+		// carry a string_id FK into icl_strings. JOIN-style deletes (rather than
+		// a `string_id IN (SELECT id FROM icl_strings WHERE …)` subquery) avoid
+		// MySQL's "can't specify target table for update in FROM clause" trap.
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE t FROM {$wpdb->prefix}icl_string_translations t" // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is $wpdb->prefix, value goes through prepare().
+				. " JOIN {$wpdb->prefix}icl_strings s ON s.id = t.string_id WHERE s.context = %s",
+				$domain
+			)
+		);
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE p FROM {$wpdb->prefix}icl_string_positions p" // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is $wpdb->prefix, value goes through prepare().
+				. " JOIN {$wpdb->prefix}icl_strings s ON s.id = p.string_id WHERE s.context = %s",
+				$domain
+			)
+		);
+		$wpdb->query(
+			$wpdb->prepare( "DELETE FROM {$wpdb->prefix}icl_strings WHERE context = %s", $domain ) // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is $wpdb->prefix, value goes through prepare().
+		);
+
+		$deleted_files = 0;
+		foreach ( $compiled_files as $file ) {
+			if ( @unlink( $file ) ) { // phpcs:ignore WordPress.PHP.NoSilencedErrors -- unlink() emits a warning on failure; the branch below already reports it via WP_CLI::warning().
+				++$deleted_files;
+			} else {
+				\WP_CLI::warning( sprintf( 'Failed to delete %s.', $file ) );
+			}
+		}
+
+		if ( function_exists( 'do_action' ) ) {
+			do_action( 'wpml_cache_clear' );
+		}
+
+		\WP_CLI::success(
+			sprintf(
+				'Removed %d icl_strings, %d icl_string_translations, %d icl_string_positions, %d compiled file(s) for "%s".',
+				$string_count,
+				$translation_count,
+				$position_count,
+				$deleted_files,
+				$domain
+			)
+		);
+	}
+
+	/**
+	 * WPML String Translation active check — table presence, not a class or
+	 * constant, since ST doesn't advertise itself as reliably as SitePress
+	 * does via `ICL_SITEPRESS_VERSION`.
+	 */
+	private function stringTranslationActive(): bool {
+		global $wpdb;
+
+		$table = $wpdb->prefix . 'icl_strings';
+		$found = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->esc_like( $table ) ) );
+
+		return $table === $found;
+	}
+
+	/**
+	 * Default text domain — the active theme's `TextDomain` header, the same
+	 * value `StarterBase::resolveThemeName()` resolves for
+	 * `$wpml_theme_domain_authoritative`.
+	 */
+	private function defaultDomain(): string {
+		if ( ! function_exists( 'wp_get_theme' ) ) {
+			return '';
+		}
+
+		$name = wp_get_theme()->get( 'TextDomain' );
+
+		return is_string( $name ) ? $name : '';
+	}
+
+	/**
+	 * Compiled WPML translation files for the domain, globbed from
+	 * `wp-content/languages/wpml/` — `<domain>-<locale>.mo`, the newer
+	 * `.l10n.php` PHP-array export, and `.json` (Jed) variants.
+	 *
+	 * @return list<string>
+	 */
+	private function compiledFiles( string $domain ): array {
+		if ( ! defined( 'WP_LANG_DIR' ) ) {
+			return array();
+		}
+
+		$dir = rtrim( WP_LANG_DIR, '/' ) . '/wpml';
+		if ( ! is_dir( $dir ) ) {
+			return array();
+		}
+
+		$patterns = array(
+			$dir . '/' . $domain . '-*.mo',
+			$dir . '/' . $domain . '-*.l10n.php',
+			$dir . '/' . $domain . '-*.json',
+		);
+
+		$files = array();
+		foreach ( $patterns as $pattern ) {
+			$matches = glob( $pattern );
+			if ( is_array( $matches ) ) {
+				$files = array_merge( $files, $matches );
+			}
+		}
+
+		return array_values( array_unique( $files ) );
+	}
+}

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -586,6 +586,13 @@ class StarterBase extends Site {
 	 * originals — a deliberate opt-in sweep, never an on-upload hook. See
 	 * {@see \Parisek\TimberKit\OriginalImagePruner}.
 	 *
+	 * `timber-kit wpml-cleanup-theme-domain` is the companion cleanup for
+	 * `$wpml_theme_domain_authoritative` — it purges the WPML String
+	 * Translation rows and compiled `.mo`/`.l10n.php`/`.json` files that were
+	 * already registered for the theme's domain before the exclusion took
+	 * effect. See
+	 * {@see \Parisek\TimberKit\Cli\WpmlCleanupThemeDomainCommand}.
+	 *
 	 * @return void
 	 */
 	private function registerCliCommands(): void {
@@ -597,6 +604,7 @@ class StarterBase extends Site {
 		\WP_CLI::add_command( 'timber-kit convert-utf8mb4', \Parisek\TimberKit\Cli\ConvertUtf8mb4Command::class );
 		\WP_CLI::add_command( 'timber-kit updates', \Parisek\TimberKit\Cli\UpdatesCommand::class );
 		\WP_CLI::add_command( 'timber-kit acfml-sync-preferences', \Parisek\TimberKit\Cli\AcfmlSyncPreferencesCommand::class );
+		\WP_CLI::add_command( 'timber-kit wpml-cleanup-theme-domain', \Parisek\TimberKit\Cli\WpmlCleanupThemeDomainCommand::class );
 	}
 
 	/**

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -2360,6 +2360,11 @@ class StarterBase extends Site {
 	 * itself (that would recurse through this same filter and/or write
 	 * unnecessarily on every page load).
 	 *
+	 * No-ops when `$this->theme_name` is empty — an unresolved theme name
+	 * (e.g. `resolveThemeName()` failing before `register()` sets it) must
+	 * never inject a bare `''` into the excluded-contexts list, which would
+	 * excuse WPML from registering *every* domain-less string.
+	 *
 	 * Hooked to `option_icl_sitepress_settings`.
 	 *
 	 * @param mixed $settings The `icl_sitepress_settings` option value.
@@ -2379,7 +2384,7 @@ class StarterBase extends Site {
 			? $settings['st']['wpml_st_auto_reg_excluded_contexts']
 			: array();
 
-		if ( ! in_array( $this->theme_name, $excluded, true ) ) {
+		if ( '' !== (string) $this->theme_name && ! in_array( $this->theme_name, $excluded, true ) ) {
 			$excluded[] = $this->theme_name;
 			$settings['st']['wpml_st_auto_reg_excluded_contexts'] = array_values( $excluded );
 		}

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -375,6 +375,38 @@ class StarterBase extends Site {
 	protected bool $wpml_skip_empty_translation_job_fields = true;
 
 	/**
+	 * Keep the theme's gettext text-domain authoritative over WPML String
+	 * Translation. WPML ST scans the theme's compiled `.mo`, registers every
+	 * string it finds, and then compiles its own overriding
+	 * `wp-content/languages/wpml/<domain>-<locale>.mo` — which WPML's
+	 * Just-In-Time MO loader loads *instead of* the theme's own `.mo` at
+	 * runtime. That silently desyncs the theme's `.po` source of truth:
+	 * editing the `.po` and rebuilding the `.mo` has no visible effect,
+	 * because WPML's separately-compiled `.mo` still wins (observed in
+	 * production — a corrected string kept rendering its stale value).
+	 *
+	 * The fix runtime-injects the theme's text-domain into
+	 * `icl_sitepress_settings['st']['wpml_st_auto_reg_excluded_contexts']`
+	 * via a filter on `option_icl_sitepress_settings` — no `update_option()`
+	 * call, nothing persisted to the database. A domain in that list is (a)
+	 * excluded from WPML ST auto-registration, and (b) skipped by WPML's
+	 * Just-In-Time `.mo` loader, so the theme's own `load_theme_textdomain()`
+	 * call serves its `.mo` directly and stays the single source of truth.
+	 *
+	 * Default ON — a deliberate exception to the default-off flag doctrine:
+	 * the theme's `.po`/`.mo` pair is already version-controlled and
+	 * dev-managed, so WPML ST managing the same strings a second time is
+	 * pure redundancy with a silent-override failure mode. No-ops without
+	 * WPML — `option_icl_sitepress_settings` is simply never read. Opt out
+	 * with `false` in the project's `Base` if a project deliberately wants
+	 * translators to manage theme strings through WPML ST instead of the
+	 * `.po`/`.mo` pipeline.
+	 *
+	 * @var bool
+	 */
+	protected bool $wpml_theme_domain_authoritative = true;
+
+	/**
 	 * Clear the whole Breeze page cache when a nav menu is saved
 	 * (`wp_update_nav_menu`), mirroring the existing options-save behavior in
 	 * {@see clear_cache_on_options_save()}. Menus render on every page, so a
@@ -723,6 +755,9 @@ class StarterBase extends Site {
 		}
 		if ( $this->wpml_skip_empty_translation_job_fields ) {
 			add_filter( 'wpml_tm_translation_job_data', array( $this, 'wpml_skip_empty_translation_job_fields' ) );
+		}
+		if ( $this->wpml_theme_domain_authoritative ) {
+			add_filter( 'option_icl_sitepress_settings', array( $this, 'wpml_exclude_theme_domain_from_st' ) );
 		}
 	}
 
@@ -2310,6 +2345,46 @@ class StarterBase extends Site {
 		}
 
 		return $package;
+	}
+
+	/**
+	 * Runtime-inject the theme's text-domain into WPML String Translation's
+	 * excluded-contexts list so WPML neither registers the theme's strings
+	 * nor compiles an overriding `.mo` for them — the theme's own `.po`/`.mo`
+	 * stays the single source of truth. See the
+	 * `$wpml_theme_domain_authoritative` property docblock for the full
+	 * rationale.
+	 *
+	 * Filters the option at read time only — nothing is persisted back to
+	 * the database, so this never calls `get_option()`/`update_option()`
+	 * itself (that would recurse through this same filter and/or write
+	 * unnecessarily on every page load).
+	 *
+	 * Hooked to `option_icl_sitepress_settings`.
+	 *
+	 * @param mixed $settings The `icl_sitepress_settings` option value.
+	 * @return mixed Settings with the theme's text-domain added to
+	 *               `st.wpml_st_auto_reg_excluded_contexts`.
+	 */
+	public function wpml_exclude_theme_domain_from_st( $settings ) {
+		if ( ! is_array( $settings ) ) {
+			return $settings;
+		}
+
+		if ( ! isset( $settings['st'] ) || ! is_array( $settings['st'] ) ) {
+			$settings['st'] = array();
+		}
+
+		$excluded = isset( $settings['st']['wpml_st_auto_reg_excluded_contexts'] ) && is_array( $settings['st']['wpml_st_auto_reg_excluded_contexts'] )
+			? $settings['st']['wpml_st_auto_reg_excluded_contexts']
+			: array();
+
+		if ( ! in_array( $this->theme_name, $excluded, true ) ) {
+			$excluded[] = $this->theme_name;
+			$settings['st']['wpml_st_auto_reg_excluded_contexts'] = array_values( $excluded );
+		}
+
+		return $settings;
 	}
 
 	/**

--- a/src/Wpml/ThemeDomainCleanupPlan.php
+++ b/src/Wpml/ThemeDomainCleanupPlan.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit\Wpml;
+
+/**
+ * Pure computation for `wp timber-kit wpml-cleanup-theme-domain`.
+ *
+ * Given pre-counted row counts (already queried from `icl_strings` /
+ * `icl_string_translations` / `icl_string_positions`) and a pre-globbed list
+ * of compiled WPML translation files for a text domain, decides whether
+ * there is anything left to remove and renders the human-readable report
+ * lines the command prints before acting.
+ *
+ * All I/O — the SQL SELECT/DELETE statements and the filesystem glob/unlink
+ * calls — happens in
+ * {@see \Parisek\TimberKit\Cli\WpmlCleanupThemeDomainCommand}; this class only
+ * reasons about numbers and paths it's handed, so it is unit-testable
+ * without a database or filesystem (same split as
+ * {@see \Parisek\TimberKit\Health\Db\ConversionPlan} and
+ * {@see \Parisek\TimberKit\Acfml\PreferenceSyncPlan}).
+ */
+final class ThemeDomainCleanupPlan {
+
+	/**
+	 * @param list<string> $compiled_files Absolute paths of compiled WPML
+	 *                                     translation files (`.mo`,
+	 *                                     `.l10n.php`, `.json`) matched for
+	 *                                     this domain.
+	 */
+	public function __construct(
+		private readonly string $domain,
+		private readonly int $string_count,
+		private readonly int $string_translation_count,
+		private readonly int $string_position_count,
+		private readonly array $compiled_files
+	) {
+	}
+
+	public function domain(): string {
+		return $this->domain;
+	}
+
+	public function stringCount(): int {
+		return $this->string_count;
+	}
+
+	public function stringTranslationCount(): int {
+		return $this->string_translation_count;
+	}
+
+	public function stringPositionCount(): int {
+		return $this->string_position_count;
+	}
+
+	/**
+	 * @return list<string>
+	 */
+	public function compiledFiles(): array {
+		return $this->compiled_files;
+	}
+
+	/**
+	 * Whether there is anything left for this domain — either in String
+	 * Translation's tables or on disk as a compiled file.
+	 */
+	public function hasWork(): bool {
+		return $this->string_count > 0
+			|| $this->string_translation_count > 0
+			|| $this->string_position_count > 0
+			|| array() !== $this->compiled_files;
+	}
+
+	/**
+	 * Human-readable report lines, printed regardless of --dry-run.
+	 *
+	 * @return list<string>
+	 */
+	public function reportLines(): array {
+		return array(
+			sprintf( 'Text domain: %s', $this->domain ),
+			sprintf( '  icl_strings rows: %d', $this->string_count ),
+			sprintf( '  icl_string_translations rows: %d', $this->string_translation_count ),
+			sprintf( '  icl_string_positions rows: %d', $this->string_position_count ),
+			sprintf( '  compiled WPML files: %d', count( $this->compiled_files ) ),
+		);
+	}
+}

--- a/tests/Unit/StarterBase/RegisterMiscHooksTest.php
+++ b/tests/Unit/StarterBase/RegisterMiscHooksTest.php
@@ -81,7 +81,7 @@ class RegisterMiscHooksTest extends StarterBaseTestCase {
 		$this->assertNotContains( 'wp_update_nav_menu', array_column( $actions, 'hook' ) );
 	}
 
-	public function test_registers_exactly_three_filters_by_default(): void {
+	public function test_registers_exactly_four_filters_by_default(): void {
 		$filters = [];
 		Functions\when( 'add_filter' )->alias( function ( $hook, ...$rest ) use ( &$filters ) {
 			$filters[] = $hook;
@@ -90,8 +90,34 @@ class RegisterMiscHooksTest extends StarterBaseTestCase {
 		$this->invokeRegisterMiscHooks( $this->bareInstance() );
 
 		$this->assertSame(
-			[ 'run_wptexturize', 'wpcf7_autop_or_not', 'wpml_tm_translation_job_data' ],
+			[ 'run_wptexturize', 'wpcf7_autop_or_not', 'wpml_tm_translation_job_data', 'option_icl_sitepress_settings' ],
 			$filters
 		);
+	}
+
+	public function test_registers_wpml_theme_domain_authoritative_filter_by_default(): void {
+		$filters = [];
+		Functions\when( 'add_filter' )->alias( function ( $hook, ...$rest ) use ( &$filters ) {
+			$filters[] = $hook;
+		} );
+
+		$this->invokeRegisterMiscHooks( $this->bareInstance() );
+
+		$this->assertContains( 'option_icl_sitepress_settings', $filters );
+	}
+
+	public function test_does_not_register_wpml_theme_domain_authoritative_filter_when_flag_disabled(): void {
+		$filters = [];
+		Functions\when( 'add_filter' )->alias( function ( $hook, ...$rest ) use ( &$filters ) {
+			$filters[] = $hook;
+		} );
+
+		$instance = $this->bareInstance();
+		$prop     = new \ReflectionProperty( StarterBase::class, 'wpml_theme_domain_authoritative' );
+		$prop->setValue( $instance, false );
+
+		$this->invokeRegisterMiscHooks( $instance );
+
+		$this->assertNotContains( 'option_icl_sitepress_settings', $filters );
 	}
 }

--- a/tests/Unit/StarterBase/WpmlThemeDomainAuthoritativeTest.php
+++ b/tests/Unit/StarterBase/WpmlThemeDomainAuthoritativeTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\StarterBase;
+
+use Brain\Monkey\Functions;
+use Parisek\TimberKit\StarterBase;
+use Tests\Unit\StarterBaseTestCase;
+
+/**
+ * Covers the `$wpml_theme_domain_authoritative` flag (default on): hook wiring
+ * inside registerMiscHooks() and the option_icl_sitepress_settings callback
+ * that excludes the theme's text-domain from WPML String Translation.
+ *
+ * Why it matters: WPML ST scans the theme's compiled `.mo`, registers its
+ * strings, and compiles its own overriding
+ * `wp-content/languages/wpml/<domain>-<locale>.mo` — which WPML's
+ * Just-In-Time MO loader serves instead of the theme's own `.mo` at runtime.
+ * That silently desyncs the theme's `.po` source of truth. Excluding the
+ * theme's domain from ST's `wpml_st_auto_reg_excluded_contexts` keeps the
+ * theme `.po`/`.mo` as the single source.
+ */
+class WpmlThemeDomainAuthoritativeTest extends StarterBaseTestCase {
+
+	private function invokeRegisterMiscHooks( StarterBase $instance ): void {
+		$method = ( new \ReflectionClass( StarterBase::class ) )->getMethod( 'registerMiscHooks' );
+		$method->invoke( $instance );
+	}
+
+	private function bareInstance( ?bool $flag = null, string $theme_name = 'my-theme' ): StarterBase {
+		$instance = ( new \ReflectionClass( StarterBase::class ) )->newInstanceWithoutConstructor();
+		if ( null !== $flag ) {
+			$property = ( new \ReflectionClass( StarterBase::class ) )->getProperty( 'wpml_theme_domain_authoritative' );
+			$property->setValue( $instance, $flag );
+		}
+		$instance->theme_name = $theme_name;
+		return $instance;
+	}
+
+	public function test_filter_registered_by_default(): void {
+		$callbacks = [];
+		Functions\when( 'add_filter' )->alias( function ( $hook, $callback, ...$rest ) use ( &$callbacks ) {
+			$callbacks[ $hook ] = $callback;
+		} );
+		Functions\when( 'add_action' )->justReturn( true );
+
+		$instance = $this->bareInstance();
+		$this->invokeRegisterMiscHooks( $instance );
+
+		$this->assertArrayHasKey( 'option_icl_sitepress_settings', $callbacks );
+		$this->assertSame( [ $instance, 'wpml_exclude_theme_domain_from_st' ], $callbacks['option_icl_sitepress_settings'] );
+	}
+
+	public function test_filter_not_registered_when_flag_opted_out(): void {
+		$filters = [];
+		Functions\when( 'add_filter' )->alias( function ( $hook, ...$rest ) use ( &$filters ) {
+			$filters[] = $hook;
+		} );
+		Functions\when( 'add_action' )->justReturn( true );
+
+		$this->invokeRegisterMiscHooks( $this->bareInstance( false ) );
+
+		$this->assertNotContains( 'option_icl_sitepress_settings', $filters );
+	}
+
+	public function test_adds_theme_domain_to_empty_settings(): void {
+		$result = $this->bareInstance( true, 'my-theme' )->wpml_exclude_theme_domain_from_st( [] );
+
+		$this->assertSame( [ 'my-theme' ], $result['st']['wpml_st_auto_reg_excluded_contexts'] );
+	}
+
+	public function test_preserves_existing_excluded_contexts_and_appends_theme_domain(): void {
+		$settings = [
+			'st' => [
+				'wpml_st_auto_reg_excluded_contexts' => [ 'some-plugin' ],
+			],
+		];
+
+		$result = $this->bareInstance( true, 'my-theme' )->wpml_exclude_theme_domain_from_st( $settings );
+
+		$this->assertSame( [ 'some-plugin', 'my-theme' ], $result['st']['wpml_st_auto_reg_excluded_contexts'] );
+	}
+
+	public function test_does_not_duplicate_theme_domain_when_already_excluded(): void {
+		$settings = [
+			'st' => [
+				'wpml_st_auto_reg_excluded_contexts' => [ 'my-theme' ],
+			],
+		];
+
+		$result = $this->bareInstance( true, 'my-theme' )->wpml_exclude_theme_domain_from_st( $settings );
+
+		$this->assertSame( [ 'my-theme' ], $result['st']['wpml_st_auto_reg_excluded_contexts'] );
+	}
+
+	public function test_preserves_other_settings_keys(): void {
+		$settings = [
+			'st'          => [],
+			'other_key'   => 'untouched',
+			'setup_wizard' => true,
+		];
+
+		$result = $this->bareInstance( true, 'my-theme' )->wpml_exclude_theme_domain_from_st( $settings );
+
+		$this->assertSame( 'untouched', $result['other_key'] );
+		$this->assertTrue( $result['setup_wizard'] );
+	}
+
+	public function test_non_array_settings_returned_unchanged(): void {
+		$this->assertSame( 'not-an-array', $this->bareInstance( true )->wpml_exclude_theme_domain_from_st( 'not-an-array' ) );
+		$this->assertFalse( $this->bareInstance( true )->wpml_exclude_theme_domain_from_st( false ) );
+	}
+}

--- a/tests/Unit/StarterBase/WpmlThemeDomainAuthoritativeTest.php
+++ b/tests/Unit/StarterBase/WpmlThemeDomainAuthoritativeTest.php
@@ -111,4 +111,45 @@ class WpmlThemeDomainAuthoritativeTest extends StarterBaseTestCase {
 		$this->assertSame( 'not-an-array', $this->bareInstance( true )->wpml_exclude_theme_domain_from_st( 'not-an-array' ) );
 		$this->assertFalse( $this->bareInstance( true )->wpml_exclude_theme_domain_from_st( false ) );
 	}
+
+	public function test_empty_theme_name_does_not_inject_empty_string(): void {
+		$result = $this->bareInstance( true, '' )->wpml_exclude_theme_domain_from_st( [] );
+
+		$this->assertArrayNotHasKey( 'wpml_st_auto_reg_excluded_contexts', $result['st'] );
+	}
+
+	public function test_empty_theme_name_does_not_append_to_existing_excluded_contexts(): void {
+		$settings = [
+			'st' => [
+				'wpml_st_auto_reg_excluded_contexts' => [ 'some-plugin' ],
+			],
+		];
+
+		$result = $this->bareInstance( true, '' )->wpml_exclude_theme_domain_from_st( $settings );
+
+		$this->assertSame( [ 'some-plugin' ], $result['st']['wpml_st_auto_reg_excluded_contexts'] );
+		$this->assertNotContains( '', $result['st']['wpml_st_auto_reg_excluded_contexts'] );
+	}
+
+	public function test_st_key_not_an_array_is_replaced_without_fatal(): void {
+		$settings = [
+			'st' => 'not-an-array',
+		];
+
+		$result = $this->bareInstance( true, 'my-theme' )->wpml_exclude_theme_domain_from_st( $settings );
+
+		$this->assertSame( [ 'my-theme' ], $result['st']['wpml_st_auto_reg_excluded_contexts'] );
+	}
+
+	public function test_excluded_contexts_not_an_array_is_treated_as_empty(): void {
+		$settings = [
+			'st' => [
+				'wpml_st_auto_reg_excluded_contexts' => 'not-an-array',
+			],
+		];
+
+		$result = $this->bareInstance( true, 'my-theme' )->wpml_exclude_theme_domain_from_st( $settings );
+
+		$this->assertSame( [ 'my-theme' ], $result['st']['wpml_st_auto_reg_excluded_contexts'] );
+	}
 }

--- a/tests/Unit/Wpml/ThemeDomainCleanupPlanTest.php
+++ b/tests/Unit/Wpml/ThemeDomainCleanupPlanTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Wpml;
+
+use Parisek\TimberKit\Wpml\ThemeDomainCleanupPlan;
+use PHPUnit\Framework\TestCase;
+
+class ThemeDomainCleanupPlanTest extends TestCase {
+
+	public function test_has_work_when_any_row_count_is_nonzero(): void {
+		$plan = new ThemeDomainCleanupPlan( 'fellows', 102, 69, 27, [] );
+
+		$this->assertTrue( $plan->hasWork() );
+	}
+
+	public function test_has_work_when_only_compiled_files_remain(): void {
+		$plan = new ThemeDomainCleanupPlan( 'fellows', 0, 0, 0, [ '/wp-content/languages/wpml/fellows-cs_CZ.mo' ] );
+
+		$this->assertTrue( $plan->hasWork() );
+	}
+
+	public function test_no_work_when_everything_is_zero_and_no_files(): void {
+		$plan = new ThemeDomainCleanupPlan( 'fellows', 0, 0, 0, [] );
+
+		$this->assertFalse( $plan->hasWork() );
+	}
+
+	public function test_report_lines_include_domain_and_every_count(): void {
+		$plan  = new ThemeDomainCleanupPlan( 'fellows', 102, 69, 27, [
+			'/wp-content/languages/wpml/fellows-cs_CZ.mo',
+			'/wp-content/languages/wpml/fellows-en_US.mo',
+		] );
+		$lines = $plan->reportLines();
+
+		$this->assertSame( 'Text domain: fellows', $lines[0] );
+		$this->assertStringContainsString( '102', implode( "\n", $lines ) );
+		$this->assertStringContainsString( '69', implode( "\n", $lines ) );
+		$this->assertStringContainsString( '27', implode( "\n", $lines ) );
+		$this->assertStringContainsString( 'compiled WPML files: 2', implode( "\n", $lines ) );
+	}
+
+	public function test_accessors_return_constructor_values(): void {
+		$files = [ '/wp-content/languages/wpml/fellows-cs_CZ.mo' ];
+		$plan  = new ThemeDomainCleanupPlan( 'fellows', 102, 69, 27, $files );
+
+		$this->assertSame( 'fellows', $plan->domain() );
+		$this->assertSame( 102, $plan->stringCount() );
+		$this->assertSame( 69, $plan->stringTranslationCount() );
+		$this->assertSame( 27, $plan->stringPositionCount() );
+		$this->assertSame( $files, $plan->compiledFiles() );
+	}
+}


### PR DESCRIPTION
## From-Project

fellows (WordPress + WPML) — a theme string was corrected in the `.po` file, the `.mo` was rebuilt, and the site kept rendering the old value. Root cause: WPML String Translation had already scanned the theme's `.mo`, registered the strings into ST, and compiled its own overriding `wp-content/languages/wpml/<domain>-<locale>.mo` — which WPML's Just-In-Time MO loader serves *instead of* the theme's own `.mo` at runtime. Editing the theme's `.po` source of truth silently had no effect.

## Why

Verified against WPML String Translation 3.5.x source: a text-domain listed in `icl_sitepress_settings['st']['wpml_st_auto_reg_excluded_contexts']` is (a) excluded from ST auto-registration (`Settings::isDomainRegistrationExcluded()`), and (b) skipped by WPML's Just-In-Time `.mo` loader (`MOFactory::get()` iterates every domain except the excluded ones — `'default'` is always excluded there too). Adding the theme's own domain to that list keeps the theme's `.po`/`.mo` pair — dev-managed, version-controlled — as the single, authoritative source for theme strings, instead of silently forking into a second WPML-managed copy.

## What

New StarterBase flag, `protected bool $wpml_theme_domain_authoritative = true;` (default on, same deliberate exception to the default-off flag doctrine as `$wpml_skip_empty_translation_job_fields` — the off-by-default state is the harmful one here). When on, registers a filter on `option_icl_sitepress_settings` that injects `$this->theme_name` into the excluded-contexts array **at read time only** — no `update_option()` call, nothing persisted to the database, applies everywhere WPML reads the setting. No-ops entirely on non-WPML sites (the option filter simply never fires).

```php
protected bool $wpml_theme_domain_authoritative = true;

// registered in registerMiscHooks(), alongside the sibling WPML flags
if ( $this->wpml_theme_domain_authoritative ) {
    add_filter( 'option_icl_sitepress_settings', array( $this, 'wpml_exclude_theme_domain_from_st' ) );
}

public function wpml_exclude_theme_domain_from_st( $settings ) {
    // ...injects $this->theme_name into $settings['st']['wpml_st_auto_reg_excluded_contexts']
}
```

## Migration note for existing sites — now automated via WP-CLI

Sites upgrading to this version where WPML String Translation has **already** registered the theme's domain need a one-time cleanup, since the flag only prevents *future* registration/override. This is now a single command instead of a manual admin-UI pass:

```
wp timber-kit wpml-cleanup-theme-domain --dry-run
wp timber-kit wpml-cleanup-theme-domain
```

`WpmlCleanupThemeDomainCommand` (new `src/Cli/WpmlCleanupThemeDomainCommand.php`, backed by the unit-tested pure `src/Wpml/ThemeDomainCleanupPlan.php`):

1. Resolves the target domain (`--domain=<name>`, default the theme's own `TextDomain`) and guards on WPML String Translation being active (`icl_strings` table present).
2. Counts, then (JOIN-style, children before parent) deletes `icl_string_translations` and `icl_string_positions` rows keyed off `icl_strings.context = <domain>`, then the `icl_strings` rows themselves.
3. Globs and deletes the compiled `wp-content/languages/wpml/<domain>-*.{mo,l10n.php,json}` files, and fires `wpml_cache_clear`.
4. `--dry-run` reports counts/files without deleting anything; a real delete prompts for confirmation unless `--yes` is passed.

Verified against a real site (fellows) before this PR: 102 `icl_strings`, 69 `icl_string_translations`, 27 `icl_string_positions` rows for the theme's domain — all safely removable once the domain was excluded, since WPML's JIT MOFactory already skips the excluded domain and the theme's own `.po`/`.mo` is authoritative.

Sites that haven't hit this yet (fresh installs, or WPML ST never scanned the theme) need no manual step — the flag is preventative by default, and the cleanup command reports "nothing to clean up" for them.

## Test plan

- [x] `php -l` on all changed/added files — no syntax errors
- [x] `composer test` (PHPUnit Unit suite, incl. new `tests/Unit/Wpml/ThemeDomainCleanupPlanTest.php`) — green
- [x] `phpstan analyse` (level 8) — no errors
- [ ] CI (this repo has GitHub Actions — waiting on checks before calling this ready)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fgb38FaYZjZufuA7CYyowq
