### PR TITLE
ci: release guard runs every test suite, not just Unit

### DIFF
--- a/.github/workflows/release-stamp.yml
+++ b/.github/workflows/release-stamp.yml
@@ -61,11 +61,12 @@ jobs:
 
       - run: composer install --no-interaction --prefer-dist
 
-      - name: Run tests
-        run: composer test
-
-      - name: Run PHPStan
-        run: composer phpstan
+      # `composer check` = test:all + phpstan. Deliberately NOT `composer test`,
+      # which is the Unit suite only (--testsuite=Unit) — the property suite was
+      # never part of this guard, so a release could be stamped without its
+      # 4317 generative assertions. It costs ~1s against Unit's ~18s.
+      - name: Run the full suite + PHPStan
+        run: composer check
 
       - name: Stamp CHANGELOG
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Release guard runs every test suite.** `release-stamp.yml` ran
+  `composer test`, which is the Unit suite only (`--testsuite=Unit`), so a
+  version could be stamped without the property suite's generative assertions.
+  It now runs a new `composer check` (`test:all` + `phpstan`) — the property
+  suite takes ~1s against Unit's ~18s, so there was no cost reason to omit it.
+  Also brings the `check` script in line with the sibling packages.
+
 ## [1.26.0] - 2026-07-20
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,10 @@
         }
     },
     "scripts": {
+        "check": [
+            "@test:all",
+            "@phpstan"
+        ],
         "phpstan": "php -d memory_limit=2G vendor/bin/phpstan analyse",
         "test": "vendor/bin/phpunit --testsuite=Unit",
         "test:all": [


### PR DESCRIPTION
`release-stamp.yml` guarded the tag with `composer test` — which in this repo is `vendor/bin/phpunit --testsuite=Unit`. **The property suite was never part of it**, so a version could be stamped without its generative assertions.

## Measured before changing anything

| Suite | Tests | Assertions | Time |
|---|---:|---:|---:|
| Unit (`composer test`) | 1016 | 1 812 | **18.0 s** |
| Property (`composer test:property`) | 8 | **4 317** | **1.0 s** |

The property suite carries **more than twice Unit's assertions in a twentieth of the time**. There was no cost argument for leaving it out — it looks like the guard predates the suite rather than a decision to exclude it.

## Changes

- **`composer check`** (= `test:all` + `phpstan`), matching `definition-kit` and `acf-json-schema`.
- The release guard now calls it.

`check` is deliberately over **`test:all`**, not `test`. An alias that silently skips a suite is *worse* than no alias, because it reads as a full check at every call site — the exact silent-state shape this whole line of work has been unpicking.

## Accepted risk

Property tests are randomized, so this can fail on a run that previously passed. That's accepted: a generative counterexample found just before a release is the most valuable moment to find one. `main` already passed CI's own property job at merge, so this is a re-check, not the only gate. If it turns into a flaky gate we debug it then rather than pre-emptively weakening the guard.

## Context

Part of a small pass unifying the four `parisek/*` packages — see [`parisek/styleguide#101`](https://github.com/parisek/styleguide/pull/101), which found that repo documenting a manual release flow its own `release-stamp.yml` had already replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015S63CuroCq4vx1k83WutRZ