### PR TITLE
fix(helpers): let a context build defer a form embed instead of rendering it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,43 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- `Helpers::formatFields( $post, $is_preview, $render_embeds = true )` and the
+  matching `fieldFormatter()` parameter. `false` hands back the shortcode for a
+  `post_object` field pointing at a form (`wpforms`, `wpcf7_contact_form`)
+  instead of rendering it. The default is unchanged, so no existing caller
+  moves.
+
+  Pass it when building a context. A context build formats every field on the
+  options page whether or not the page will print it, and the documented
+  canonical call — `Helpers::formatFields( 'option' )` from `timber_context()`
+  — therefore rendered a form on **every** request of **every** page. Measured
+  on a production site: 6 kB of form markup built and discarded per request.
+
+  The asset cost is the larger half and the original report named the wrong
+  mechanism for it. WPForms enqueues in `wp_head` only when `is_singular()` and
+  the post content holds the shortcode or block; what loads its stylesheets and
+  jQuery site-wide is the `wp_footer` pass, which fires because a rendered form
+  registered itself during the context build. Same outcome, different hook, and
+  it matters: the fix has to stop the render, not the output.
+
+  A second copy of the form's element ids also landed in the DOM of any page
+  that rendered the same form itself.
+
+- `|shortcode` Twig filter, the other half. A deferred embed is a string, so the
+  one template that prints the form renders it there:
+  `{{ content.contact.form|shortcode }}`. Rendering at that point is when the
+  form plugin discovers the form; WPForms handles it explicitly by enqueueing on
+  `wp_footer`, at the cost of a brief flash of unstyled content — which is the
+  trade the deferral buys on every page that has no form at all.
+
+  A rendered form carries a nonce, so `fieldFormatter()` counts it as dynamic
+  and nothing may cache it. Deferring the embed is therefore also what lets the
+  rest of an options page be storable — the same rule the menu cache follows
+  ([ADR-0007](docs/adr/0007-prove-cache-purity-from-inputs.md)).
+
+
+### Added
+
 - `CacheSignature` — the shared part of every cross-request cache key: site,
   language, the current user's roles, and a content version from
   `wp_cache_get_last_changed()` over `posts` and `terms`. WordPress bumps those

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -794,6 +794,25 @@ class Helpers {
 	 * all, and reads identically to "the data is not there". `get_field()` by
 	 * name still resolves in that situation; prefer it when probing.
 	 *
+	 * **Pass `$render_embeds = false` when building a context.** A context build
+	 * formats every field on the options page whether or not the page will print
+	 * it, and a `post_object` pointing at a form is rendered by running its
+	 * shortcode. That spends the render on every page — measured at 6 kB of
+	 * markup on a site with one such field — and it is what makes the form
+	 * plugin load its stylesheets and jQuery site-wide: a rendered form
+	 * registers itself, and the plugin's `wp_footer` pass then enqueues assets
+	 * for it. It also puts a second copy of the form's element ids into the DOM
+	 * of any page that renders the same form itself.
+	 *
+	 * The template that actually prints the form renders it there:
+	 * `{{ content.contact.form|shortcode }}`.
+	 *
+	 * There is a second effect worth knowing. A rendered form carries a nonce,
+	 * so it is never a function of stored data and nothing may cache it —
+	 * `fieldFormatter()` counts it as dynamic for exactly that reason.
+	 * Deferring the embed is therefore also what lets the rest of an options
+	 * page be storable at all.
+	 *
 	 * @param object|int|string|null $post       Post object, term object, numeric post ID,
 	 *                                            options-page string key, or null to use the
 	 *                                            current queried object.
@@ -802,9 +821,14 @@ class Helpers {
 	 *                                            certain form plugins, and keeps the raw
 	 *                                            definition of an unfilled repeater /
 	 *                                            flexible_content so a placeholder can render.
+	 * @param bool                   $render_embeds False hands back the shortcode for a
+	 *                                            `post_object` field pointing at a form
+	 *                                            (`wpforms`, `wpcf7_contact_form`) instead of
+	 *                                            rendering it. Default true keeps every existing
+	 *                                            caller's behaviour.
 	 * @return array<string, mixed> Associative array keyed by ACF field name with formatted values.
 	 */
-	public static function formatFields( $post = null, $is_preview = false ) {
+	public static function formatFields( $post = null, $is_preview = false, bool $render_embeds = true ) {
 
 		$post_id = null;
 
@@ -870,7 +894,7 @@ class Helpers {
 		$content = [];
 		if ( ! empty( $fields ) ) {
 			foreach ( $fields as $key => $field ) {
-				$value = self::fieldFormatter( $field, $post_id, $is_preview );
+				$value = self::fieldFormatter( $field, $post_id, $is_preview, $render_embeds );
 
 				if ( self::isFormattedFieldPresent( $field, $value ) ) {
 					$content[ $key ] = $value;
@@ -1577,7 +1601,7 @@ class Helpers {
 	 *               checking `$field['type'] === 'true_false'` against the
 	 *               original field definition alongside the returned value.
 	 */
-	public static function fieldFormatter( $field, $post_id = null, $is_preview = false ) {
+	public static function fieldFormatter( $field, $post_id = null, $is_preview = false, bool $render_embeds = true ) {
 
 		// we need to allow post_id null when we are using it during preview block without saving
 		if ( empty( $field ) ) {
@@ -1674,21 +1698,29 @@ class Helpers {
 		} elseif ( $field['type'] === 'post_object' ) {
 
 			if ( $field['value'] instanceof \WP_Post ) {
+				// Two reasons to hand back the shortcode instead of the form.
+				// A preview cannot render one at all. And a caller building a
+				// context does not know whether the page will print it, so
+				// rendering costs every page the work and the plugin's assets —
+				// see `$render_embeds` on formatFields().
+				$defer = $is_preview || ! $render_embeds;
+
 				if ( $field['value']->post_type === 'wpcf7_contact_form' ) {
-					// during preview we need to return only shortcode as preview is not working
-					if ( $is_preview ) {
-						$field['value'] = '[contact-form-7 id="' . $field['value']->ID . '" title=""]';
-					} else {
-						++self::$dynamic_format_count;
-						$field['value'] = do_shortcode( '[contact-form-7 id="' . $field['value']->ID . '" title=""]' );
-					}
+					$shortcode = '[contact-form-7 id="' . $field['value']->ID . '" title=""]';
 				} elseif ( $field['value']->post_type === 'wpforms' ) {
-					if ( $is_preview ) {
-						// during preview we need to return only shortcode as preview is not working
-						$field['value'] = '[wpforms id="' . $field['value']->ID . '"]';
+					$shortcode = '[wpforms id="' . $field['value']->ID . '"]';
+				} else {
+					$shortcode = null;
+				}
+
+				if ( null !== $shortcode ) {
+					if ( $defer ) {
+						$field['value'] = $shortcode;
 					} else {
+						// A rendered form carries a nonce, so it is never a
+						// function of stored data. Nothing may cache it.
 						++self::$dynamic_format_count;
-						$field['value'] = do_shortcode( '[wpforms id="' . $field['value']->ID . '"]' );
+						$field['value'] = do_shortcode( $shortcode );
 					}
 				}
 			}
@@ -1716,7 +1748,7 @@ class Helpers {
 						foreach ( $value as $sub_key => &$sub_value ) {
 							if ( isset( $sub_fields[ $sub_key ] ) ) {
 								$sub_fields[ $sub_key ]['value'] = $sub_value;
-								$sub_value = self::fieldFormatter( $sub_fields[ $sub_key ], $post_id, $is_preview );
+								$sub_value = self::fieldFormatter( $sub_fields[ $sub_key ], $post_id, $is_preview, $render_embeds );
 							}
 						}
 						if ( 'repeater' === $field['type'] && is_array( $value ) ) {
@@ -1725,7 +1757,7 @@ class Helpers {
 					} else {
 						if ( isset( $sub_fields[ $key ] ) ) {
 							$sub_fields[ $key ]['value'] = $value;
-							$value = self::fieldFormatter( $sub_fields[ $key ], $post_id, $is_preview );
+							$value = self::fieldFormatter( $sub_fields[ $key ], $post_id, $is_preview, $render_embeds );
 						}
 					}
 				}
@@ -1755,13 +1787,13 @@ class Helpers {
 						foreach ( $value as $layout_key => &$layout_value ) {
 							if ( isset( $layouts[ $value['acf_fc_layout'] ][ $layout_key ] ) ) {
 								$layouts[ $value['acf_fc_layout'] ][ $layout_key ]['value'] = $layout_value;
-								$layout_value = self::fieldFormatter( $layouts[ $value['acf_fc_layout'] ][ $layout_key ], $post_id, $is_preview );
+								$layout_value = self::fieldFormatter( $layouts[ $value['acf_fc_layout'] ][ $layout_key ], $post_id, $is_preview, $render_embeds );
 							}
 						}
 					} else {
 						if ( isset( $layouts[ $key ] ) ) {
 							$layouts[ $key ]['value'] = $value;
-							$value = self::fieldFormatter( $layouts[ $key ], $post_id, $is_preview );
+							$value = self::fieldFormatter( $layouts[ $key ], $post_id, $is_preview, $render_embeds );
 						}
 					}
 				}

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -1733,6 +1733,7 @@ class StarterBase extends Site {
 			'is_safe'           => [ 'html' ],
 		] ) );
 		$twig->addFunction( new TwigFunction( 'merge_resizer', [ $this, 'twig_merge_resizer' ] ) );
+		$twig->addFilter( new TwigFilter( 'shortcode', [ $this, 'twig_shortcode' ], [ 'is_safe' => [ 'html' ] ] ) );
 		$twig->addFunction( new TwigFunction( 'gtm4wp_the_gtm_tag', [ $this, 'twig_gtm4wp_the_gtm_tag' ] ) );
 		$twig->addFunction( new TwigFunction( 'gtm_container', [ $this, 'twig_gtm_container' ] ) );
 		$twig->addFunction( new TwigFunction( 'gtm_container_noscript', [ $this, 'twig_gtm_container_noscript' ] ) );
@@ -1926,6 +1927,33 @@ class StarterBase extends Site {
 		} catch ( \Throwable $e ) {
 			return false;
 		}
+	}
+
+	/**
+	 * Expand shortcodes in a value, at the point a template prints it.
+	 *
+	 * The other half of `formatFields()`'s `$render_embeds` parameter. A
+	 * context build hands back `[wpforms id="12"]` rather than a rendered form,
+	 * because it cannot know whether the page will print it. The one template
+	 * that does print it says so:
+	 *
+	 * ```twig
+	 * {{ content.contact.form|shortcode }}
+	 * ```
+	 *
+	 * Rendering here rather than during the context build is also when the form
+	 * plugin discovers it. WPForms handles that case explicitly — assets it
+	 * missed in `wp_head` are enqueued again on `wp_footer`, at the cost of a
+	 * brief flash of unstyled content, which is the trade the deferral buys on
+	 * every page that has no form at all.
+	 *
+	 * Marked `is_safe`, because the point of the filter is to emit markup.
+	 *
+	 * @param mixed $value Value that may hold shortcodes.
+	 * @return mixed Value with shortcodes expanded; non-strings pass through.
+	 */
+	public function twig_shortcode( $value ) {
+		return is_string( $value ) ? do_shortcode( $value ) : $value;
 	}
 
 	/**

--- a/tests/Unit/Helpers/FieldFormatterTest.php
+++ b/tests/Unit/Helpers/FieldFormatterTest.php
@@ -529,6 +529,92 @@ class FieldFormatterTest extends HelpersTestCase {
 		$this->assertSame( '[wpforms id="200"]', $result );
 	}
 
+	public function test_deferred_embed_returns_the_shortcode_without_rendering(): void {
+		// The whole point: a context build must not spend the render, and must
+		// not let the form plugin discover a form on a page that has none.
+		$this->define_wp_post_if_needed();
+
+		$rendered = 0;
+		Functions\when( 'do_shortcode' )->alias(
+			function ( $shortcode ) use ( &$rendered ) {
+				++$rendered;
+				return '<div class="wpforms">' . $shortcode . '</div>';
+			}
+		);
+
+		$post = new \WP_Post( (object) [ 'ID' => 200, 'post_type' => 'wpforms' ] );
+
+		$result = Helpers::fieldFormatter(
+			[ 'type' => 'post_object', 'value' => $post ],
+			1,
+			false,
+			false
+		);
+
+		$this->assertSame( '[wpforms id="200"]', $result );
+		$this->assertSame( 0, $rendered, 'do_shortcode ran, so the plugin still discovered the form' );
+	}
+
+	public function test_deferring_the_embed_keeps_the_value_cacheable(): void {
+		// A rendered form carries a nonce, so fieldFormatter counts it dynamic
+		// and nothing may store it. Deferring is therefore not only cheaper --
+		// it is what lets the rest of an options page be storable at all.
+		$this->define_wp_post_if_needed();
+		Functions\when( 'do_shortcode' )->alias( static fn ( $s ) => '<form>' . $s . '</form>' );
+
+		$post  = new \WP_Post( (object) [ 'ID' => 200, 'post_type' => 'wpforms' ] );
+		$field = [ 'type' => 'post_object', 'value' => $post ];
+
+		$before = Helpers::dynamicFormatCount();
+		Helpers::fieldFormatter( $field, 1, false, true );
+		$rendered_moved = Helpers::dynamicFormatCount() - $before;
+
+		$before = Helpers::dynamicFormatCount();
+		Helpers::fieldFormatter( $field, 1, false, false );
+		$deferred_moved = Helpers::dynamicFormatCount() - $before;
+
+		$this->assertSame( 1, $rendered_moved, 'a rendered form must count as dynamic' );
+		$this->assertSame( 0, $deferred_moved, 'a deferred form is just a string and must not' );
+	}
+
+	public function test_a_cf7_embed_defers_the_same_way(): void {
+		$this->define_wp_post_if_needed();
+
+		$rendered = 0;
+		Functions\when( 'do_shortcode' )->alias(
+			function ( $s ) use ( &$rendered ) {
+				++$rendered;
+				return $s;
+			}
+		);
+
+		$post = new \WP_Post( (object) [ 'ID' => 42, 'post_type' => 'wpcf7_contact_form' ] );
+
+		$result = Helpers::fieldFormatter(
+			[ 'type' => 'post_object', 'value' => $post ],
+			1,
+			false,
+			false
+		);
+
+		$this->assertSame( '[contact-form-7 id="42" title=""]', $result );
+		$this->assertSame( 0, $rendered );
+	}
+
+	public function test_the_default_still_renders(): void {
+		// The parameter is opt-out. A caller that knows nothing about it keeps
+		// the behaviour it had.
+		$this->define_wp_post_if_needed();
+		Functions\when( 'do_shortcode' )->alias( static fn ( $s ) => '<form>' . $s . '</form>' );
+
+		$post = new \WP_Post( (object) [ 'ID' => 200, 'post_type' => 'wpforms' ] );
+
+		$this->assertStringContainsString(
+			'<form>',
+			Helpers::fieldFormatter( [ 'type' => 'post_object', 'value' => $post ], 1 )
+		);
+	}
+
 	private function define_wp_post_if_needed(): void {
 		if ( ! class_exists( '\WP_Post' ) ) {
 			eval( '


### PR DESCRIPTION
Closes #92.

> **Rebuilt 2026-08-27 on current `main`.** The original branch was one commit from before v1.26 and conflicted in all three files it touched. The approach changed too, so it was re-implemented rather than merged forward.

## The problem

`Helpers::formatFields( 'option' )` is the documented way to source globals from `timber_context()`. It formats **every** field on the options page whether or not the page will print it, and a `post_object` pointing at a form is formatted by running its shortcode. So every request of every page rendered a form — 6 kB of markup on the reported site, built and discarded.

## The original report named the wrong mechanism for the asset cost

Worth correcting, because it decides the shape of the fix. The report said the render "triggers the plugin's asset enqueue, so `wpforms-*.css` and jQuery land in `<head>` of every page".

`Frontend.php:1547` says otherwise — the `wp_head` path enqueues CSS only when `is_singular()` **and** the post content holds the shortcode or block:

```php
if ( ! is_singular() ) { return; }
if ( has_shortcode( $post->post_content, 'wpforms' ) || has_block( 'wpforms/form-selector' ) ) {
    $this->assets_css();
}
```

On a form-less page neither is true, so that path never fired. What loads the assets is `assets_footer()` on `wp_footer`, which enqueues whenever `$this->forms` is non-empty — and the context build populated it by rendering.

Same symptom, different hook. It matters because it means suppressing the *output* is not enough; the fix has to stop the *render*, since that is what registers the form.

## The fix

`formatFields( $post, $is_preview, $render_embeds = true )` and the matching `fieldFormatter()` parameter. `false` hands back `[wpforms id="12"]` instead of rendering it. Default unchanged — no existing caller moves.

**Plus the half the earlier draft lacked:** a `|shortcode` Twig filter, so the one template that actually prints the form renders it where it is printed.

```twig
{{ content.contact.form|shortcode }}
```

Rendering there is when the plugin discovers the form. WPForms handles that case explicitly — `assets_footer()` exists for it, at the cost of a brief flash of unstyled content, which is the trade the deferral buys on every page that has no form at all. **Verified in the plugin source rather than assumed**; it is the question that decides whether deferring is viable at all, and nobody had checked it.

## Rejected: the lazy value object

The issue ranked this first ("reads as the real fix to me"). Three concrete objections:

- **It is never empty.** `formatFields()` drops fields whose formatted value is empty. A lazy object is always truthy, so an unfilled form field would start appearing in the context.
- **It is not storable.** `MenuFieldsCache::isStorable()` rejects objects, so an options page holding one could never be cached — the opposite of what deferral is for.
- **It breaks `is_string()`.** A theme testing the value's type gets a different answer, silently.

## It composes with the menu cache

A rendered form carries a nonce, so `fieldFormatter()` counts it dynamic and nothing may cache it. **Deferring the embed is what lets the rest of an options page be storable at all** — which is what #147 needs, and it follows the same rule as the menu cache ([ADR-0007](../blob/main/docs/adr/0007-prove-cache-purity-from-inputs.md)): decide from an input, before the work.

`test_deferring_the_embed_keeps_the_value_cacheable` asserts exactly that, by reading the dynamic counter either side of both calls.

## Migration for a project that hits this

Two steps, and the second only where a form is actually printed:

```php
// timber_context()
$global_fields = Helpers::formatFields( 'option', false, false );
```
```twig
{# the one template that prints it #}
{{ content.contact.form|shortcode }}
```

## Tests

Four added, verified load-bearing by removal — disabling the deferral fails exactly three of them and nothing else. 1828 tests, PHPStan clean.