### PR TITLE
docs(readme): add the sibling packages' badge row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **README badges** — Packagist version, PHP version, Timber, Tests, License.
+  Matches `parisek/definition-kit` and `parisek/acf-json-schema`, which already
+  carried the same row; `parisek/styleguide` gains it in parallel.
+
 ### Changed
 
 - **Release guard runs every test suite.** `release-stamp.yml` ran

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # timber-kit
 
+[![Packagist Version](https://img.shields.io/packagist/v/parisek/timber-kit.svg)](https://packagist.org/packages/parisek/timber-kit)
+[![PHP Version](https://img.shields.io/packagist/php-v/parisek/timber-kit.svg)](https://packagist.org/packages/parisek/timber-kit)
+[![Timber](https://img.shields.io/badge/Timber-2.x-blue.svg)](https://timber.github.io/docs/v2/)
+[![Tests](https://github.com/parisek/timber-kit/actions/workflows/tests.yml/badge.svg)](https://github.com/parisek/timber-kit/actions/workflows/tests.yml)
+[![License](https://img.shields.io/packagist/l/parisek/timber-kit.svg)](LICENSE)
+
 WordPress/Timber starter kit — configurable base class, ACF helpers, image resizer, dev media proxy, WPForms config bridge, ACF block renderer, WPML Copy-field override.
 
 ## Installation


### PR DESCRIPTION
`parisek/definition-kit` and `parisek/acf-json-schema` both open their README with the same five-badge row. This repo and `parisek/styleguide` had none — the same split the ADR unification just closed.

Adopted here: Packagist version, PHP version, **Timber 2.x**, Tests, License. Timber takes the slot where the two ACF packages carry an *ACF Pro* badge: the hard dependency declared in `composer.json` is `timber/timber: ^2.0`, while ACF is used through helpers rather than required.

Tests badge verified against the real workflow filename (`tests.yml`).

Docs only.