### PR TITLE
fix(helpers): gate the repeater/flexible null-value pass-through on $is_preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,15 +26,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   with nothing in it — which is why it survived review.
 
   Measured on a `nav_menu_item` group whose `more_items` repeater was filled on
-  10 of 425 items: 67 of 69 items reported a 28-element `more_items`.
+  10 of 425 items: 67 of 69 items reported a 28-element `more_items`. Options
+  pages resolve through the same gate, so an options-page repeater left unfilled
+  had the same symptom and is closed by the same change.
 
-  Outside preview the value is now `FALSE`, which `mapFields()` prunes, so the
-  key is simply absent. **Behaviour change, narrow:** the only affected input is
-  a `repeater` / `flexible_content` with `value => null` read with
-  `$is_preview = false`. `BlockRenderer::buildContent()` already propagates the
-  flag; a block render path that bypasses `BlockRenderer` and omits it would
-  lose its editor placeholder (editor-only, front end unaffected) and is fixed
-  by passing the argument the signature already carries.
+  Outside preview the value is now `FALSE`. **Where that lands differs by
+  depth:** `formatFields()` prunes on `! empty( $value )`, so a *top-level*
+  field drops out of the context entirely — the key is absent. A *nested*
+  repeater / flexible_content inside a populated parent row is assigned in
+  place by the recursion and is not pruned, so the row carries `links => false`
+  rather than omitting the key. Both read as empty in Twig; PHP consumers doing
+  `array_key_exists()` on a nested row see `false` where they previously saw the
+  definition array.
+
+  **Behaviour change, narrow:** the only affected input is a `repeater` /
+  `flexible_content` with `value => null` read with `$is_preview = false`.
+  `BlockRenderer::buildContent()` already propagates the flag; a block render
+  path that bypasses `BlockRenderer` — a legacy per-theme
+  `timber_block_render_callback()` predating the `BlockRenderer` migration — and
+  omits it would lose its editor placeholder (editor-only, front end
+  unaffected), and is fixed by forwarding the `$is_preview` WordPress already
+  hands that callback.
 
 - **Release guard runs every test suite.** `release-stamp.yml` ran
   `composer test`, which is the Unit suite only (`--testsuite=Unit`), so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
+- **`fieldFormatter()` gates the repeater/flexible null-value pass-through on
+  `$is_preview`** ([#98](https://github.com/parisek/timber-kit/issues/98)). An
+  unfilled `repeater` / `flexible_content` returned its raw ACF field-definition
+  array regardless of context. That is the block-preview contract — an unsaved
+  block needs `sub_fields` to render a placeholder — but it was ungated, so it
+  also fired on ordinary front-end reads, where the definition array reads as a
+  populated list: `{% if x and x|length > 0 %}` passes on the definition's own
+  28 keys, a template opens its wrapper, and the inner per-row guard then
+  suppresses every row. The visible result is empty chrome — a bordered `<ul>`
+  with nothing in it — which is why it survived review.
+
+  Measured on a `nav_menu_item` group whose `more_items` repeater was filled on
+  10 of 425 items: 67 of 69 items reported a 28-element `more_items`.
+
+  Outside preview the value is now `FALSE`, which `mapFields()` prunes, so the
+  key is simply absent. **Behaviour change, narrow:** the only affected input is
+  a `repeater` / `flexible_content` with `value => null` read with
+  `$is_preview = false`. `BlockRenderer::buildContent()` already propagates the
+  flag; a block render path that bypasses `BlockRenderer` and omits it would
+  lose its editor placeholder (editor-only, front end unaffected) and is fixed
+  by passing the argument the signature already carries.
+
 - **Release guard runs every test suite.** `release-stamp.yml` ran
   `composer test`, which is the Unit suite only (`--testsuite=Unit`), so a
   version could be stamped without the property suite's generative assertions.

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -762,12 +762,21 @@ class Helpers {
 	 * contexts).  Each field value is passed through {@see fieldFormatter()}.
 	 * Fields with an empty formatted value are omitted from the result.
 	 *
+	 * Resolution goes through `get_field_objects()`, which honours the field
+	 * group's location rule. A group scoped to something the current request
+	 * does not establish — a `nav_menu_item` rule under WP-CLI with another
+	 * theme active, so no menu location is registered — surfaces no fields at
+	 * all, and reads identically to "the data is not there". `get_field()` by
+	 * name still resolves in that situation; prefer it when probing.
+	 *
 	 * @param object|int|string|null $post       Post object, term object, numeric post ID,
 	 *                                            options-page string key, or null to use the
 	 *                                            current queried object.
 	 * @param bool                   $is_preview True when rendering inside a Gutenberg block
-	 *                                            preview (suppresses shortcode execution for
-	 *                                            certain form plugins).
+	 *                                            preview. Suppresses shortcode execution for
+	 *                                            certain form plugins, and keeps the raw
+	 *                                            definition of an unfilled repeater /
+	 *                                            flexible_content so a placeholder can render.
 	 * @return array<string, mixed> Associative array keyed by ACF field name with formatted values.
 	 */
 	public static function formatFields( $post = null, $is_preview = false ) {
@@ -1131,13 +1140,18 @@ class Helpers {
 		// array into templates — `{{ content.x|typography }}` fatals on
 		// arrays. Mirrors the pre-1.8 behaviour where valueless option fields
 		// simply never surfaced. Repeater/flexible keep their documented
-		// null-value pass-through (block-preview contract, covered by tests).
+		// null-value pass-through, but only under preview (see below).
 		if ( ! array_key_exists( 'value', $field ) ) {
 			return FALSE;
 		}
 
 		if ( ! isset( $field['value'] ) ) {
-			if ( in_array( $field['type'], array( 'repeater', 'flexible_content' ), true ) ) {
+			// Only a block preview has a use for the definition: an unsaved block
+			// needs `sub_fields` / `layouts` to render its placeholder. On an
+			// ordinary read the same array masquerades as a populated list —
+			// `x|length > 0` passes on the definition's own keys, so a template
+			// opens its wrapper for rows that do not exist.
+			if ( $is_preview && in_array( $field['type'], array( 'repeater', 'flexible_content' ), true ) ) {
 				return $field;
 			}
 

--- a/tests/Unit/Helpers/FieldFormatterTest.php
+++ b/tests/Unit/Helpers/FieldFormatterTest.php
@@ -808,8 +808,8 @@ class FieldFormatterTest extends HelpersTestCase {
 		$this->assertSame( 'Bob', $result[1]['name'] );
 	}
 
-	public function test_repeater_null_value_returns_field_as_is(): void {
-		// isset() returns false for null, so early return $field happens
+	public function test_repeater_null_value_returns_field_as_is_in_preview(): void {
+		// Block preview needs the definition (sub_fields) to render a placeholder.
 		$field = [
 			'type'       => 'repeater',
 			'sub_fields' => [
@@ -818,9 +818,23 @@ class FieldFormatterTest extends HelpersTestCase {
 			'value'      => null,
 		];
 
-		$result = Helpers::fieldFormatter( $field );
+		$result = Helpers::fieldFormatter( $field, null, true );
 
 		$this->assertSame( $field, $result );
+	}
+
+	public function test_repeater_null_value_returns_false_outside_preview(): void {
+		// Front-end reads must see "empty", not a definition array masquerading
+		// as a populated list of rows.
+		$field = [
+			'type'       => 'repeater',
+			'sub_fields' => [
+				[ 'name' => 'title', 'type' => 'text' ],
+			],
+			'value'      => null,
+		];
+
+		$this->assertFalse( Helpers::fieldFormatter( $field ) );
 	}
 
 	public function test_flexible_content_basic(): void {
@@ -1021,8 +1035,8 @@ class FieldFormatterTest extends HelpersTestCase {
 		$this->assertSame( '_blank', $result[0]['button']['attributes']['target'] );
 	}
 
-	public function test_flexible_content_null_value_returns_field_as_is(): void {
-		// isset() returns false for null, so early return $field happens
+	public function test_flexible_content_null_value_returns_field_as_is_in_preview(): void {
+		// Block preview needs the definition (layouts) to render a placeholder.
 		$field = [
 			'type'    => 'flexible_content',
 			'layouts' => [
@@ -1036,8 +1050,26 @@ class FieldFormatterTest extends HelpersTestCase {
 			'value'   => null,
 		];
 
-		$result = Helpers::fieldFormatter( $field );
+		$result = Helpers::fieldFormatter( $field, null, true );
 
 		$this->assertSame( $field, $result );
+	}
+
+	public function test_flexible_content_null_value_returns_false_outside_preview(): void {
+		// Front-end reads must see "empty", not a definition array.
+		$field = [
+			'type'    => 'flexible_content',
+			'layouts' => [
+				[
+					'name'       => 'block',
+					'sub_fields' => [
+						[ 'name' => 'title', 'type' => 'text' ],
+					],
+				],
+			],
+			'value'   => null,
+		];
+
+		$this->assertFalse( Helpers::fieldFormatter( $field ) );
 	}
 }

--- a/tests/Unit/Helpers/FormatFieldsTest.php
+++ b/tests/Unit/Helpers/FormatFieldsTest.php
@@ -930,4 +930,69 @@ class FormatFieldsTest extends HelpersTestCase {
 
 		$this->assertSame( 'site_title@option', $result['site_title'] );
 	}
+
+	/**
+	 * Locks the $is_preview hand-off from formatFields() into fieldFormatter().
+	 * Drop the argument at the call site and this goes red: the placeholder
+	 * definition an unsaved block renders from would silently disappear.
+	 */
+	public function test_preview_keeps_unfilled_repeater_definition(): void {
+		$field = [ 'type' => 'repeater', 'sub_fields' => [ [ 'name' => 'title', 'type' => 'text' ] ], 'value' => null ];
+
+		Functions\when( 'get_field_objects' )->justReturn( [ 'rows' => $field ] );
+
+		$this->assertSame( $field, Helpers::formatFields( 7, true )['rows'] );
+	}
+
+	public function test_unfilled_repeater_is_absent_outside_preview(): void {
+		Functions\when( 'get_field_objects' )->justReturn( [
+			'rows' => [ 'type' => 'repeater', 'sub_fields' => [ [ 'name' => 'title', 'type' => 'text' ] ], 'value' => null ],
+		] );
+
+		$this->assertArrayNotHasKey( 'rows', Helpers::formatFields( 7 ) );
+	}
+
+	/**
+	 * Same hand-off, one level down. fieldFormatter() recurses into sub-fields
+	 * and must carry $is_preview with it; a nested repeater left unfilled inside
+	 * a populated parent row is the case that exercises it.
+	 */
+	public function test_preview_propagates_into_nested_repeater(): void {
+		$nested = [ 'name' => 'links', 'type' => 'repeater', 'sub_fields' => [ [ 'name' => 'url', 'type' => 'text' ] ] ];
+
+		Functions\when( 'get_field_objects' )->justReturn( [
+			'sections' => [
+				'type'       => 'repeater',
+				'sub_fields' => [ [ 'name' => 'heading', 'type' => 'text' ], $nested ],
+				'value'      => [ [ 'heading' => 'Docs', 'links' => null ] ],
+			],
+		] );
+
+		$row = Helpers::formatFields( 7, true )['sections'][0];
+
+		$this->assertSame( 'Docs', $row['heading'] );
+		$this->assertSame( 'repeater', $row['links']['type'] );
+	}
+
+	/**
+	 * The nested counterpart is NOT pruned — formatFields() prunes only at the
+	 * top level, so a null nested repeater lands in the row as false rather than
+	 * being omitted. Documented here because it is easy to assume otherwise.
+	 */
+	public function test_nested_unfilled_repeater_is_false_outside_preview(): void {
+		$nested = [ 'name' => 'links', 'type' => 'repeater', 'sub_fields' => [ [ 'name' => 'url', 'type' => 'text' ] ] ];
+
+		Functions\when( 'get_field_objects' )->justReturn( [
+			'sections' => [
+				'type'       => 'repeater',
+				'sub_fields' => [ [ 'name' => 'heading', 'type' => 'text' ], $nested ],
+				'value'      => [ [ 'heading' => 'Docs', 'links' => null ] ],
+			],
+		] );
+
+		$row = Helpers::formatFields( 7 )['sections'][0];
+
+		$this->assertSame( 'Docs', $row['heading'] );
+		$this->assertFalse( $row['links'] );
+	}
 }


### PR DESCRIPTION
Closes #98.

## What changes

One condition in `Helpers::fieldFormatter()`:

```php
if ( ! isset( $field['value'] ) ) {
    if ( $is_preview && in_array( $field['type'], array( 'repeater', 'flexible_content' ), true ) ) {
        return $field;
    }
    return FALSE;
}
```

The pass-through is #68's block-preview contract and is kept — an unsaved block needs `sub_fields` / `layouts` to render a placeholder. It was ungated, so it also fired on ordinary front-end reads, where the definition array reads as a populated list: `{% if x and x|length > 0 %}` passes on the definition's own 28 keys, the template opens its wrapper, and the inner per-row guard suppresses every row. The result is empty chrome, not a visibly broken render — which is why it survived review. Measured on a `nav_menu_item` group: 67 of 69 items reported a 28-element `more_items`.

`$is_preview` was previously consulted only by the CF7 / WPForms branches, so this extends an existing convention.

## Tests

Test-first. The two tests #68 named are split by context rather than deleted:

| Test | Asserts |
| --- | --- |
| `test_repeater_null_value_returns_field_as_is_in_preview` | preview contract holds (now passes `true`) |
| `test_flexible_content_null_value_returns_field_as_is_in_preview` | same, flexible |
| `test_repeater_null_value_returns_false_outside_preview` | **new** — front end sees empty |
| `test_flexible_content_null_value_returns_false_outside_preview` | **new** — same, flexible |

Both new tests were watched failing against `main` (returned the definition array), then went green. `composer check` passes: 1036 unit tests, property suite, PHPStan level 8 clean, ADR index in sync.

## Behaviour change — declared

Public API unchanged (no signature, return type, or new argument). Exactly one input behaves differently: `repeater` / `flexible_content` with `value => null`, read with `$is_preview = false`. Before: field-definition array. After: `FALSE`, which `mapFields()` prunes, so the key is absent.

One regression path exists: a block render that bypasses `BlockRenderer` and omits `$is_preview` loses its editor placeholder — editor-only, front end unaffected, fixed by passing the flag. `BlockRenderer::buildContent()` (BlockRenderer.php:295) already propagates it correctly.

## Open point for review — the feature-flag doctrine

`AGENTS.md` § *Feature flags & breaking changes* says behavior-changing work ships behind a `StarterBase` flag, default off. This PR does not add one, and that is a judgement call worth an explicit yes or no:

- `Helpers` is static with no `StarterBase` instance in scope, so a flag would need a static property — a new mechanism, not the documented one.
- Defaulting it off would leave the definition-array leak on by default, i.e. keep the bug shipping.
- The surrounding block already states the invariant this restores: *"must read as empty, not leak the raw field-definition array into templates"*.

Treated as a bug fix rather than new behavior on those grounds. Happy to rework behind a flag if you read the doctrine as binding here.

## Rejected alternative

Returning `array()` instead of `FALSE` for the non-preview case. `mapFields()` prunes on `! empty( $value )`, so an empty array prunes identically — no benefit, while leaving `repeater` the one type not returning `FALSE` from this branch.

## Docblock

Two notes added while here: `$is_preview` on `formatFields()` now documents the placeholder role (it only mentioned shortcode suppression), and the location-rule false negative from the issue's aside is recorded — `get_field_objects()` honours the group's location rule, so probing a `nav_menu_item` group under WP-CLI with another theme active reads identically to "no data", with no warning. `get_field()` by name still resolves there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BsyBWmGD7itEupuAabxQC8
