### PR TITLE
feat(starter-base): allow $options_pages entries to set ACF post_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,16 +22,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   to match the theme's own selector. A name collision reads as success, which is
   what made it expensive to find rather than merely wrong.
 
-  A sub-page **inherits its parent's `post_id`** unless it declares its own. ACF
-  does not do this — `acf_validate_options_page()` defaults every page to
-  `'options'` independently, parent or not — and without the inheritance a
-  namespaced parent with unmarked children would split one theme's settings
-  across two namespaces, with `formatFields()` returning only half of them. The
-  read side needed no change: `Helpers::getFieldObjectsForOptions()` already
-  matches on namespace.
+  A sub-page **inherits its parent's `post_id`** unless it declares its own, and
+  the inheritance is transitive across nesting levels. ACF does not do this —
+  `acf_options_page::validate_page()` applies `'post_id' => 'options'` through
+  `wp_parse_args` to every page independently, parent or not — and without the
+  inheritance a namespaced parent with unmarked children would split one theme's
+  settings across two namespaces, with `formatFields()` returning only half of
+  them. The read side needed no change: `Helpers::getFieldObjectsForOptions()`
+  already matches on namespace.
 
   Adopting it on a live site is a data migration — stored values stay behind
   under the old prefix.
+
+### Fixed
+
+- **Breeze cache purge missed options pages with a custom `post_id`.**
+  `clear_cache_on_options_save()` compared the incoming id against the literal
+  `'options'`, but ACF's admin controller saves through
+  `acf_save_post( $page['post_id'] )` — so a namespaced page (and, under WPML,
+  any language-suffixed id from `acf_get_valid_post_id()`) fired the hook with
+  an id the check rejected, and stale pages kept being served after a save. It
+  now matches any id that `acf_decode_post_id()` classifies as an options
+  namespace. The purge is site-wide either way, so widening the match can only
+  flush on another page's save — the safe direction for a cache.
 
 - **README badges** — Packagist version, PHP version, Timber, Tests, License.
   Matches `parisek/definition-kit` and `parisek/acf-json-schema`, which already

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **README badges** — Packagist version, PHP version, Timber, Tests, License.
+  Matches `parisek/definition-kit` and `parisek/acf-json-schema`, which already
+  carried the same row; `parisek/styleguide` gains it in parallel.
+
 ### Changed
 
 - **Release guard runs every test suite.** `release-stamp.yml` ran

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **`post_id` on an `$options_pages` entry** — sets the ACF storage namespace, so
+  a theme's options no longer share the default `options_<field_name>` prefix in
+  `wp_options` with every other options page on the install. Purely additive:
+  omit the key and ACF's own default applies exactly as before.
+  ([#100](https://github.com/parisek/timber-kit/issues/100))
+
+  Found on a site carrying a second options page created years earlier through
+  ACF's admin UI — a database row, invisible to any grep of the repo. Both sides
+  owned a field named `footer`; the theme's own `links`, `announcement`, `social`
+  and `exit_popup` groups never surfaced at all, while the footer rendered
+  *correctly* from the other page's data because `options_footer_apps_*` happened
+  to match the theme's own selector. A name collision reads as success, which is
+  what made it expensive to find rather than merely wrong.
+
+  A sub-page **inherits its parent's `post_id`** unless it declares its own. ACF
+  does not do this — `acf_validate_options_page()` defaults every page to
+  `'options'` independently, parent or not — and without the inheritance a
+  namespaced parent with unmarked children would split one theme's settings
+  across two namespaces, with `formatFields()` returning only half of them. The
+  read side needed no change: `Helpers::getFieldObjectsForOptions()` already
+  matches on namespace.
+
+  Adopting it on a live site is a data migration — stored values stay behind
+  under the old prefix.
+
 - **README badges** — Packagist version, PHP version, Timber, Tests, License.
   Matches `parisek/definition-kit` and `parisek/acf-json-schema`, which already
   carried the same row; `parisek/styleguide` gains it in parallel.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # timber-kit
 
+[![Packagist Version](https://img.shields.io/packagist/v/parisek/timber-kit.svg)](https://packagist.org/packages/parisek/timber-kit)
+[![PHP Version](https://img.shields.io/packagist/php-v/parisek/timber-kit.svg)](https://packagist.org/packages/parisek/timber-kit)
+[![Timber](https://img.shields.io/badge/Timber-2.x-blue.svg)](https://timber.github.io/docs/v2/)
+[![Tests](https://github.com/parisek/timber-kit/actions/workflows/tests.yml/badge.svg)](https://github.com/parisek/timber-kit/actions/workflows/tests.yml)
+[![License](https://img.shields.io/packagist/l/parisek/timber-kit.svg)](LICENSE)
+
 WordPress/Timber starter kit — configurable base class, ACF helpers, image resizer, dev media proxy, WPForms config bridge, ACF block renderer, WPML Copy-field override.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -541,7 +541,7 @@ When any override is active, an admin notice on WPForms admin screens lists whic
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| `$options_pages` | array | one "Theme Settings" page | List of ACF options pages. `parent_slug` => sub-page; `admin_bar => true` => add admin-bar link for this entry; `[]` disables the feature entirely (no page, no admin-bar link). The default "Theme Settings" entry has `admin_bar => true` |
+| `$options_pages` | array | one "Theme Settings" page | List of ACF options pages. `parent_slug` => sub-page; `admin_bar => true` => add admin-bar link for this entry; `post_id` => ACF storage namespace (see below); `[]` disables the feature entirely (no page, no admin-bar link). The default "Theme Settings" entry has `admin_bar => true` |
 
 ```php
 // one top-level page with an admin-bar shortcut + two sub-pages under it
@@ -555,6 +555,25 @@ $this->options_pages = [
 // disable completely
 $this->options_pages = [];
 ```
+
+#### `post_id` — storage namespace
+
+Omitted, ACF applies its own default of `'options'`: values land in `wp_options` as `options_<field_name>`, **keyed by field name, not by page**. That holds fine while an install has exactly one set of options pages — and stops holding the moment a second one appears, which it can without any repo change (a plugin's page, or one created through ACF's admin UI, which lives in the database as an `acf-ui-options-page` post and shows up in no grep of the theme).
+
+Two pages then share one namespace, and where their field names overlap they read each other's values. Nothing errors: `get_field('links_login', 'option')` returns the *other* page's stored value, `get_field('links', 'option')` returns `null`, and `Helpers::formatFields()` sees nothing — an options group that resolved to nothing is indistinguishable from one nobody filled in. The colliding case is the worse of the two, because the page renders and looks correct.
+
+```php
+$this->options_pages = [
+    [ 'menu_slug' => 'settings', 'page_title' => 'Theme Settings', 'post_id' => 'mytheme_settings' ],
+    [ 'menu_slug' => 'footer', 'page_title' => 'Footer', 'parent_slug' => 'settings' ],
+];
+```
+
+Values are stored as `mytheme_settings_<field_name>` and read with `Helpers::formatFields('mytheme_settings')`.
+
+**A sub-page inherits its parent's `post_id`** unless it declares its own. ACF does not — `acf_validate_options_page()` defaults every page to `'options'` independently, parent or not — so without the inheritance a namespaced parent with unmarked children would split one theme's settings across two namespaces and `formatFields()` would return only half of them. Declare `post_id` on the child to opt out.
+
+Adopting this on a live site is a **data migration**: existing values stay behind under the old prefix and have to be copied to the new one. Set it from the start on new projects.
 
 ### Breadcrumbs
 

--- a/README.md
+++ b/README.md
@@ -571,7 +571,11 @@ $this->options_pages = [
 
 Values are stored as `mytheme_settings_<field_name>` and read with `Helpers::formatFields('mytheme_settings')`.
 
-**A sub-page inherits its parent's `post_id`** unless it declares its own. ACF does not — `acf_validate_options_page()` defaults every page to `'options'` independently, parent or not — so without the inheritance a namespaced parent with unmarked children would split one theme's settings across two namespaces and `formatFields()` would return only half of them. Declare `post_id` on the child to opt out.
+**A sub-page inherits its parent's `post_id`** unless it declares its own. ACF does not — `acf_options_page::validate_page()` applies `'post_id' => 'options'` through `wp_parse_args` to every page independently, parent or not — so without the inheritance a namespaced parent with unmarked children would split one theme's settings across two namespaces and `formatFields()` would return only half of them. Declare `post_id` on the child to opt out.
+
+Inheritance is **transitive**: ACF's `add_sub_page()` accepts a `parent_slug` pointing at another sub-page, so a page nested two levels down takes the namespace of its nearest ancestor that declares one. A `parent_slug` referencing a page *outside* `$options_pages` (a plugin's) inherits nothing — this class cannot know what namespace that page registered with.
+
+Adopting `post_id` also widens what `clear_cache_on_options_save()` matches: it purges on a save to any options namespace rather than the literal `'options'`, since ACF saves through `acf_save_post( $page['post_id'] )` and would otherwise stop purging for exactly the projects that namespace their storage.
 
 Adopting this on a live site is a **data migration**: existing values stay behind under the old prefix and have to be copied to the new one. Set it from the start on new projects.
 

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -293,6 +293,33 @@ class StarterBase extends Site {
 	 *     ['menu_slug'=>'dev','page_title'=>'Dev Settings','capability'=>'manage_options'],
 	 *   ];
 	 *
+	 * `post_id` (optional, top-level entries) sets the ACF storage namespace for
+	 * the page. Omitted, ACF applies its own default of `'options'`, so values
+	 * land in `wp_options` as `options_<field_name>` — keyed by field name, not
+	 * by page. That is invisible right up until a second options page exists on
+	 * the install (a plugin's, or one created through ACF's admin UI, which lives
+	 * in the database and appears in no grep of the repo): two pages owning a
+	 * field of the same name silently read each other's values, and an options
+	 * group that resolved to nothing is indistinguishable from one nobody filled
+	 * in. Setting it namespaces this theme's storage:
+	 *   $this->options_pages = [
+	 *     ['menu_slug'=>'settings','page_title'=>'Theme Settings','post_id'=>'mytheme_settings'],
+	 *   ];
+	 * Values are then stored as `mytheme_settings_<field_name>`, and the theme
+	 * reads them with `Helpers::formatFields('mytheme_settings')`.
+	 *
+	 * **A sub-page inherits its parent's `post_id`** unless it declares its own.
+	 * ACF does not do this — `acf_validate_options_page()` defaults every page to
+	 * `'options'` independently, parent or not — so a namespaced parent with
+	 * unmarked children would split one theme's settings across two namespaces
+	 * and `formatFields()` would return only half of them. Within a single
+	 * `$options_pages` list a sub-page is visibly part of the same store, so it
+	 * is treated as one; declare `post_id` on the child to opt out.
+	 *
+	 * Adopting `post_id` on a live site is a **data migration**: existing values
+	 * stay behind under the old prefix and must be copied to the new one. New
+	 * projects should set it from the start.
+	 *
 	 * Set to an empty array (`$this->options_pages = [];`) to register NO options
 	 * pages at all — disables the feature entirely (no ACF page, no admin-bar link).
 	 *
@@ -2203,8 +2230,12 @@ class StarterBase extends Site {
 
 		// Register top-level pages first so a sub-page's parent is always present
 		// by the time the child is registered, regardless of list order.
+		$parent_post_ids = [];
 		foreach ( $this->options_pages as $page ) {
 			if ( ! isset( $page['parent_slug'] ) ) {
+				if ( isset( $page['post_id'] ) ) {
+					$parent_post_ids[ $page['menu_slug'] ] = $page['post_id'];
+				}
 				$this->register_options_page( $page );
 			}
 		}
@@ -2212,6 +2243,12 @@ class StarterBase extends Site {
 		if ( function_exists( 'acf_add_options_sub_page' ) ) {
 			foreach ( $this->options_pages as $page ) {
 				if ( isset( $page['parent_slug'] ) ) {
+					// Inherit the parent's storage namespace — see $options_pages.
+					// ACF itself does not: every page defaults to 'options'
+					// independently, which would split one theme's settings in two.
+					if ( ! isset( $page['post_id'] ) && isset( $parent_post_ids[ $page['parent_slug'] ] ) ) {
+						$page['post_id'] = $parent_post_ids[ $page['parent_slug'] ];
+					}
 					$this->register_options_page( $page );
 				}
 			}
@@ -2235,6 +2272,12 @@ class StarterBase extends Site {
 			'redirect'        => false,
 			'show_in_graphql' => false,
 		];
+
+		// Only set when declared — omitting the key leaves ACF's own 'options'
+		// default in place, so every existing consumer is unaffected.
+		if ( isset( $page['post_id'] ) ) {
+			$args['post_id'] = $page['post_id'];
+		}
 
 		if ( isset( $page['parent_slug'] ) ) {
 			$args['parent_slug'] = $page['parent_slug'];

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -279,9 +279,10 @@ class StarterBase extends Site {
 	 * a sub-page (acf_add_options_sub_page) under that parent; otherwise it is a
 	 * top-level page (acf_add_options_page). `icon_url` is only used for top-level
 	 * pages (sub-pages do not take an icon); defaults to `'dashicons-admin-generic'`
-	 * when not set. A 'parent_slug' must reference a top-level page in the same
-	 * list (top-level pages are always registered first, so order within the list
-	 * does not matter). `capability` sets the WordPress capability required to
+	 * when not set. A 'parent_slug' normally references a top-level page in the
+	 * same list (top-level pages are always registered first, so order within the
+	 * list does not matter); ACF also accepts one pointing at another sub-page,
+	 * or at a page registered elsewhere entirely, and neither is rejected here. `capability` sets the WordPress capability required to
 	 * access that page; defaults to `edit_posts` when not set. `admin_bar` (bool,
 	 * default off) adds an admin-bar shortcut to this page; set it on any entry —
 	 * including sub-pages — to surface a direct link under the site name. Multiple
@@ -293,8 +294,8 @@ class StarterBase extends Site {
 	 *     ['menu_slug'=>'dev','page_title'=>'Dev Settings','capability'=>'manage_options'],
 	 *   ];
 	 *
-	 * `post_id` (optional, top-level entries) sets the ACF storage namespace for
-	 * the page. Omitted, ACF applies its own default of `'options'`, so values
+	 * `post_id` (optional, any entry) sets the ACF storage namespace for the
+	 * page. Omitted, ACF applies its own default of `'options'`, so values
 	 * land in `wp_options` as `options_<field_name>` — keyed by field name, not
 	 * by page. That is invisible right up until a second options page exists on
 	 * the install (a plugin's, or one created through ACF's admin UI, which lives
@@ -309,12 +310,15 @@ class StarterBase extends Site {
 	 * reads them with `Helpers::formatFields('mytheme_settings')`.
 	 *
 	 * **A sub-page inherits its parent's `post_id`** unless it declares its own.
-	 * ACF does not do this — `acf_validate_options_page()` defaults every page to
-	 * `'options'` independently, parent or not — so a namespaced parent with
-	 * unmarked children would split one theme's settings across two namespaces
-	 * and `formatFields()` would return only half of them. Within a single
+	 * ACF does not do this — `acf_options_page::validate_page()` applies
+	 * `'post_id' => 'options'` through `wp_parse_args` to every page
+	 * independently, parent or not — so a namespaced parent with unmarked
+	 * children would split one theme's settings across two namespaces and
+	 * `formatFields()` would return only half of them. Within a single
 	 * `$options_pages` list a sub-page is visibly part of the same store, so it
-	 * is treated as one; declare `post_id` on the child to opt out.
+	 * is treated as one; declare `post_id` on the child to opt out. Inheritance
+	 * is transitive — a sub-page under a sub-page takes the namespace of its
+	 * nearest ancestor that declares one.
 	 *
 	 * Adopting `post_id` on a live site is a **data migration**: existing values
 	 * stay behind under the old prefix and must be copied to the new one. New
@@ -2241,18 +2245,77 @@ class StarterBase extends Site {
 		}
 
 		if ( function_exists( 'acf_add_options_sub_page' ) ) {
+			// Resolve inheritance for the whole list before registering anything:
+			// ACF's add_sub_page() accepts a parent_slug pointing at another
+			// sub-page, so a namespace can have to travel more than one level and
+			// a single pass over the list would depend on declaration order.
+			$resolved = $this->resolve_options_page_namespaces( $parent_post_ids );
+
 			foreach ( $this->options_pages as $page ) {
 				if ( isset( $page['parent_slug'] ) ) {
-					// Inherit the parent's storage namespace — see $options_pages.
-					// ACF itself does not: every page defaults to 'options'
-					// independently, which would split one theme's settings in two.
-					if ( ! isset( $page['post_id'] ) && isset( $parent_post_ids[ $page['parent_slug'] ] ) ) {
-						$page['post_id'] = $parent_post_ids[ $page['parent_slug'] ];
+					if ( ! isset( $page['post_id'] ) && isset( $resolved[ $page['menu_slug'] ] ) ) {
+						$page['post_id'] = $resolved[ $page['menu_slug'] ];
 					}
 					$this->register_options_page( $page );
 				}
 			}
 		}
+	}
+
+	/**
+	 * Walk the sub-page hierarchy and give every entry the storage namespace it
+	 * inherits from its nearest ancestor that declares one.
+	 *
+	 * Inheritance exists because ACF does not do it: `validate_page()` applies
+	 * `'post_id' => 'options'` through `wp_parse_args` to every page
+	 * independently, parent or not. A namespaced parent with unmarked children
+	 * would therefore split one theme's settings across two namespaces, and
+	 * `Helpers::formatFields()` would return only the half that matched — the
+	 * silent-half-empty failure this feature exists to prevent, reintroduced one
+	 * level down.
+	 *
+	 * Repeated passes rather than recursion: the list is a handful of entries,
+	 * and a pass that resolves nothing terminates the loop, so a `parent_slug`
+	 * cycle (`a` → `b` → `a`, which ACF itself would also not untangle) settles
+	 * instead of overflowing the stack.
+	 *
+	 * @param array<string, string> $seed menu_slug => post_id for entries that declare one.
+	 * @return array<string, string> menu_slug => inherited post_id, for sub-pages only.
+	 */
+	private function resolve_options_page_namespaces( array $seed ): array {
+		$known = $seed;
+		$children = [];
+
+		foreach ( $this->options_pages as $page ) {
+			if ( ! isset( $page['parent_slug'], $page['menu_slug'] ) ) {
+				continue;
+			}
+			// A child's own declaration wins and becomes inheritable in turn.
+			if ( isset( $page['post_id'] ) ) {
+				$known[ $page['menu_slug'] ] = $page['post_id'];
+				continue;
+			}
+			$children[ $page['menu_slug'] ] = $page['parent_slug'];
+		}
+
+		$resolved = [];
+		do {
+			$progress = false;
+			foreach ( $children as $slug => $parent_slug ) {
+				if ( ! isset( $known[ $parent_slug ] ) ) {
+					continue;
+				}
+				// An ancestor outside $options_pages (a plugin's page) is never in
+				// $known, so its descendants keep ACF's default — correct, since
+				// this class has no idea what namespace that page registered with.
+				$resolved[ $slug ] = $known[ $parent_slug ];
+				$known[ $slug ]    = $known[ $parent_slug ];
+				unset( $children[ $slug ] );
+				$progress = true;
+			}
+		} while ( $progress && $children );
+
+		return $resolved;
 	}
 
 	/**
@@ -2317,21 +2380,60 @@ class StarterBase extends Site {
 	}
 
 	/**
-	 * Clear Breeze cache when the ACF options page is saved.
+	 * Clear Breeze cache when an ACF options page is saved.
+	 *
+	 * Matches any post id that decodes to an OPTIONS namespace, not the literal
+	 * string `'options'`. ACF's admin controller saves via
+	 * `acf_save_post( $this->page['post_id'] )`, so a page registered with a
+	 * custom `post_id` (see $options_pages) fires this hook with that id — an
+	 * equality check against `'options'` would silently stop purging the cache
+	 * for exactly the projects that namespace their storage. The same applies
+	 * under WPML, where `acf_get_valid_post_id()` may append a language suffix
+	 * before the save.
+	 *
+	 * The purge is site-wide either way, so widening the match cannot flush too
+	 * narrowly; it can only flush on another page's save, which is the safe
+	 * direction for a cache.
 	 *
 	 * Hooked to `acf/save_post`.
 	 *
-	 * @param int|string $post_id The post ID or 'options' for the options page.
+	 * @param int|string $post_id The post ID, or an options-page post id.
 	 * @return void
 	 */
 	public function clear_cache_on_options_save( $post_id ) {
-		if ( $post_id !== 'options' ) {
+		if ( ! $this->is_options_post_id( $post_id ) ) {
 			return;
 		}
 
 		if ( has_action( 'breeze_clear_all_cache' ) ) {
 			do_action( 'breeze_clear_all_cache' );
 		}
+	}
+
+	/**
+	 * Whether a post id refers to an ACF options page of any namespace.
+	 *
+	 * Delegates to ACF's own `acf_decode_post_id()` so every id ACF recognises
+	 * counts — `'options'`, the `'option'` alias, a custom `post_id`, and their
+	 * WPML language-suffixed forms. Falls back to the two literals when ACF
+	 * isn't loaded, which keeps the pre-ACF behaviour rather than matching
+	 * nothing.
+	 *
+	 * @param int|string $post_id
+	 * @return bool
+	 */
+	private function is_options_post_id( $post_id ): bool {
+		if ( ! is_string( $post_id ) ) {
+			return false;
+		}
+
+		if ( ! function_exists( 'acf_decode_post_id' ) ) {
+			return $post_id === 'options' || $post_id === 'option';
+		}
+
+		$decoded = acf_decode_post_id( $post_id );
+
+		return is_array( $decoded ) && ( $decoded['type'] ?? '' ) === 'option';
 	}
 
 	/**

--- a/tests/Unit/StarterBase/AcfOptionsPagePostIdTest.php
+++ b/tests/Unit/StarterBase/AcfOptionsPagePostIdTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\StarterBase;
+
+use Brain\Monkey\Functions;
+use Tests\Unit\StarterBaseTestCase;
+
+/**
+ * `post_id` on an $options_pages entry — the ACF storage namespace.
+ *
+ * The assertions all read the $args array handed to acf_add_options_page() /
+ * acf_add_options_sub_page(), because that is the entire surface of the
+ * feature: what ACF stores under is decided there and nowhere else.
+ */
+class AcfOptionsPagePostIdTest extends StarterBaseTestCase {
+
+	/** @var array<int, array<string, mixed>> */
+	private array $top_level = [];
+
+	/** @var array<int, array<string, mixed>> */
+	private array $sub_pages = [];
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->top_level = [];
+		$this->sub_pages = [];
+
+		Functions\when( 'acf_add_options_page' )->alias( function ( $args ) {
+			$this->top_level[] = $args;
+		} );
+		Functions\when( 'acf_add_options_sub_page' )->alias( function ( $args ) {
+			$this->sub_pages[] = $args;
+		} );
+	}
+
+	/**
+	 * Omitting the key must leave $args untouched, not pass an explicit
+	 * 'options'. Every pre-existing consumer relies on ACF's own default
+	 * applying, so the addition has to be invisible when unused.
+	 */
+	public function test_post_id_absent_from_args_when_not_declared(): void {
+		$base = $this->createStarterBase( [
+			'options_pages' => [
+				[ 'menu_slug' => 'settings', 'page_title' => 'Theme Settings' ],
+			],
+		] );
+
+		$base->acf_options_page();
+
+		$this->assertCount( 1, $this->top_level );
+		$this->assertArrayNotHasKey( 'post_id', $this->top_level[0] );
+	}
+
+	public function test_post_id_passed_through_for_top_level_page(): void {
+		$base = $this->createStarterBase( [
+			'options_pages' => [
+				[ 'menu_slug' => 'settings', 'page_title' => 'Theme Settings', 'post_id' => 'mytheme_settings' ],
+			],
+		] );
+
+		$base->acf_options_page();
+
+		$this->assertSame( 'mytheme_settings', $this->top_level[0]['post_id'] );
+	}
+
+	/**
+	 * The inheritance rule. ACF defaults every page to 'options' independently
+	 * (acf_validate_options_page), so without this a namespaced parent and its
+	 * unmarked children would store into two different namespaces and
+	 * formatFields() would return only the parent's half.
+	 */
+	public function test_sub_page_inherits_parent_post_id(): void {
+		$base = $this->createStarterBase( [
+			'options_pages' => [
+				[ 'menu_slug' => 'settings', 'page_title' => 'Theme Settings', 'post_id' => 'mytheme_settings' ],
+				[ 'menu_slug' => 'footer', 'page_title' => 'Footer', 'parent_slug' => 'settings' ],
+			],
+		] );
+
+		$base->acf_options_page();
+
+		$this->assertCount( 1, $this->sub_pages );
+		$this->assertSame( 'mytheme_settings', $this->sub_pages[0]['post_id'] );
+	}
+
+	/** Declaration order must not matter — top-level pages register first. */
+	public function test_sub_page_inherits_when_declared_before_its_parent(): void {
+		$base = $this->createStarterBase( [
+			'options_pages' => [
+				[ 'menu_slug' => 'footer', 'page_title' => 'Footer', 'parent_slug' => 'settings' ],
+				[ 'menu_slug' => 'settings', 'page_title' => 'Theme Settings', 'post_id' => 'mytheme_settings' ],
+			],
+		] );
+
+		$base->acf_options_page();
+
+		$this->assertSame( 'mytheme_settings', $this->sub_pages[0]['post_id'] );
+	}
+
+	/** A child's own declaration wins over the parent's — the opt-out. */
+	public function test_sub_page_own_post_id_wins_over_parent(): void {
+		$base = $this->createStarterBase( [
+			'options_pages' => [
+				[ 'menu_slug' => 'settings', 'page_title' => 'Theme Settings', 'post_id' => 'mytheme_settings' ],
+				[
+					'menu_slug'   => 'footer',
+					'page_title'  => 'Footer',
+					'parent_slug' => 'settings',
+					'post_id'     => 'mytheme_footer',
+				],
+			],
+		] );
+
+		$base->acf_options_page();
+
+		$this->assertSame( 'mytheme_footer', $this->sub_pages[0]['post_id'] );
+	}
+
+	/** An un-namespaced parent leaves the child un-namespaced too. */
+	public function test_sub_page_gets_no_post_id_when_parent_has_none(): void {
+		$base = $this->createStarterBase( [
+			'options_pages' => [
+				[ 'menu_slug' => 'settings', 'page_title' => 'Theme Settings' ],
+				[ 'menu_slug' => 'footer', 'page_title' => 'Footer', 'parent_slug' => 'settings' ],
+			],
+		] );
+
+		$base->acf_options_page();
+
+		$this->assertArrayNotHasKey( 'post_id', $this->sub_pages[0] );
+	}
+
+	/**
+	 * A sub-page whose parent_slug points outside the list (a plugin's page,
+	 * say) has no namespace to inherit and must not pick up an unrelated one.
+	 */
+	public function test_sub_page_with_foreign_parent_inherits_nothing(): void {
+		$base = $this->createStarterBase( [
+			'options_pages' => [
+				[ 'menu_slug' => 'settings', 'page_title' => 'Theme Settings', 'post_id' => 'mytheme_settings' ],
+				[ 'menu_slug' => 'extra', 'page_title' => 'Extra', 'parent_slug' => 'some-plugin-page' ],
+			],
+		] );
+
+		$base->acf_options_page();
+
+		$this->assertArrayNotHasKey( 'post_id', $this->sub_pages[0] );
+	}
+}

--- a/tests/Unit/StarterBase/AcfOptionsPagePostIdTest.php
+++ b/tests/Unit/StarterBase/AcfOptionsPagePostIdTest.php
@@ -133,6 +133,80 @@ class AcfOptionsPagePostIdTest extends StarterBaseTestCase {
 	}
 
 	/**
+	 * ACF's add_sub_page() accepts a parent_slug pointing at another sub-page,
+	 * so the namespace has to travel further than one level. Without this, the
+	 * deepest page falls back to 'options' while its siblings sit under the
+	 * theme's namespace — the same split this feature exists to prevent.
+	 */
+	public function test_inheritance_is_transitive_across_nesting_levels(): void {
+		$base = $this->createStarterBase( [
+			'options_pages' => [
+				[ 'menu_slug' => 'settings', 'page_title' => 'Settings', 'post_id' => 'mytheme_settings' ],
+				[ 'menu_slug' => 'sub', 'page_title' => 'Sub', 'parent_slug' => 'settings' ],
+				[ 'menu_slug' => 'subsub', 'page_title' => 'SubSub', 'parent_slug' => 'sub' ],
+			],
+		] );
+
+		$base->acf_options_page();
+
+		$by_slug = array_column( $this->sub_pages, null, 'menu_slug' );
+		$this->assertSame( 'mytheme_settings', $by_slug['sub']['post_id'] );
+		$this->assertSame( 'mytheme_settings', $by_slug['subsub']['post_id'] );
+	}
+
+	/** Deepest-first declaration must resolve the same way. */
+	public function test_transitive_inheritance_ignores_declaration_order(): void {
+		$base = $this->createStarterBase( [
+			'options_pages' => [
+				[ 'menu_slug' => 'subsub', 'page_title' => 'SubSub', 'parent_slug' => 'sub' ],
+				[ 'menu_slug' => 'sub', 'page_title' => 'Sub', 'parent_slug' => 'settings' ],
+				[ 'menu_slug' => 'settings', 'page_title' => 'Settings', 'post_id' => 'mytheme_settings' ],
+			],
+		] );
+
+		$base->acf_options_page();
+
+		$by_slug = array_column( $this->sub_pages, null, 'menu_slug' );
+		$this->assertSame( 'mytheme_settings', $by_slug['subsub']['post_id'] );
+	}
+
+	/** A mid-level override re-namespaces its own subtree, not its parent's. */
+	public function test_mid_level_override_applies_to_its_own_descendants(): void {
+		$base = $this->createStarterBase( [
+			'options_pages' => [
+				[ 'menu_slug' => 'settings', 'page_title' => 'Settings', 'post_id' => 'mytheme_settings' ],
+				[ 'menu_slug' => 'sub', 'page_title' => 'Sub', 'parent_slug' => 'settings', 'post_id' => 'mytheme_sub' ],
+				[ 'menu_slug' => 'subsub', 'page_title' => 'SubSub', 'parent_slug' => 'sub' ],
+			],
+		] );
+
+		$base->acf_options_page();
+
+		$by_slug = array_column( $this->sub_pages, null, 'menu_slug' );
+		$this->assertSame( 'mytheme_sub', $by_slug['subsub']['post_id'] );
+	}
+
+	/**
+	 * A parent_slug cycle is a misconfiguration ACF would not untangle either.
+	 * The requirement is only that resolution terminates rather than recursing
+	 * forever — the list is walked in repeated passes for exactly this reason.
+	 */
+	public function test_parent_slug_cycle_terminates_without_inheriting(): void {
+		$base = $this->createStarterBase( [
+			'options_pages' => [
+				[ 'menu_slug' => 'a', 'page_title' => 'A', 'parent_slug' => 'b' ],
+				[ 'menu_slug' => 'b', 'page_title' => 'B', 'parent_slug' => 'a' ],
+			],
+		] );
+
+		$base->acf_options_page();
+
+		$this->assertCount( 2, $this->sub_pages );
+		$this->assertArrayNotHasKey( 'post_id', $this->sub_pages[0] );
+		$this->assertArrayNotHasKey( 'post_id', $this->sub_pages[1] );
+	}
+
+	/**
 	 * A sub-page whose parent_slug points outside the list (a plugin's page,
 	 * say) has no namespace to inherit and must not pick up an unrelated one.
 	 */

--- a/tests/Unit/StarterBase/ClearCacheOnOptionsSaveTest.php
+++ b/tests/Unit/StarterBase/ClearCacheOnOptionsSaveTest.php
@@ -18,6 +18,7 @@ class ClearCacheOnOptionsSaveTest extends StarterBaseTestCase {
 
 	public function test_clears_cache_on_options_save(): void {
 		Functions\when( 'has_action' )->justReturn( true );
+		Functions\when( 'acf_decode_post_id' )->justReturn( [ 'type' => 'option', 'id' => 'options' ] );
 		$dispatched = [];
 		Functions\when( 'do_action' )->alias( function ( $action ) use ( &$dispatched ) {
 			$dispatched[] = $action;
@@ -26,6 +27,39 @@ class ClearCacheOnOptionsSaveTest extends StarterBaseTestCase {
 		$this->base->clear_cache_on_options_save( 'options' );
 
 		$this->assertContains( 'breeze_clear_all_cache', $dispatched );
+	}
+
+	/**
+	 * A page registered with a custom `post_id` (see $options_pages) fires
+	 * `acf/save_post` with that id, not with 'options'. An equality check
+	 * against the literal would leave the cache stale after every save on
+	 * exactly the projects that namespace their storage.
+	 */
+	public function test_clears_cache_for_a_custom_options_namespace(): void {
+		Functions\when( 'has_action' )->justReturn( true );
+		Functions\when( 'acf_decode_post_id' )->justReturn( [ 'type' => 'option', 'id' => 'mytheme_settings' ] );
+		$dispatched = [];
+		Functions\when( 'do_action' )->alias( function ( $action ) use ( &$dispatched ) {
+			$dispatched[] = $action;
+		} );
+
+		$this->base->clear_cache_on_options_save( 'mytheme_settings' );
+
+		$this->assertContains( 'breeze_clear_all_cache', $dispatched );
+	}
+
+	/** A real post save must still not trigger a site-wide flush. */
+	public function test_skips_a_post_id_acf_does_not_classify_as_options(): void {
+		Functions\when( 'has_action' )->justReturn( true );
+		Functions\when( 'acf_decode_post_id' )->justReturn( [ 'type' => 'post', 'id' => 42 ] );
+		$dispatched = [];
+		Functions\when( 'do_action' )->alias( function ( $action ) use ( &$dispatched ) {
+			$dispatched[] = $action;
+		} );
+
+		$this->base->clear_cache_on_options_save( 'post_42' );
+
+		$this->assertEmpty( $dispatched );
 	}
 
 	public function test_skips_non_options_post_id(): void {
@@ -42,6 +76,7 @@ class ClearCacheOnOptionsSaveTest extends StarterBaseTestCase {
 
 	public function test_skips_when_breeze_not_active(): void {
 		Functions\when( 'has_action' )->justReturn( false );
+		Functions\when( 'acf_decode_post_id' )->justReturn( [ 'type' => 'option', 'id' => 'options' ] );
 		$dispatched = [];
 		Functions\when( 'do_action' )->alias( function ( $action ) use ( &$dispatched ) {
 			$dispatched[] = $action;


### PR DESCRIPTION
Closes #100.

## From project

`sloneek` (WordPress, timber-kit v1.26.1), during a legacy Sage → Timber migration. Options values migrated correctly into the database and nothing reached the front end.

## Why

ACF defaults every options page to `post_id = 'options'`, so values land in `wp_options` as `options_<field_name>` — **keyed by field name, not by page**. `$options_pages` exposed no way to change that, so a theme shared one storage namespace with every other options page on the install.

That assumption holds until a second options page exists, which can happen with no repo change at all: the sloneek install carries one created years ago through ACF's admin UI — an `acf-ui-options-page` post in the database, invisible to any grep.

Both sides owned a field named `footer`:

```
acf_get_field_groups(['options_page' => 'settings'])   → 5 groups, all active
Helpers::formatFields('option')                        → show_notification_bar_switcher,
                                                          sale_timer_global,
                                                          hide_notification_bar,
                                                          footer   ← the other page's
```

The theme's own `links`, `announcement`, `social` and `exit_popup` groups never surfaced. Two things made this expensive rather than merely wrong:

1. **A name collision reads as success.** The theme's footer rendered app-store buttons correctly — from `options_footer_apps_*` rows belonging to the *other* page, which happen to match the theme's own selector. That render was recorded as evidence the wiring was right. It wasn't.
2. **`get_field()` and `get_fields()` disagree silently.** `get_field('links_login', 'option')` returns a value, `get_field('links', 'option')` returns `null`, `formatFields()` sees nothing. No error, no log line — an empty options group is indistinguishable from one nobody filled in.

## What

An optional per-entry `post_id`, passed through to `acf_add_options_page()` / `acf_add_options_sub_page()`:

```php
protected array $options_pages = [
    [ 'menu_slug' => 'settings', 'page_title' => 'Theme Settings', 'post_id' => 'mytheme_settings' ],
    [ 'menu_slug' => 'footer', 'page_title' => 'Footer', 'parent_slug' => 'settings' ],
];
```

**A sub-page inherits its parent's `post_id`** unless it declares its own. This answers the open question in #100, and the answer is that ACF does *not* inherit: `acf_validate_options_page()` applies `'post_id' => 'options'` via `wp_parse_args` to every page independently, parent or not (verified against ACF Pro `pro/options-page.php`). Left alone, a namespaced parent with unmarked children would split one theme's settings across two namespaces and `formatFields()` would return only half of them — the same silent-half-empty failure this PR exists to end. Within a single `$options_pages` list a sub-page is visibly part of the same store, so it is treated as one; declaring `post_id` on the child opts out.

The **read side needed no change**: `Helpers::getFieldObjectsForOptions()` already filters `acf_get_options_pages()` by namespace and `decodeOptionsNamespace()` already collapses the `option`/`options` alias. The gap was only at registration.

## Breaking change?

**No, on its own.** Omitting the key leaves ACF's default in place, so every existing consumer behaves exactly as today. Additive to both the property shape and the generated `$args`.

**Yes, for whoever adopts it.** Setting `post_id` changes where values are read and written, so a live site needs its stored options copied to the new prefix, and the theme's own `formatFields()` call site changes too. That is an argument for opt-in — which is what this is — not for changing the default.

## Deliberately not done

- **No default change.** Namespacing by default would silently orphan every existing site's options.
- **No collision detection.** Warning about a shared namespace would require guessing which of two pages is the intruder; namespacing removes the collision instead of reporting it.
- **The colliding page itself** is the downstream project's cleanup, not this package's problem.

## Tests

`tests/Unit/StarterBase/AcfOptionsPagePostIdTest.php`, 7 cases asserting the `$args` handed to ACF — absent when undeclared, passed through, inherited by a sub-page, inherited regardless of declaration order, child override wins, no inheritance from an un-namespaced parent, no inheritance from a `parent_slug` pointing outside the list.

`composer check` green: 1041 unit + 8 property tests, PHPStan clean, ADR index OK.