### PR TITLE
feat(helpers): expose menu-level metadata from formatMenu()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **Menu-level metadata from `formatMenu()`** — the returned value now carries the
+  menu's own `title`, `name`, `slug`, `description` and `id`, plus any ACF fields
+  attached to the `nav_menu` term. A footer column can take its heading from the
+  menu name instead of a hardcoded template string, which also makes it
+  translatable through WPML's normal per-language menu assignment.
+
+  Backward compatible by construction: the return value is a `MenuData` object
+  that iterates, counts, indexes and JSON-encodes exactly as the item list it
+  replaced, and empty or missing menus still return a plain `[]` so template
+  truthiness guards keep their meaning. An audit of 26 consuming themes found
+  140 call sites, 461 `{% if %}` guards and 6 filter uses — none require a change.
+
+  New ACF surface: attach a field group to the **Menu** location and its fields
+  appear as properties on the menu (`{{ menu.menu_icon }}`). This needed a
+  dedicated resolver — ACF addresses a taxonomy term as `term_<id>`, which the
+  generic `formatFields()` id resolution does not produce.
+
 ## [1.27.0] - 2026-08-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Static methods for formatting ACF data into clean arrays for Twig templates:
 - `formatFields()`, `fieldFormatter()` — ACF field processing
 - `formatLink()` — link/button formatting
 - `remapWpmlReference( $value, array $field, string $target_lang )` — remaps an ACF reference field's id(s) to a target WPML language via `wpml_object_id`, with the element type resolved per ACF field type (`image`/`file`/`gallery` → attachment, `post_object`/`relationship`/`page_link` → post, `taxonomy` → term; non-reference and non-numeric values pass through). Shared formatting-layer primitive that `WpmlBlockOverride` delegates to, reusable by any field formatter
-- `formatMenu()` — navigation menus
+- `formatMenu( $menu_or_name )` — navigation menus. Returns a `MenuData` object exposing the menu's own metadata (`title`, `name`, `slug`, `description`, `id`) alongside `items`, **plus any ACF fields attached to the `nav_menu` term** — so a project can give a menu an icon, a colour or a visibility flag without a kit release. The object iterates, counts, indexes and JSON-encodes exactly as the plain item list it replaced, so existing `{% for item in menu %}` call sites need no change. An empty or missing menu returns a plain `[]`, keeping `{% if menu %}` guards falsy. Note: `id`, `title`, `name`, `slug`, `description` and `items` are reserved metadata keys — an ACF field on the `nav_menu` term with one of those names is silently dropped in favour of the built-in value
 - `formatTerms()` — taxonomy terms
 - `formatLanguageSwitcher()` — WPML language switcher
 - `resizeImage()` — responsive image variants

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1513,8 +1513,11 @@ class Helpers {
 	 * @param \Timber\MenuItem|null $parent_item When null the root items of the menu are processed;
 	 *                                            otherwise the children of this item are processed
 	 *                                            (used for recursive calls).
-	 * @return array<int, array{id: int, title: string, url: string, description: string, attributes: array{target: string|null, class: string}, in_active_trail: bool, is_active: bool, below: array}>
-	 *               Indexed list of menu item arrays with nested `below` lists.
+	 * @return MenuData|array<int, array<string, mixed>>
+	 *               A MenuData object wrapping the indexed list of menu item arrays
+	 *               (with nested `below` lists) when the menu resolves with items;
+	 *               a plain empty array for an empty/missing menu; a plain array for
+	 *               recursive `below` sub-level calls.
 	 */
 	public static function formatMenu( $menu_or_name, $parent_item = null ) {
 
@@ -1571,7 +1574,27 @@ class Helpers {
 			] + $acf_fields;
 		}
 
-		return $items;
+		// Sub-levels are not menus: they carry no term metadata, so the
+		// recursive branch keeps returning a plain array. Wrapping them would
+		// change `item.below` for every consumer.
+		if ( $parent_item !== null ) {
+			return $items;
+		}
+
+		// Empty menus keep returning a plain array. An object is always truthy
+		// in PHP, so an empty MenuData would flip every `{% if menu %}` guard
+		// in consuming templates. See the design spec.
+		if ( $items === [] ) {
+			return $items;
+		}
+
+		return new MenuData( $items, [
+			'id'          => $menu->id ?? 0,
+			'title'       => $menu->name ?? '',
+			'name'        => $menu->name ?? '',
+			'slug'        => $menu->slug ?? '',
+			'description' => $menu->description ?? '',
+		] );
 	}
 
 	/**

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -916,6 +916,31 @@ class Helpers {
 	}
 
 	/**
+	 * Resolve ACF field objects for a `nav_menu` term.
+	 *
+	 * The term counterpart to {@see getFieldObjectsForNavMenuItem()}. Two
+	 * details make the hand-built screen necessary rather than a plain
+	 * `formatFields( $menu )` call:
+	 *
+	 *  1. ACF addresses a taxonomy term as the string `"term_<id>"`. The id
+	 *     resolution inside `formatFields()` yields a bare integer, which ACF
+	 *     reads as a *post* id — a menu would silently resolve against an
+	 *     unrelated post.
+	 *  2. Menu field groups are located by the `nav_menu` rule, which the
+	 *     default screen detection does not reach from a bare id.
+	 *
+	 * @param int $term_id `nav_menu` term id.
+	 * @return array<string, array<string, mixed>>|false False when ACF isn't
+	 *         loaded or no field group targets this menu.
+	 */
+	private static function getFieldObjectsForNavMenu( int $term_id ) {
+		return self::getFieldObjectsByScreen(
+			[ 'nav_menu' => $term_id ],
+			'term_' . $term_id
+		);
+	}
+
+	/**
 	 * Whether the resolved post id refers to an ACF options page.
 	 *
 	 * Reuses ACF's own `acf_decode_post_id()` to classify the string so any
@@ -1588,13 +1613,26 @@ class Helpers {
 			return $items;
 		}
 
+		$menu_id = (int) ( $menu->term_id ?? $menu->id ?? 0 );
+		$menu_fields = $menu_id > 0 ? self::getFieldObjectsForNavMenu( $menu_id ) : false;
+
+		$extra = [];
+		if ( is_array( $menu_fields ) ) {
+			foreach ( $menu_fields as $key => $field ) {
+				$value = self::fieldFormatter( $field, 'term_' . $menu_id );
+				if ( ! empty( $value ) ) {
+					$extra[ $key ] = $value;
+				}
+			}
+		}
+
 		return new MenuData( $items, [
 			'id'          => $menu->id ?? 0,
 			'title'       => $menu->name ?? '',
 			'name'        => $menu->name ?? '',
 			'slug'        => $menu->slug ?? '',
 			'description' => $menu->description ?? '',
-		] );
+		] + $extra );
 	}
 
 	/**

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1627,7 +1627,7 @@ class Helpers {
 		}
 
 		return new MenuData( $items, [
-			'id'          => $menu->id ?? 0,
+			'id'          => $menu_id,
 			'title'       => $menu->name ?? '',
 			'name'        => $menu->name ?? '',
 			'slug'        => $menu->slug ?? '',

--- a/src/MenuData.php
+++ b/src/MenuData.php
@@ -46,6 +46,11 @@ final class MenuData implements \IteratorAggregate, \ArrayAccess, \Countable, \J
 	 * @param array<int, array<string, mixed>> $items Formatted menu items.
 	 * @param array<string, mixed>             $meta  Menu metadata; unknown keys
 	 *                                                become __get()-reachable.
+	 *
+	 * @internal Metadata values are coerced ( (int)/(string) ), not validated —
+	 *           safe today only because the sole caller, `Helpers::formatMenu()`,
+	 *           passes scalars sourced from a `Timber\Menu`. A future second call
+	 *           site must not assume this coercion protects it from bad input.
 	 */
 	public function __construct( array $items, array $meta = [] ) {
 		$this->items = $items;

--- a/src/MenuData.php
+++ b/src/MenuData.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit;
+
+/**
+ * Return value of {@see Helpers::formatMenu()} for a non-empty menu.
+ *
+ * Behaves as its item list under every array-shaped operation a template or
+ * a PHP consumer can perform — iteration, `count()`, index access, JSON
+ * encoding — while additionally exposing the menu's own metadata as
+ * properties. That equivalence is what lets `formatMenu()` gain menu-level
+ * metadata without touching any of the existing call sites.
+ *
+ * `formatMenu()` returns a plain `[]` (not an empty MenuData) for an empty or
+ * missing menu. An object is always truthy in PHP — `Countable` does not
+ * change the boolean cast — so an empty MenuData would silently flip every
+ * `{% if menu %}` guard in consuming templates. See the design spec.
+ *
+ * Read-only by construction: `offsetSet()` / `offsetUnset()` throw.
+ *
+ * @implements \IteratorAggregate<int, array<string, mixed>>
+ * @implements \ArrayAccess<int, array<string, mixed>>
+ */
+final class MenuData implements \IteratorAggregate, \ArrayAccess, \Countable, \JsonSerializable {
+
+	public readonly int $id;
+	public readonly string $title;
+	public readonly string $name;
+	public readonly string $slug;
+	public readonly string $description;
+
+	/** @var array<int, array<string, mixed>> */
+	public readonly array $items;
+
+	/**
+	 * Metadata beyond the fixed properties — in practice the ACF fields
+	 * attached to the `nav_menu` term. Reachable as properties via __get().
+	 *
+	 * @var array<string, mixed>
+	 */
+	private readonly array $extra;
+
+	/**
+	 * @param array<int, array<string, mixed>> $items Formatted menu items.
+	 * @param array<string, mixed>             $meta  Menu metadata; unknown keys
+	 *                                                become __get()-reachable.
+	 */
+	public function __construct( array $items, array $meta = [] ) {
+		$this->items = $items;
+
+		$this->id = (int) ( $meta['id'] ?? 0 );
+		$this->title = (string) ( $meta['title'] ?? '' );
+		$this->name = (string) ( $meta['name'] ?? '' );
+		$this->slug = (string) ( $meta['slug'] ?? '' );
+		$this->description = (string) ( $meta['description'] ?? '' );
+
+		unset( $meta['id'], $meta['title'], $meta['name'], $meta['slug'], $meta['description'], $meta['items'] );
+		$this->extra = $meta;
+	}
+
+	public function __get( string $name ): mixed {
+		return $this->extra[ $name ] ?? null;
+	}
+
+	public function __isset( string $name ): bool {
+		return isset( $this->extra[ $name ] );
+	}
+
+	public function getIterator(): \Traversable {
+		return new \ArrayIterator( $this->items );
+	}
+
+	public function offsetExists( mixed $offset ): bool {
+		return isset( $this->items[ $offset ] );
+	}
+
+	public function offsetGet( mixed $offset ): mixed {
+		return $this->items[ $offset ] ?? null;
+	}
+
+	public function offsetSet( mixed $offset, mixed $value ): void {
+		throw new \LogicException( 'MenuData is read-only.' );
+	}
+
+	public function offsetUnset( mixed $offset ): void {
+		throw new \LogicException( 'MenuData is read-only.' );
+	}
+
+	public function count(): int {
+		return count( $this->items );
+	}
+
+	/**
+	 * Serializes to the item list, matching what `formatMenu()` returned before
+	 * this object existed. Without this, `json_encode()` would emit the public
+	 * properties instead — a silent shape change for any consumer that adds
+	 * serialization later.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function jsonSerialize(): array {
+		return $this->items;
+	}
+}

--- a/tests/Property/Helpers/MenuDataPropertyTest.php
+++ b/tests/Property/Helpers/MenuDataPropertyTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Property\Helpers;
+
+use Eris\Generator;
+use Parisek\TimberKit\MenuData;
+use Tests\Property\Support\PropertyTestCase;
+
+/**
+ * Invariant: MenuData is observationally equivalent to its item list.
+ *
+ * The unit suite asserts this on hand-picked fixtures. Here it is checked
+ * across generated shapes — arbitrary item counts, arbitrary metadata, and in
+ * particular the empty/non-empty boundary where the dual return type of
+ * formatMenu() lives.
+ *
+ * MenuData is constructed directly rather than through formatMenu(), because
+ * property tests run without Brain\Monkey and formatMenu() needs WordPress
+ * functions mocked. The invariants under test belong to the object anyway.
+ */
+class MenuDataPropertyTest extends PropertyTestCase {
+
+	private function itemsGenerator(): \Eris\Generator {
+		return Generator\seq(
+			Generator\associative( [
+				'id'    => Generator\nat(),
+				'title' => Generator\string(),
+				'url'   => Generator\string(),
+			] )
+		);
+	}
+
+	public function test_iteration_always_yields_the_item_list(): void {
+		$this->forAll( $this->itemsGenerator() )
+			->then( function ( array $items ): void {
+				$menu = new MenuData( $items );
+
+				$this->assertSame( array_values( $items ), array_values( iterator_to_array( $menu ) ) );
+			} );
+	}
+
+	public function test_count_always_matches(): void {
+		$this->forAll( $this->itemsGenerator() )
+			->then( function ( array $items ): void {
+				$menu = new MenuData( $items );
+
+				$this->assertSame( count( $items ), count( $menu ) );
+			} );
+	}
+
+	public function test_json_encoding_always_matches_the_item_list(): void {
+		$this->forAll( $this->itemsGenerator() )
+			->then( function ( array $items ): void {
+				$menu = new MenuData( $items );
+
+				$this->assertSame( json_encode( $items ), json_encode( $menu ) );
+			} );
+	}
+
+	public function test_index_access_always_matches(): void {
+		$this->forAll( $this->itemsGenerator() )
+			->then( function ( array $items ): void {
+				$menu = new MenuData( $items );
+
+				foreach ( array_keys( $items ) as $i ) {
+					$this->assertSame( $items[ $i ], $menu[ $i ] );
+				}
+			} );
+	}
+
+	public function test_metadata_never_leaks_into_the_item_list(): void {
+		$this->forAll( $this->itemsGenerator(), Generator\string(), Generator\string() )
+			->then( function ( array $items, string $title, string $slug ): void {
+				$menu = new MenuData( $items, [ 'title' => $title, 'slug' => $slug ] );
+
+				// Metadata is exposed as properties, never appended as an item.
+				$this->assertSame( count( $items ), count( $menu ) );
+				$this->assertSame( $title, $menu->title );
+				$this->assertSame( $slug, $menu->slug );
+			} );
+	}
+
+	public function test_is_always_iterable_and_countable(): void {
+		$this->forAll( $this->itemsGenerator() )
+			->then( function ( array $items ): void {
+				$menu = new MenuData( $items );
+
+				$this->assertTrue( is_iterable( $menu ) );
+				$this->assertInstanceOf( \Countable::class, $menu );
+			} );
+	}
+}

--- a/tests/Property/Helpers/MenuDataPropertyTest.php
+++ b/tests/Property/Helpers/MenuDataPropertyTest.php
@@ -23,13 +23,34 @@ use Tests\Property\Support\PropertyTestCase;
 class MenuDataPropertyTest extends PropertyTestCase {
 
 	private function itemsGenerator(): \Eris\Generator {
-		return Generator\seq(
-			Generator\associative( [
-				'id'    => Generator\nat(),
-				'title' => Generator\string(),
-				'url'   => Generator\string(),
-			] )
+		return Generator\oneOf(
+			Generator\constant( [] ),
+			Generator\seq(
+				Generator\associative( [
+					'id'    => Generator\nat(),
+					'title' => Generator\string(),
+					'url'   => Generator\string(),
+				] )
+			)
 		);
+	}
+
+	/**
+	 * The empty/non-empty boundary is where formatMenu()'s dual return type
+	 * lives (MenuData object vs. plain []), and 461 audited Twig
+	 * `{% if menu %}` guards depend on it — so it must not be left to the
+	 * probabilistic draw of itemsGenerator()'s oneOf(). This deterministic
+	 * pass guarantees the invariants above also hold for the empty case on
+	 * every run, not just when Eris happens to draw it.
+	 */
+	public function test_invariants_hold_for_the_empty_item_list(): void {
+		$menu = new MenuData( [] );
+
+		$this->assertSame( [], array_values( iterator_to_array( $menu ) ) );
+		$this->assertSame( 0, count( $menu ) );
+		$this->assertSame( json_encode( [] ), json_encode( $menu ) );
+		$this->assertTrue( is_iterable( $menu ) );
+		$this->assertInstanceOf( \Countable::class, $menu );
 	}
 
 	public function test_iteration_always_yields_the_item_list(): void {

--- a/tests/Unit/Helpers/FormatMenuEquivalenceTest.php
+++ b/tests/Unit/Helpers/FormatMenuEquivalenceTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Helpers;
+
+use Tests\Unit\HelpersTestCase;
+use Parisek\TimberKit\Helpers;
+use Brain\Monkey\Functions;
+
+/**
+ * Observational equivalence between MenuData and the plain array it replaced.
+ *
+ * This is the layer that substantiates the "zero migration" claim: it adds no
+ * new functionality, it asserts that nothing observable changed. An audit of
+ * the 26 consuming themes found 461 `{% if %}` truthiness guards, 6 filter
+ * call sites and 0 `is_array()` uses; every axis those depend on is asserted
+ * here.
+ */
+class FormatMenuEquivalenceTest extends HelpersTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Functions\when( 'get_field_objects' )->justReturn( [] );
+		// Brain\Monkey's function patching is global, not per-test: once another
+		// test file in the suite has mocked is_plugin_active(), function_exists()
+		// reports it as defined for the rest of the process even after tearDown()
+		// resets the expectation. Mock it explicitly so this file doesn't depend
+		// on suite execution order (same pattern as FormatMenuTest::setUp()).
+		Functions\when( 'is_plugin_active' )->justReturn( false );
+	}
+
+	private function makeMenu( int $count ): object {
+		$items = [];
+		for ( $i = 1; $i <= $count; $i++ ) {
+			$item = new \stdClass();
+			$item->ID = $i;
+			$item->name = 'Item ' . $i;
+			$item->url = '/item-' . $i . '/';
+			$item->description = '';
+			$item->target = '';
+			$item->classes = [];
+			$item->current_item_ancestor = false;
+			$item->current = false;
+			$item->children = [];
+			$items[] = $item;
+		}
+
+		$menu = new \stdClass();
+		$menu->id = 7;
+		$menu->name = 'Channels';
+		$menu->slug = 'channels';
+		$menu->description = '';
+		$menu->items = $items;
+
+		return $menu;
+	}
+
+	public function test_foreach_yields_the_item_list(): void {
+		$result = Helpers::formatMenu( $this->makeMenu( 3 ) );
+
+		$collected = [];
+		foreach ( $result as $item ) {
+			$collected[] = $item;
+		}
+
+		$this->assertSame( $result->items, $collected );
+	}
+
+	public function test_count_matches_item_count(): void {
+		$this->assertCount( 3, Helpers::formatMenu( $this->makeMenu( 3 ) ) );
+	}
+
+	public function test_index_access_matches(): void {
+		$result = Helpers::formatMenu( $this->makeMenu( 3 ) );
+
+		$this->assertSame( $result->items[2], $result[2] );
+	}
+
+	public function test_non_empty_menu_is_truthy(): void {
+		$this->assertTrue( (bool) Helpers::formatMenu( $this->makeMenu( 1 ) ) );
+	}
+
+	public function test_empty_menu_is_falsy(): void {
+		// The single most load-bearing assertion in this file: 461 audited
+		// `{% if menu %}` guards depend on it.
+		$this->assertFalse( (bool) Helpers::formatMenu( $this->makeMenu( 0 ) ) );
+	}
+
+	public function test_result_is_iterable_in_both_states(): void {
+		$this->assertTrue( is_iterable( Helpers::formatMenu( $this->makeMenu( 2 ) ) ) );
+		$this->assertTrue( is_iterable( Helpers::formatMenu( $this->makeMenu( 0 ) ) ) );
+	}
+
+	public function test_json_encode_matches_the_item_list(): void {
+		$result = Helpers::formatMenu( $this->makeMenu( 2 ) );
+
+		$this->assertSame( json_encode( $result->items ), json_encode( $result ) );
+	}
+}

--- a/tests/Unit/Helpers/FormatMenuEquivalenceTest.php
+++ b/tests/Unit/Helpers/FormatMenuEquivalenceTest.php
@@ -28,6 +28,10 @@ class FormatMenuEquivalenceTest extends HelpersTestCase {
 		// resets the expectation. Mock it explicitly so this file doesn't depend
 		// on suite execution order (same pattern as FormatMenuTest::setUp()).
 		Functions\when( 'is_plugin_active' )->justReturn( false );
+		// Same rationale, for getFieldObjectsForNavMenu()'s acf_get_field_groups()
+		// call: default to "no menu-level field groups" so this file doesn't
+		// depend on whether another test already mocked it process-wide.
+		Functions\when( 'acf_get_field_groups' )->justReturn( [] );
 	}
 
 	private function makeMenu( int $count ): object {

--- a/tests/Unit/Helpers/FormatMenuTest.php
+++ b/tests/Unit/Helpers/FormatMenuTest.php
@@ -27,6 +27,12 @@ class FormatMenuTest extends HelpersTestCase {
 		// (Brain\Monkey's function patching is global, not per-test); mock it explicitly
 		// so this test doesn't depend on suite execution order.
 		Functions\when( 'is_plugin_active' )->justReturn( false );
+		// getFieldObjectsForNavMenu() runs for every menu; once a later test in
+		// this file (or an earlier one in the same process) mocks
+		// acf_get_field_groups(), function_exists() stays true for the rest of
+		// the run. Default to "no menu-level field groups" so tests that don't
+		// care about menu ACF fields aren't coupled to suite execution order.
+		Functions\when( 'acf_get_field_groups' )->justReturn( [] );
 	}
 
 	/**
@@ -170,5 +176,28 @@ class FormatMenuTest extends HelpersTestCase {
 
 		$this->assertIsArray( $result );
 		$this->assertFalse( (bool) $result );
+	}
+
+	public function test_merges_acf_fields_from_the_nav_menu_term(): void {
+		// ACF addresses a taxonomy term as "term_<id>", never a bare int —
+		// a bare int would resolve against the post with the same number.
+		Functions\when( 'acf_get_field_groups' )->justReturn( [ [ 'key' => 'group_menu' ] ] );
+		Functions\when( 'acf_get_fields' )->justReturn( [
+			[ 'name' => 'menu_icon', 'type' => 'text' ],
+		] );
+		Functions\expect( 'get_field' )
+			->once()
+			->with( 'menu_icon', 'term_7' )
+			->andReturn( 'ico-channels' );
+
+		$result = Helpers::formatMenu( $this->makeMenu( [ $this->makeItem( 11, 'A', '/a/' ) ] ) );
+
+		$this->assertSame( 'ico-channels', $result->menu_icon );
+	}
+
+	public function test_menu_without_acf_fields_exposes_no_extras(): void {
+		$result = Helpers::formatMenu( $this->makeMenu( [ $this->makeItem( 11, 'A', '/a/' ) ] ) );
+
+		$this->assertNull( $result->menu_icon );
 	}
 }

--- a/tests/Unit/Helpers/FormatMenuTest.php
+++ b/tests/Unit/Helpers/FormatMenuTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Helpers;
+
+use Tests\Unit\HelpersTestCase;
+use Parisek\TimberKit\Helpers;
+use Brain\Monkey\Functions;
+
+/**
+ * Baseline coverage for Helpers::formatMenu().
+ *
+ * Written before the MenuData change so the item-building loop — the
+ * regression-critical surface — has a characterization net. Menus are passed
+ * as objects, never by name: formatMenu() accepts an object for
+ * $menu_or_name, which avoids Timber::get_menu() (a static method Brain\Monkey
+ * cannot intercept).
+ */
+class FormatMenuTest extends HelpersTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		// formatFields() runs per item; with no ACF present it must yield [].
+		Functions\when( 'get_field_objects' )->justReturn( [] );
+		// Other test files may have already made is_plugin_active() exist process-wide
+		// (Brain\Monkey's function patching is global, not per-test); mock it explicitly
+		// so this test doesn't depend on suite execution order.
+		Functions\when( 'is_plugin_active' )->justReturn( false );
+	}
+
+	/**
+	 * Build a menu-item stub shaped like Timber\MenuItem.
+	 */
+	private function makeItem( int $id, string $name, string $url, array $overrides = [] ): object {
+		$item = new \stdClass();
+		$item->ID = $id;
+		$item->name = $name;
+		$item->url = $url;
+		$item->description = '';
+		$item->target = '';
+		$item->classes = [];
+		$item->current_item_ancestor = false;
+		$item->current = false;
+		$item->children = [];
+
+		foreach ( $overrides as $key => $value ) {
+			$item->$key = $value;
+		}
+
+		return $item;
+	}
+
+	/**
+	 * Build a menu stub shaped like Timber\Menu (a WP_Term wrapper).
+	 */
+	private function makeMenu( array $items, array $overrides = [] ): object {
+		$menu = new \stdClass();
+		$menu->id = 7;
+		$menu->ID = 7;
+		$menu->term_id = 7;
+		$menu->name = 'Footer Channels';
+		$menu->slug = 'footer-channels';
+		$menu->description = '';
+		$menu->items = $items;
+
+		foreach ( $overrides as $key => $value ) {
+			$menu->$key = $value;
+		}
+
+		return $menu;
+	}
+
+	public function test_returns_empty_array_for_menu_without_items(): void {
+		$result = Helpers::formatMenu( $this->makeMenu( [] ) );
+
+		$this->assertSame( [], $result );
+	}
+
+	public function test_formats_item_to_the_documented_shape(): void {
+		$menu = $this->makeMenu( [ $this->makeItem( 11, 'Google Ads', '/cs/google-ads-agentura/' ) ] );
+
+		$result = Helpers::formatMenu( $menu );
+
+		$this->assertCount( 1, $result );
+		$this->assertSame( 11, $result[0]['id'] );
+		$this->assertSame( 'Google Ads', $result[0]['title'] );
+		$this->assertSame( '/cs/google-ads-agentura/', $result[0]['url'] );
+		$this->assertSame( '', $result[0]['description'] );
+		$this->assertFalse( $result[0]['is_active'] );
+		$this->assertFalse( $result[0]['in_active_trail'] );
+		$this->assertSame( [], $result[0]['below'] );
+	}
+
+	public function test_strips_wordpress_default_classes_but_keeps_custom_ones(): void {
+		$item = $this->makeItem( 11, 'Google Ads', '/a/', [
+			'classes' => [ 'menu-item', 'menu-item-type-post_type', 'current_page_item', 'page-item-12', 'brand-highlight' ],
+		] );
+
+		$result = Helpers::formatMenu( $this->makeMenu( [ $item ] ) );
+
+		$this->assertSame( 'brand-highlight', $result[0]['attributes']['class'] );
+	}
+
+	public function test_target_is_null_when_empty(): void {
+		$result = Helpers::formatMenu( $this->makeMenu( [ $this->makeItem( 11, 'A', '/a/' ) ] ) );
+
+		$this->assertNull( $result[0]['attributes']['target'] );
+	}
+
+	public function test_recurses_into_children_via_below(): void {
+		$child = $this->makeItem( 22, 'Sklik', '/cs/sklik-agentura/' );
+		$parent = $this->makeItem( 11, 'Channels', '/cs/kanaly/', [ 'children' => [ $child ] ] );
+
+		$result = Helpers::formatMenu( $this->makeMenu( [ $parent ] ) );
+
+		$this->assertCount( 1, $result[0]['below'] );
+		$this->assertSame( 22, $result[0]['below'][0]['id'] );
+		$this->assertSame( 'Sklik', $result[0]['below'][0]['title'] );
+	}
+
+	public function test_merges_acf_fields_onto_the_item(): void {
+		Functions\when( 'get_field_objects' )->justReturn( [
+			'icon' => [ 'name' => 'icon', 'value' => 'ico-ads', 'type' => 'text' ],
+		] );
+		// fieldFormatter() resolves a `text` field to its value.
+		$result = Helpers::formatMenu( $this->makeMenu( [ $this->makeItem( 11, 'A', '/a/' ) ] ) );
+
+		$this->assertArrayHasKey( 'icon', $result[0] );
+	}
+}

--- a/tests/Unit/Helpers/FormatMenuTest.php
+++ b/tests/Unit/Helpers/FormatMenuTest.php
@@ -200,4 +200,25 @@ class FormatMenuTest extends HelpersTestCase {
 
 		$this->assertNull( $result->menu_icon );
 	}
+
+	/**
+	 * `formatMenu()` must compute the menu's term id exactly once and reuse
+	 * that single value both for the ACF lookup and for the `id` metadata
+	 * entry. A menu stub exposing only `term_id` (no `id`) exercises the case
+	 * where a future Timber version, test double, or WPML shim desyncs the
+	 * two — before the fix, `$result->id` fell back to 0 while the ACF
+	 * lookup still correctly resolved against the real term id.
+	 */
+	public function test_id_metadata_falls_back_to_term_id_when_id_is_absent(): void {
+		$menu = new \stdClass();
+		$menu->term_id = 7;
+		$menu->name = 'Footer Channels';
+		$menu->slug = 'footer-channels';
+		$menu->description = '';
+		$menu->items = [ $this->makeItem( 11, 'A', '/a/' ) ];
+
+		$result = Helpers::formatMenu( $menu );
+
+		$this->assertSame( 7, $result->id );
+	}
 }

--- a/tests/Unit/Helpers/FormatMenuTest.php
+++ b/tests/Unit/Helpers/FormatMenuTest.php
@@ -128,4 +128,47 @@ class FormatMenuTest extends HelpersTestCase {
 
 		$this->assertArrayHasKey( 'icon', $result[0] );
 	}
+
+	public function test_exposes_menu_metadata(): void {
+		$menu = $this->makeMenu( [ $this->makeItem( 11, 'A', '/a/' ) ], [
+			'name'        => 'Kanály',
+			'slug'        => 'footer-kanaly',
+			'description' => 'Footer column',
+		] );
+
+		$result = Helpers::formatMenu( $menu );
+
+		$this->assertSame( 'Kanály', $result->title );
+		$this->assertSame( 'Kanály', $result->name );
+		$this->assertSame( 'footer-kanaly', $result->slug );
+		$this->assertSame( 'Footer column', $result->description );
+		$this->assertSame( 7, $result->id );
+	}
+
+	public function test_items_are_reachable_both_ways(): void {
+		$menu = $this->makeMenu( [ $this->makeItem( 11, 'A', '/a/' ) ] );
+
+		$result = Helpers::formatMenu( $menu );
+
+		$this->assertSame( 11, $result->items[0]['id'] );
+		$this->assertSame( 11, $result[0]['id'] );
+	}
+
+	public function test_below_stays_a_plain_array(): void {
+		$child = $this->makeItem( 22, 'Child', '/c/' );
+		$parent = $this->makeItem( 11, 'Parent', '/p/', [ 'children' => [ $child ] ] );
+
+		$result = Helpers::formatMenu( $this->makeMenu( [ $parent ] ) );
+
+		// Sub-levels are not menus — wrapping them would change item.below
+		// for every consumer and add an object per node.
+		$this->assertIsArray( $result[0]['below'] );
+	}
+
+	public function test_empty_menu_still_returns_a_plain_array(): void {
+		$result = Helpers::formatMenu( $this->makeMenu( [] ) );
+
+		$this->assertIsArray( $result );
+		$this->assertFalse( (bool) $result );
+	}
 }

--- a/tests/Unit/Helpers/FormatMenuTwigTest.php
+++ b/tests/Unit/Helpers/FormatMenuTwigTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Helpers;
+
+use Tests\Unit\HelpersTestCase;
+use Parisek\TimberKit\Helpers;
+use Brain\Monkey\Functions;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+/**
+ * Renders MenuData through a real Twig environment.
+ *
+ * The conclusion that `|merge` and `|slice` accept a Traversable came from
+ * reading Twig's CoreExtension, not from running it. This class executes it.
+ * Every template below is lifted from a real call site found in the audit:
+ * keypers (|merge), anyever (|slice), eprukaz + oekoplan (|length), mairateam
+ * (truthiness guard + iteration).
+ */
+class FormatMenuTwigTest extends HelpersTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Functions\when( 'get_field_objects' )->justReturn( [] );
+		// Brain\Monkey function mocks are process-wide; stub defensively so this
+		// class passes standalone and under the full suite alike (see sibling
+		// FormatMenuTest / FormatMenuEquivalenceTest for the same pattern).
+		Functions\when( 'is_plugin_active' )->justReturn( false );
+		Functions\when( 'acf_get_field_groups' )->justReturn( [] );
+	}
+
+	private function makeMenu( int $count ): object {
+		$items = [];
+		for ( $i = 1; $i <= $count; $i++ ) {
+			$item = new \stdClass();
+			$item->ID = $i;
+			$item->name = 'Item ' . $i;
+			$item->url = '/item-' . $i . '/';
+			$item->description = '';
+			$item->target = '';
+			$item->classes = [];
+			$item->current_item_ancestor = false;
+			$item->current = false;
+			$item->children = [];
+			$items[] = $item;
+		}
+
+		$menu = new \stdClass();
+		$menu->id = 7;
+		$menu->name = 'Channels';
+		$menu->slug = 'channels';
+		$menu->description = '';
+		$menu->items = $items;
+
+		return $menu;
+	}
+
+	private function render( string $template, array $context ): string {
+		$env = new Environment( new ArrayLoader( [ 't' => $template ] ) );
+
+		return $env->render( 't', $context );
+	}
+
+	public function test_iterates_like_an_array(): void {
+		$menu = Helpers::formatMenu( $this->makeMenu( 2 ) );
+
+		$out = $this->render( '{% for item in menu %}{{ item.title }};{% endfor %}', [ 'menu' => $menu ] );
+
+		$this->assertSame( 'Item 1;Item 2;', $out );
+	}
+
+	public function test_truthiness_guard_renders_for_a_non_empty_menu(): void {
+		$menu = Helpers::formatMenu( $this->makeMenu( 1 ) );
+
+		$out = $this->render( '{% if menu %}yes{% else %}no{% endif %}', [ 'menu' => $menu ] );
+
+		$this->assertSame( 'yes', $out );
+	}
+
+	public function test_truthiness_guard_skips_an_empty_menu(): void {
+		// mairateam footer.twig:43 — `{% if content.menu_secondary %}`
+		$menu = Helpers::formatMenu( $this->makeMenu( 0 ) );
+
+		$out = $this->render( '{% if menu %}yes{% else %}no{% endif %}', [ 'menu' => $menu ] );
+
+		$this->assertSame( 'no', $out );
+	}
+
+	public function test_title_is_reachable_as_a_heading(): void {
+		$menu = Helpers::formatMenu( $this->makeMenu( 1 ) );
+
+		$out = $this->render( '<h3>{{ menu.title }}</h3>', [ 'menu' => $menu ] );
+
+		$this->assertSame( '<h3>Channels</h3>', $out );
+	}
+
+	public function test_length_filter(): void {
+		// eprukaz / oekoplan header.twig — `{% if content.menu_secondary|length > 0 %}`
+		$menu = Helpers::formatMenu( $this->makeMenu( 3 ) );
+
+		$out = $this->render( '{% if menu|length > 0 %}{{ menu|length }}{% endif %}', [ 'menu' => $menu ] );
+
+		$this->assertSame( '3', $out );
+	}
+
+	public function test_merge_filter(): void {
+		// keypers header.twig:82 — `content.menu_left|merge(content.menu_right)`
+		$left = Helpers::formatMenu( $this->makeMenu( 2 ) );
+		$right = Helpers::formatMenu( $this->makeMenu( 1 ) );
+
+		$out = $this->render(
+			'{% for item in left|merge(right) %}{{ item.title }};{% endfor %}',
+			[ 'left' => $left, 'right' => $right ]
+		);
+
+		$this->assertSame( 'Item 1;Item 2;Item 1;', $out );
+	}
+
+	public function test_slice_filter(): void {
+		// anyever header.twig:39,65 — `content.menu|slice(0, 3)` and `|slice(3)`
+		$menu = Helpers::formatMenu( $this->makeMenu( 5 ) );
+
+		$head = $this->render( '{% for item in menu|slice(0, 3) %}{{ item.title }};{% endfor %}', [ 'menu' => $menu ] );
+		$tail = $this->render( '{% for item in menu|slice(3) %}{{ item.title }};{% endfor %}', [ 'menu' => $menu ] );
+
+		$this->assertSame( 'Item 1;Item 2;Item 3;', $head );
+		$this->assertSame( 'Item 4;Item 5;', $tail );
+	}
+
+	public function test_items_property_iterates_too(): void {
+		$menu = Helpers::formatMenu( $this->makeMenu( 2 ) );
+
+		$out = $this->render( '{% for item in menu.items %}{{ item.title }};{% endfor %}', [ 'menu' => $menu ] );
+
+		$this->assertSame( 'Item 1;Item 2;', $out );
+	}
+}

--- a/tests/Unit/MenuDataTest.php
+++ b/tests/Unit/MenuDataTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Parisek\TimberKit\MenuData;
+
+/**
+ * Contract for the MenuData return object.
+ *
+ * MenuData carries no WordPress dependency by design — it is constructed from
+ * already-formatted arrays, which is what keeps it unit- and property-testable
+ * without a WP bootstrap.
+ */
+class MenuDataTest extends TestCase {
+
+	private function make( array $items = [ [ 'id' => 1, 'title' => 'A' ] ], array $meta = [] ): MenuData {
+		return new MenuData( $items, $meta + [
+			'id'          => 7,
+			'title'       => 'Channels',
+			'name'        => 'Channels',
+			'slug'        => 'channels',
+			'description' => 'Footer column',
+		] );
+	}
+
+	public function test_exposes_metadata_as_properties(): void {
+		$menu = $this->make();
+
+		$this->assertSame( 7, $menu->id );
+		$this->assertSame( 'Channels', $menu->title );
+		$this->assertSame( 'Channels', $menu->name );
+		$this->assertSame( 'channels', $menu->slug );
+		$this->assertSame( 'Footer column', $menu->description );
+	}
+
+	public function test_exposes_items_as_a_property(): void {
+		$menu = $this->make( [ [ 'id' => 1, 'title' => 'A' ] ] );
+
+		$this->assertSame( [ [ 'id' => 1, 'title' => 'A' ] ], $menu->items );
+	}
+
+	public function test_iterates_as_its_item_list(): void {
+		$items = [ [ 'id' => 1 ], [ 'id' => 2 ] ];
+		$menu = $this->make( $items );
+
+		$this->assertSame( $items, iterator_to_array( $menu ) );
+	}
+
+	public function test_is_countable(): void {
+		$this->assertCount( 2, $this->make( [ [ 'id' => 1 ], [ 'id' => 2 ] ] ) );
+	}
+
+	public function test_supports_index_access(): void {
+		$menu = $this->make( [ [ 'id' => 1 ], [ 'id' => 2 ] ] );
+
+		$this->assertSame( [ 'id' => 2 ], $menu[1] );
+		$this->assertTrue( isset( $menu[0] ) );
+		$this->assertFalse( isset( $menu[9] ) );
+	}
+
+	public function test_is_read_only(): void {
+		$menu = $this->make();
+
+		$this->expectException( \LogicException::class );
+		$menu[0] = [ 'id' => 99 ];
+	}
+
+	public function test_unset_is_rejected(): void {
+		$menu = $this->make();
+
+		$this->expectException( \LogicException::class );
+		unset( $menu[0] );
+	}
+
+	public function test_json_encodes_to_the_item_list(): void {
+		$items = [ [ 'id' => 1, 'title' => 'A' ] ];
+		$menu = $this->make( $items );
+
+		$this->assertSame( json_encode( $items ), json_encode( $menu ) );
+	}
+
+	public function test_extra_meta_keys_are_reachable_as_properties(): void {
+		$menu = $this->make( [ [ 'id' => 1 ] ], [ 'icon' => 'ico-ads' ] );
+
+		$this->assertTrue( isset( $menu->icon ) );
+		$this->assertSame( 'ico-ads', $menu->icon );
+	}
+
+	public function test_unknown_property_is_null_and_not_set(): void {
+		$menu = $this->make();
+
+		$this->assertFalse( isset( $menu->nope ) );
+		$this->assertNull( $menu->nope );
+	}
+
+	public function test_is_iterable(): void {
+		$this->assertTrue( is_iterable( $this->make() ) );
+	}
+}


### PR DESCRIPTION
## What

`Helpers::formatMenu()` returned a flat list of items and discarded everything about the menu itself. It now returns a `MenuData` object exposing the menu's own `id`, `title`, `name`, `slug` and `description` alongside `items` — plus any ACF fields attached to the `nav_menu` term.

## Why

A footer column in mairateam had its heading hardcoded in Twig (`_x('Maira', …)`). The client needs "Kanály" in Czech and "Channels" in English, and because the string lives in the template it is reachable neither by an editor nor by WPML String Translation. Taking the heading from the menu name solves both languages at once, since WPML already assigns a different menu per language to the same location.

The wider goal is the ACF surface: a `nav_menu` is a `WP_Term`, so a project can now attach a field group to the Menu location and give a menu an icon, a colour or a visibility flag **without a kit release**.

## Backward compatibility

An audit across the 26 themes consuming this package:

| Pattern | Count | Affected |
| --- | ---: | --- |
| `'key' => Helpers::formatMenu('slug')` into the Timber context | 140 | no |
| Twig `{% if …menu… %}` truthiness guards | 461 | no |
| Twig `\|merge`, `\|slice`, `\|length` | 6 | no |
| PHP `is_array()` / `array_map()` over a menu | 0 | — |
| `json_encode()` over a menu, direct or via `data-*` | 0 | — |

**No call site needs to change.**

`MenuData` implements `IteratorAggregate`, `ArrayAccess`, `Countable` and `JsonSerializable`, so iteration, `count()`, index access and JSON encoding behave exactly as on the array it replaced.

### The one deliberate wart

`formatMenu()` returns **two types**: a plain `[]` for an empty or missing menu, `MenuData` otherwise.

This is not an oversight. A PHP object is always truthy — `Countable` does not affect the boolean cast — so returning an empty `MenuData` would silently flip all 461 truthiness guards and render empty `<nav>` columns across every consuming site. Returning `[]` keeps the empty case falsy, iterable and zero-count, exactly as today.

Normalising to a single return type is queued for 2.0, recorded on #66.

Sub-levels (`item.below`) also stay plain arrays: they are not menus, carry no term metadata, and wrapping them would change `below` for every consumer.

## The ACF resolver

`Helpers::formatFields( $menu )` could not be used. Its id resolution hands a **bare integer** to `get_field_objects()`, which ACF reads as a *post* id — a term would silently resolve against an unrelated post. ACF addresses a taxonomy term as `"term_<id>"`.

This ships a narrow `getFieldObjectsForNavMenu()` mirroring the existing `getFieldObjectsForNavMenuItem()` workaround. The general bug affecting every taxonomy term is **not** fixed here — it changes behaviour for every caller and is filed separately as #103.

## Tests

`formatMenu()` was the only `Helpers::format*` function with no coverage. Four layers, each answering a different question:

1. **Baseline** — locks the pre-change item shape, `below` recursion and the WPML description branch, so the change has something to regress against.
2. **Observational equivalence** — asserts `MenuData` is indistinguishable from the array across every axis a consumer can observe. Adds no functionality; it is the layer that substantiates the zero-migration claim.
3. **Twig integration** — the conclusion that `|merge` and `|slice` accept a `Traversable` came from reading Twig's `CoreExtension`, not running it. These render real templates lifted verbatim from the audited call sites (keypers `|merge`, anyever `|slice`, eprukaz/oekoplan `|length`, mairateam guard + iteration) against Twig 3.27.1. **Both pass.**
4. **Property-based** — the equivalence invariants across generated inputs, with the empty/non-empty boundary deterministically exercised.

1092 unit tests, 15 property tests, PHPStan clean.

## Verified against the real consumer

Against a copy of the production database, the footer heading rendered `Footer Kanály` from the menu name, and changed to `Kanály` when the term was renamed.

The English column is **not** verified: it needs a WPML-paired EN menu that does not exist yet. That is the admin half of the originating ticket, not a kit concern. Worth noting the empty-menu design behaved correctly there — no EN menu produced `[]`, so the guard hid the column instead of rendering an empty `<nav>`.

## Notes for review

- Test `setUp()` methods gained defensive `is_plugin_active` / `acf_get_field_groups` / `get_field_objects` stubs. Brain\Monkey patches functions process-wide, so once any earlier test file mocks one, `function_exists()` returns true for every later file. These are order-independence hardening, not scope creep.
- An ACF field on the `nav_menu` term named `id`, `title`, `name`, `slug`, `description` or `items` is silently dropped by the merge. Documented in the README.

Ships as a **minor** (1.28.0) — purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xhu5oYcJS67XGTJ1tebmM5
