### PR TITLE
fix(helpers): resolve taxonomy terms and users to ACF's term_/user_ id form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   dedicated resolver — ACF addresses a taxonomy term as `term_<id>`, which the
   generic `formatFields()` id resolution does not produce.
 
+### Fixed
+
+- **`Helpers::formatFields()` resolved taxonomy terms (and users) against post
+  ids** — the id-resolution branch handed `get_field_objects()` a bare integer
+  (`$post->term_id` / `$post->ID`) for a term or user object, which ACF reads
+  as a post id, silently resolving against whatever post happens to share that
+  number instead of the actual term/user. Fixed by detecting term and user
+  objects *before* the generic `->ID` fallback — `Timber\Term` aliases `->ID`
+  to `->term_id`, and `Timber\User` exposes `->ID` just like a post, so both
+  previously always matched the post branch first — and passing ACF's own
+  `"term_<id>"` / `"user_<id>"` id forms. Detection prefers the `object_type`
+  discriminator Timber's own `Term`/`User`/`Post` classes set, with an
+  `instanceof \WP_Term` / `instanceof \WP_User` check and (for terms) a
+  duck-typed `term_id`-without-`post_type` fallback for plain-object shims
+  that don't extend either core class. No known call site is affected: an
+  audit of ~90 `formatFields()` call sites across 26 consuming themes found
+  none passing a term or user object today.
+  ([#103](https://github.com/parisek/timber-kit/issues/103))
+
 ## [1.27.0] - 2026-08-02
 
 ### Added

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -93,7 +93,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property object\:\:\$ID\.$#'
 			identifier: property.notFound
-			count: 1
+			count: 3
 			path: src/Helpers.php
 
 		-

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -783,7 +783,20 @@ class Helpers {
 
 		$post_id = null;
 
-		if ( is_object( $post ) && ! empty( $post->ID ) ) {
+		if ( is_object( $post ) && self::isTermObject( $post ) ) {
+			// ACF addresses a taxonomy term as the string "term_<id>" —  never
+			// a bare integer, which ACF reads as a post id, silently resolving
+			// against whatever post happens to share that number. Detection
+			// must run before the generic ->ID fallback below: Timber\Term
+			// aliases ->ID to ->term_id, so a term would otherwise always hit
+			// the ->ID branch first.
+			$post_id = 'term_' . ( $post->term_id ?? $post->ID );
+		} elseif ( is_object( $post ) && self::isUserObject( $post ) ) {
+			// Same bug, same fix, for users: ACF addresses a user as
+			// "user_<id>". Must also run before the ->ID fallback below —
+			// Timber\User exposes ->ID just like a post.
+			$post_id = 'user_' . $post->ID;
+		} elseif ( is_object( $post ) && ! empty( $post->ID ) ) {
 			$post_id = $post->ID;
 		} elseif ( is_object( $post ) && ! empty( $post->term_id ) ) {
 			$post_id = $post->term_id;
@@ -844,6 +857,59 @@ class Helpers {
 	}
 
 	/**
+	 * Whether an object passed to {@see formatFields()} represents a taxonomy
+	 * term rather than a post.
+	 *
+	 * `Timber\Term` does not extend `WP_Term` in Timber 2 — it wraps one via
+	 * `CoreEntity` — so an `instanceof \WP_Term` check alone misses it. Three
+	 * complementary signals, checked cheapest-and-most-specific first:
+	 *   1. `->object_type === 'term'` — the discriminator Timber entities
+	 *      themselves expose (`Term`, `User`, `Post` all set it in their own
+	 *      constructor). Preferred over duck-typing where available: it's an
+	 *      explicit, single-property check that can't collide with a post's
+	 *      shape, whereas `Timber\Post` also carries no `term_id` today but
+	 *      isn't guaranteed to stay that way forever.
+	 *   2. Explicit `WP_Term` instance check covers WordPress-shaped term
+	 *      objects regardless of which extra properties they carry (a term
+	 *      with a coincidental `post_type` meta wouldn't slip through a
+	 *      duck-typed check).
+	 *   3. Property-presence fallback (`term_id` without `post_type`) covers
+	 *      term-like plain objects from `(object)` casts and third-party
+	 *      shims that don't extend `WP_Term` and don't set `object_type`.
+	 *
+	 * @param object $post Original object input passed to {@see formatFields()}.
+	 */
+	private static function isTermObject( object $post ): bool {
+		if ( isset( $post->object_type ) && $post->object_type === 'term' ) {
+			return true;
+		}
+		if ( $post instanceof \WP_Term ) {
+			return true;
+		}
+		return isset( $post->term_id ) && ! isset( $post->post_type );
+	}
+
+	/**
+	 * Whether an object passed to {@see formatFields()} represents a user
+	 * rather than a post.
+	 *
+	 * `Timber\User` exposes `->ID` exactly like `Timber\Post`, so — like
+	 * {@see isTermObject()} — detection must happen before the generic
+	 * `->ID` fallback resolves it as a post id. Two signals: the
+	 * `->object_type === 'user'` discriminator Timber's own `User` class
+	 * sets, and an explicit `WP_User` instance check for plain WordPress
+	 * user objects.
+	 *
+	 * @param object $post Original object input passed to {@see formatFields()}.
+	 */
+	private static function isUserObject( object $post ): bool {
+		if ( isset( $post->object_type ) && $post->object_type === 'user' ) {
+			return true;
+		}
+		return $post instanceof \WP_User;
+	}
+
+	/**
 	 * Whether the resolved post id refers to a `nav_menu_item` post.
 	 *
 	 * Detection prefers the in-memory object (avoids an extra DB hit) and
@@ -856,19 +922,11 @@ class Helpers {
 		// Term objects (`formatFields($category)`) must never enter the
 		// menu-item path — otherwise a numeric `term_id` that happens to equal
 		// an unrelated `nav_menu_item` post id would route the term through
-		// the wrong resolver. Two complementary guards:
-		//   1. Explicit `WP_Term` instance check covers WordPress-shaped
-		//      term objects regardless of which extra properties they carry
-		//      (a term with a coincidental `post_type` meta wouldn't slip
-		//      through a duck-typed check).
-		//   2. Property-presence fallback (`term_id` without `post_type`)
-		//      covers term-like plain objects from `(object)` casts and
-		//      third-party shims that don't extend `WP_Term`.
+		// the wrong resolver. {@see isTermObject()} is the same discriminator
+		// the id-resolution branch above already uses, so this guard stays in
+		// lockstep with which objects resolve to `term_<id>`.
 		if ( is_object( $post ) ) {
-			if ( $post instanceof \WP_Term ) {
-				return false;
-			}
-			if ( isset( $post->term_id ) && ! isset( $post->post_type ) ) {
+			if ( self::isTermObject( $post ) ) {
 				return false;
 			}
 			if ( isset( $post->post_type ) && $post->post_type === 'nav_menu_item' ) {

--- a/tests/Unit/Helpers/FormatFieldsTest.php
+++ b/tests/Unit/Helpers/FormatFieldsTest.php
@@ -36,10 +36,12 @@ class FormatFieldsTest extends HelpersTestCase {
 	}
 
 	public function test_with_term_object(): void {
+		// Regression for #103: ACF addresses a taxonomy term as "term_<id>",
+		// never a bare integer — a bare int reads as a post id to ACF.
 		$term = (object) [ 'term_id' => 15 ];
 
 		Functions\when( 'get_field_objects' )->alias( function ( $id ) {
-			if ( $id === 15 ) {
+			if ( $id === 'term_15' ) {
 				return [
 					'color' => [ 'type' => 'color_picker', 'value' => '#ff0000' ],
 				];
@@ -50,6 +52,126 @@ class FormatFieldsTest extends HelpersTestCase {
 		$result = Helpers::formatFields( $term );
 
 		$this->assertSame( '#ff0000', $result['color'] );
+	}
+
+	public function test_with_wp_term_instance_resolves_term_prefixed_id(): void {
+		// #103: a real WP_Term instance must resolve identically to the
+		// duck-typed plain-object case above.
+		$term = new \WP_Term( [ 'term_id' => 15, 'taxonomy' => 'category' ] );
+
+		Functions\when( 'get_field_objects' )->alias( function ( $id ) {
+			if ( $id === 'term_15' ) {
+				return [
+					'color' => [ 'type' => 'color_picker', 'value' => '#ff0000' ],
+				];
+			}
+			return false;
+		} );
+
+		$result = Helpers::formatFields( $term );
+
+		$this->assertSame( '#ff0000', $result['color'] );
+	}
+
+	public function test_with_timber_style_term_object_resolves_term_prefixed_id(): void {
+		// #103: Timber\Term does not extend WP_Term in Timber 2 — it wraps
+		// one via CoreEntity — so a Timber-shaped plain object (ID, term_id,
+		// taxonomy, no post_type) must still be detected as a term, not fall
+		// through to the bare ->ID branch.
+		$term = (object) [ 'ID' => 15, 'term_id' => 15, 'taxonomy' => 'category' ];
+
+		Functions\when( 'get_field_objects' )->alias( function ( $id ) {
+			if ( $id === 'term_15' ) {
+				return [
+					'color' => [ 'type' => 'color_picker', 'value' => '#ff0000' ],
+				];
+			}
+			return false;
+		} );
+
+		$result = Helpers::formatFields( $term );
+
+		$this->assertSame( '#ff0000', $result['color'] );
+	}
+
+	public function test_with_user_object_resolves_user_prefixed_id(): void {
+		// #103: users have the identical bug — ACF addresses a user as
+		// "user_<id>", never a bare integer.
+		$user = new \WP_User( [ 'ID' => 8 ] );
+
+		Functions\when( 'get_field_objects' )->alias( function ( $id ) {
+			if ( $id === 'user_8' ) {
+				return [
+					'bio_color' => [ 'type' => 'color_picker', 'value' => '#00ff00' ],
+				];
+			}
+			return false;
+		} );
+
+		$result = Helpers::formatFields( $user );
+
+		$this->assertSame( '#00ff00', $result['bio_color'] );
+	}
+
+	public function test_with_timber_style_user_object_resolves_user_prefixed_id(): void {
+		// #103: a Timber\User-shaped plain object (object_type === 'user'),
+		// mirroring how Timber\User discriminates itself from Timber\Post —
+		// both expose ->ID, so object_type is the reliable signal.
+		$user = (object) [ 'ID' => 8, 'object_type' => 'user' ];
+
+		Functions\when( 'get_field_objects' )->alias( function ( $id ) {
+			if ( $id === 'user_8' ) {
+				return [
+					'bio_color' => [ 'type' => 'color_picker', 'value' => '#00ff00' ],
+				];
+			}
+			return false;
+		} );
+
+		$result = Helpers::formatFields( $user );
+
+		$this->assertSame( '#00ff00', $result['bio_color'] );
+	}
+
+	public function test_normal_post_still_resolves_to_bare_id(): void {
+		// #103 regression guard: the fix must not change post resolution.
+		$post = (object) [ 'ID' => 42 ];
+
+		Functions\when( 'get_field_objects' )->alias( function ( $id ) {
+			if ( $id === 42 ) {
+				return [
+					'title' => [ 'type' => 'text', 'value' => 'Hello' ],
+				];
+			}
+			return false;
+		} );
+
+		$result = Helpers::formatFields( $post );
+
+		$this->assertSame( 'Hello', $result['title'] );
+	}
+
+	public function test_options_string_still_routes_to_options_resolver(): void {
+		// #103 regression guard: string options-page ids must not be
+		// reinterpreted as term/user objects — they were never objects to
+		// begin with, but pin the behaviour alongside the other guards.
+		Functions\when( 'acf_get_options_pages' )->justReturn( [
+			[ 'post_id' => 'options', 'menu_slug' => 'theme-options' ],
+		] );
+		Functions\when( 'acf_decode_post_id' )->alias( function ( $id ) {
+			return in_array( $id, [ 'option', 'options' ], true ) ? [ 'type' => 'option', 'id' => $id ] : false;
+		} );
+		Functions\when( 'acf_get_field_groups' )->justReturn( [ [ 'key' => 'group_options' ] ] );
+		Functions\when( 'acf_get_fields' )->justReturn( [
+			[ 'key' => 'field_site_logo', 'name' => 'site_logo', 'type' => 'text' ],
+		] );
+		Functions\when( 'get_field' )->alias( function ( $name, $id ) {
+			return $name === 'site_logo' && $id === 'option' ? 'logo.svg' : null;
+		} );
+
+		$result = Helpers::formatFields( 'option' );
+
+		$this->assertSame( 'logo.svg', $result['site_logo'] );
 	}
 
 	public function test_with_numeric_id(): void {
@@ -68,6 +190,13 @@ class FormatFieldsTest extends HelpersTestCase {
 	}
 
 	public function test_with_string_options_page(): void {
+		// Defensive stub: acf_decode_post_id() may already be "defined" for
+		// Brain\Monkey's function_exists() once any test in the suite mocks
+		// it (process-wide patch), so isOptionsPostId()'s function_exists()
+		// gate can no longer be relied on to short-circuit here. Force it to
+		// a non-array result so isOptionsPostId() returns false and this
+		// test still exercises the plain get_field_objects() fallback.
+		Functions\when( 'acf_decode_post_id' )->justReturn( false );
 		Functions\when( 'get_field_objects' )->alias( function ( $id ) {
 			if ( $id === 'options' ) {
 				return [
@@ -208,6 +337,8 @@ class FormatFieldsTest extends HelpersTestCase {
 	}
 
 	public function test_with_string_option_singular(): void {
+		// Defensive stub — see test_with_string_options_page() above for why.
+		Functions\when( 'acf_decode_post_id' )->justReturn( false );
 		Functions\when( 'get_field_objects' )->alias( function ( $id ) {
 			if ( $id === 'option' ) {
 				return [
@@ -572,8 +703,12 @@ class FormatFieldsTest extends HelpersTestCase {
 		Functions\when( 'wp_get_post_terms' )->alias( function () {
 			throw new \RuntimeException( 'nav_menu_item path must not run for term objects' );
 		} );
+		// The resolved post id is now the string "term_225" — isOptionsPostId()
+		// asks ACF to classify it; a real acf_decode_post_id() reports 'term',
+		// not 'option', so the options-resolver path is correctly skipped.
+		Functions\when( 'acf_decode_post_id' )->justReturn( [ 'type' => 'term', 'id' => 225 ] );
 		Functions\when( 'get_field_objects' )->alias( function ( $id ) {
-			return $id === 225
+			return $id === 'term_225'
 				? [ 'category_color' => [ 'type' => 'color_picker', 'value' => '#abc' ] ]
 				: false;
 		} );
@@ -605,8 +740,9 @@ class FormatFieldsTest extends HelpersTestCase {
 		Functions\when( 'acf_get_field_groups' )->alias( function () {
 			throw new \RuntimeException( 'menu-item resolver must not run for WP_Term instances' );
 		} );
+		Functions\when( 'acf_decode_post_id' )->justReturn( [ 'type' => 'term', 'id' => 225 ] );
 		Functions\when( 'get_field_objects' )->alias( function ( $id ) {
-			return $id === 225
+			return $id === 'term_225'
 				? [ 'category_color' => [ 'type' => 'color_picker', 'value' => '#abc' ] ]
 				: false;
 		} );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -114,3 +114,19 @@ if ( ! class_exists( 'WP_Term' ) ) {
 		}
 	}
 }
+
+// Minimal WP_User stub for tests that need an instance to satisfy `instanceof WP_User`.
+// `#[\AllowDynamicProperties]` mirrors WordPress core, which annotates `WP_User`
+// the same way (dynamic props are hydrated from the `$data` user row).
+if ( ! class_exists( 'WP_User' ) ) {
+	#[\AllowDynamicProperties]
+	class WP_User {
+		public int $ID = 0;
+
+		public function __construct( array|object $props = [] ) {
+			foreach ( (array) $props as $key => $value ) {
+				$this->$key = $value;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #103.

## The bug

`Helpers::formatFields()` resolved its ACF id like this:

```php
if ( is_object( $post ) && ! empty( $post->ID ) ) {
    $post_id = $post->ID;
} elseif ( is_object( $post ) && ! empty( $post->term_id ) ) {
    $post_id = $post->term_id;
}
```

Both arms produce a **bare integer**, which goes to `get_field_objects()`. ACF reads a bare integer as a *post* id, so a taxonomy term resolved against whatever post happened to share that number — silently, returning wrong fields or none. ACF's own id forms are `"term_<id>"` and `"user_<id>"`; the bare-integer form can never reach either.

**Users had the identical bug** and are fixed here too: `Timber\User` exposes `->ID` just like a post, so a user also matched the first branch.

## Why it was not a one-liner

Adding a term branch *below* the `->ID` arm fixes nothing — `Timber\Term` aliases `->ID` to `->term_id`, so a term matched the post branch first. The detection has to precede the generic fallback.

`Timber\Term` also does not extend `WP_Term` in Timber 2 (it is a `CoreEntity` wrapping one), so `instanceof \WP_Term` alone misses it.

Detection is therefore layered, preferring the strongest signal available:

1. `->object_type` — the discriminator Timber's own `Term` / `User` / `Post` classes set (`'term'` / `'user'` / `'post'`)
2. `instanceof \WP_Term` / `instanceof \WP_User`
3. for terms, a duck-typed `term_id`-without-`post_type` fallback, covering plain-object shims that extend neither core class

Layer 3 mirrors the precedent already in this file: `isNavMenuItemPostId()` solved the same recognition problem and now delegates its term-exclusion guard to the shared `isTermObject()`, so the two checks cannot drift apart.

## Blast radius: none today

An audit of ~90 `formatFields()` call sites across the 26 consuming themes found **none** passing a term or a user — every call passes a post object, a numeric id, or an options string. This corrects a latent bug rather than changing live behaviour.

Explicitly unchanged and covered by non-regression tests: ordinary posts (bare `ID`), numeric ids, `block_*` ids, options strings via `isOptionsPostId()`, and `nav_menu_item` routing via `isNavMenuItemPostId()` / `getFieldObjectsForNavMenuItem()`.

## Two pre-existing tests changed — deliberately

`test_with_term_object` asserted `get_field_objects( 15 )` — the bare-integer call that **is** the bug. It now asserts `get_field_objects( 'term_15' )`. Two sibling tests got the same `225` → `'term_225'` correction plus an `acf_decode_post_id` stub, since the resolved id is now a string that flows through `isOptionsPostId()`.

No assertion was deleted, weakened or narrowed; those tests' load-bearing parts (the menu-item path never being invoked, enforced by `RuntimeException`) are untouched. Six new tests were added covering real `WP_Term`, real `WP_User`, Timber-shaped plain objects for both, and the two non-regression guards above.

## Note on `getFieldObjectsForNavMenu()`

The resolver added in #104 for `nav_menu` terms is **not** made redundant by this fix. It exists to hand-build the ACF *screen* (`[ 'nav_menu' => $id ]`) that menu-location field groups match on, which is a separate gap from the id form. It was verified against a live ACF Pro install; leaving it in place.

## Verification

- `composer test` — 1098 tests, 1938 assertions, 1 skipped
- `composer test:property` — 15 tests, 6683 assertions
- `composer phpstan` — no errors

The `phpstan-baseline.neon` `object::$ID` ignore count went 1 → 3 for two new accesses of the same untyped-`object` shape, rather than introducing a new suppression class.

Rebased onto `main` after #104 merged; the only conflict was both branches appending to `## [Unreleased]`, and both entries are kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xhu5oYcJS67XGTJ1tebmM5
