### PR TITLE
fix(wpml): sweep ACFML's acf/load_reference leak when syncing Copy fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **`Acfml\LoadReferenceGuard` + `Wpml\CopyFieldSync`** — sync Copy-marked
+  custom fields to translations in a loop without the two costs that make the
+  obvious implementation unusable.
+
+  ACFML 2.2.4 leaks a filter callback per synced meta key:
+  `WPML_ACF_Worker::getFieldObjectWithFilteredReference()` adds a closure to
+  `acf/load_reference` and then removes `'acf/$metaKey'` — single-quoted, so a
+  literal hook name that never exists. Every later `get_field_object()` walks
+  the accumulated list, and the per-post cost rises with the iteration ordinal:
+  the same post measured 0.092s alone in a fresh process and 4.64s at ordinal
+  40. Sweeping restores what ACFML itself intends, so the guard becomes a no-op
+  once upstream corrects the typo.
+
+  `CopyFieldSync::push()` additionally syncs only the named keys instead of the
+  whole `custom_fields_translation` dictionary, which is site-wide, monotonic
+  and quadratic to walk. Over 24 posts with 807 Copy keys the combination went
+  from 16.33s to 0.95s and — more to the point — flattened the growth curve
+  from 22x to none.
+
 ## [1.28.0] - 2026-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -342,6 +342,59 @@ Applying newly-translatable keys triggers WPML's ProcessNewTranslatableFields
 background task — affected translations get flagged as needing update, which
 is the point: translators see the previously invisible backlog.
 
+### Syncing Copy fields in a loop
+
+**Never call `wpml_sync_all_custom_fields` per post in a loop.** It walks the
+whole dictionary each time, and that dictionary is site-wide and monotonic —
+ACFML registers one entry per *flattened* meta key, so a repeater contributes
+one per row index that has ever existed. A site with 23 declared fields
+measured 807 Copy entries. Two costs stack on top of each other:
+
+1. `WPML_Sync_Custom_Fields::sync_all_custom_fields()` loops the N keys and
+   each `sync_to_translations()` runs `in_array()` over the same N-element
+   list — quadratic. Measured on the `in_array` alone, per post: 2 000 keys
+   0.004s, 10 000 keys 0.094s, 50 000 keys 2.617s.
+2. ACFML leaks one `acf/load_reference` filter callback per synced key
+   (`WPML_ACF_Worker::getFieldObjectWithFilteredReference()` removes
+   `'acf/$metaKey'` in single quotes — a literal hook name that never exists —
+   instead of `'acf/load_reference'`), so the per-post cost also climbs with
+   every post already processed. Reproduced on acfml **2.2.4**.
+
+`CopyFieldSync` avoids both: it syncs only the keys you name, and sweeps the
+leaked callbacks afterwards.
+
+```php
+use Parisek\TimberKit\Wpml\CopyFieldSync;
+
+$sync = new CopyFieldSync();
+
+foreach ( $rows as $row ) {
+    $post_id = $this->write( $row );
+    $sync->push( $post_id, [ 'price', 'status', 'floor' ] );   // + `_price`, … companions
+}
+
+// Non-zero means the installed ACFML still leaks; 0 once upstream fixes it.
+$logger->info( sprintf( 'swept %d leaked callbacks', $sync->sweptTotal() ) );
+```
+
+Pass only the keys actually written — listing every field of the post brings
+back cost 1 in miniature and syncs values nothing touched.
+
+Measured on 24 posts with 807 Copy keys in one process:
+
+| | first post | last post | total |
+|---|---|---|---|
+| `wpml_sync_all_custom_fields`, no sweep | 0.060s | 1.327s (22x) | 16.33s |
+| same, swept after each post | 0.047s | 0.040s (0.8x) | 0.95s |
+
+The point is less the 17x than the flat curve: cost stops depending on the
+iteration ordinal.
+
+`Acfml\LoadReferenceGuard` is available on its own for code that syncs some
+other way — construct it immediately before the loop (it only removes
+callbacks registered after construction, so filters the theme added at boot
+survive) and call `sweep()` per iteration, or wrap the work in `around()`.
+
 ## Usage
 
 Create a `Base` class in your theme that extends `StarterBase`:

--- a/src/Acfml/LoadReferenceGuard.php
+++ b/src/Acfml/LoadReferenceGuard.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit\Acfml;
+
+/**
+ * Undoes ACFML's `acf/load_reference` filter leak.
+ *
+ * `WPML_ACF_Worker::getFieldObjectWithFilteredReference()` (acfml 2.2.4,
+ * `classes/class-wpml-acf-worker.php`) adds a closure to `acf/load_reference`,
+ * calls `get_field_object()`, then tries to remove it again:
+ *
+ * ```php
+ * add_filter( 'acf/load_reference', $keepOnlyLastFieldReference );
+ * $field = get_field_object( $metaKey, $objectFromId, false, false );
+ * remove_filter( 'acf/$metaKey', $keepOnlyLastFieldReference );   // <- single-quoted
+ * ```
+ *
+ * The removal names `'acf/$metaKey'` in single quotes, so `$metaKey` is not
+ * interpolated and the call targets a literal hook name that never exists. The
+ * closure is therefore never removed. ACFML runs that method once per synced
+ * meta key, so a `wpml_sync_all_custom_fields` over a dictionary of N Copy keys
+ * leaks N closures — and every later `get_field_object()` walks all of them.
+ *
+ * The cost is invisible in a single request and severe in a loop. Measured on a
+ * site with 807 Copy keys, syncing 24 posts in one process:
+ *
+ * | | first post | last post | total |
+ * |---|---|---|---|
+ * | as shipped | 0.060s | 1.327s (22x) | 16.33s |
+ * | swept after each post | 0.047s | 0.040s (0.8x) | 0.95s |
+ *
+ * The per-post cost stops depending on the iteration ordinal — the growth is
+ * the leak, not the dictionary size. (Confirmed by measuring the same post in a
+ * fresh process: 0.092s alone versus 4.64s at ordinal 40.)
+ *
+ * Sweeping restores the state ACFML itself intends, which is what makes this
+ * safe rather than clever: the closure is scoped to one `get_field_object()`
+ * call and has no purpose afterwards. Should upstream fix the typo, sweeping
+ * becomes a no-op — nothing leaks, so nothing is removed.
+ *
+ * ```php
+ * $guard = new LoadReferenceGuard();
+ * foreach ( $post_ids as $post_id ) {
+ *     do_action( 'wpml_sync_custom_field', $post_id, 'price' );
+ *     $guard->sweep();
+ * }
+ * ```
+ *
+ * Only callbacks registered *after* construction are removed, so filters the
+ * theme added at boot survive. Construct the guard immediately before the loop
+ * and it needs no allow-list.
+ */
+final class LoadReferenceGuard {
+
+	public const HOOK = 'acf/load_reference';
+
+	/**
+	 * Callback IDs present at construction, per priority: priority => [ id => true ].
+	 *
+	 * @var array<int|string, array<int|string, true>>
+	 */
+	private array $baseline;
+
+	private int $swept = 0;
+
+	/**
+	 * @param string $hook Filter to guard. Defaults to the one ACFML leaks; injectable for tests.
+	 */
+	public function __construct( private readonly string $hook = self::HOOK ) {
+		$this->baseline = $this->snapshot();
+	}
+
+	/**
+	 * Removes callbacks added since construction and returns how many went.
+	 *
+	 * Closures only. A named function or object method appearing mid-loop is far
+	 * more likely to be a deliberate registration by application code than a
+	 * leak, and dropping it would be a surprise; the leaked callbacks are all
+	 * anonymous, so the narrower rule loses nothing.
+	 */
+	public function sweep(): int {
+		$hooks = $this->hookObject();
+
+		if ( null === $hooks ) {
+			return 0;
+		}
+
+		$removed = 0;
+
+		foreach ( $hooks->callbacks as $priority => $callbacks ) {
+			foreach ( $callbacks as $id => $callback ) {
+				if ( isset( $this->baseline[ $priority ][ $id ] ) ) {
+					continue;
+				}
+
+				if ( ! ( ( $callback['function'] ?? null ) instanceof \Closure ) ) {
+					continue;
+				}
+
+				$hooks->remove_filter( $this->hook, $callback['function'], (int) $priority );
+				$removed++;
+			}
+		}
+
+		$this->swept += $removed;
+
+		return $removed;
+	}
+
+	/**
+	 * Total removed across every {@see sweep()} on this instance — for logging
+	 * and for asserting in tests that the leak was actually present.
+	 */
+	public function sweptTotal(): int {
+		return $this->swept;
+	}
+
+	/**
+	 * Runs `$work` and sweeps afterwards, even if it throws.
+	 *
+	 * @template T
+	 * @param \Closure(): T $work
+	 * @return T
+	 */
+	public function around( \Closure $work ): mixed {
+		try {
+			return $work();
+		} finally {
+			$this->sweep();
+		}
+	}
+
+	/**
+	 * @return array<int|string, array<int|string, true>>
+	 */
+	private function snapshot(): array {
+		$hooks = $this->hookObject();
+
+		if ( null === $hooks ) {
+			return [];
+		}
+
+		$snapshot = [];
+
+		foreach ( $hooks->callbacks as $priority => $callbacks ) {
+			$snapshot[ $priority ] = array_fill_keys( array_keys( $callbacks ), true );
+		}
+
+		return $snapshot;
+	}
+
+	/**
+	 * The `WP_Hook` for the guarded filter, or null when nothing is registered
+	 * yet — which is the normal state before ACFML has run even once.
+	 */
+	private function hookObject(): ?\WP_Hook {
+		global $wp_filter;
+
+		if ( ! isset( $wp_filter[ $this->hook ] ) || ! $wp_filter[ $this->hook ] instanceof \WP_Hook ) {
+			return null;
+		}
+
+		return $wp_filter[ $this->hook ];
+	}
+}

--- a/src/Wpml/CopyFieldSync.php
+++ b/src/Wpml/CopyFieldSync.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit\Wpml;
+
+use Parisek\TimberKit\Acfml\LoadReferenceGuard;
+
+/**
+ * Pushes Copy-marked custom fields from a source post to its translations,
+ * without the two traps of doing it by hand.
+ *
+ * **Never call `wpml_sync_all_custom_fields` in a loop.** It walks the whole
+ * `custom_fields_translation` dictionary per post, and that dictionary is
+ * site-wide and monotonic: ACFML registers one entry per *flattened* meta key,
+ * so a repeater contributes one entry per row index that has ever existed. A
+ * site with 23 declared fields measured 807 Copy entries. Two costs follow:
+ *
+ * 1. `WPML_Sync_Custom_Fields::sync_all_custom_fields()` loops the N keys and
+ *    each `sync_to_translations()` does an `in_array()` over the same N-element
+ *    list — quadratic. Measured on the `in_array` alone, per post: 2 000 keys
+ *    0.004s, 10 000 keys 0.094s, 50 000 keys 2.617s.
+ * 2. Every synced key leaks a filter callback ({@see LoadReferenceGuard}), so
+ *    the cost also climbs with each post already processed.
+ *
+ * Syncing only the keys actually written avoids the first; the guard avoids the
+ * second. Both matter — on the site above, the two together took a 147-post
+ * import from 26 minutes to a few.
+ *
+ * ```php
+ * $sync = new CopyFieldSync();
+ * foreach ( $rows as $row ) {
+ *     $post_id = $this->write( $row );
+ *     $sync->push( $post_id, [ 'price', 'status', 'floor' ] );
+ * }
+ * ```
+ *
+ * Only fields the caller actually wrote should be passed. Listing every field
+ * of the post reintroduces cost 1 in miniature and syncs values nothing
+ * touched.
+ */
+final class CopyFieldSync {
+
+	private readonly LoadReferenceGuard $guard;
+
+	public function __construct( ?LoadReferenceGuard $guard = null ) {
+		$this->guard = $guard ?? new LoadReferenceGuard();
+	}
+
+	/**
+	 * Syncs the named meta keys from `$post_id` to its translations.
+	 *
+	 * Whether a key is copied, translated or ignored stays WPML's decision —
+	 * this only narrows *which* keys are offered. A key WPML has marked
+	 * Translate is left alone by `wpml_sync_custom_field` itself.
+	 *
+	 * ACF stores a `_<name>` companion holding the field key, and WPML treats it
+	 * as a separate dictionary entry. Syncing the value without its companion
+	 * leaves the translation's field reference pointing at whatever was there
+	 * before, so companions are synced too unless the caller opts out.
+	 *
+	 * @param int          $post_id    Source post — must be in the default language.
+	 * @param list<string> $meta_keys  Meta keys (ACF field *names*, not `field_…` keys).
+	 * @param bool         $companions Also sync each key's `_<name>` companion.
+	 * @return int Callbacks swept afterwards; 0 once upstream fixes the leak.
+	 */
+	public function push( int $post_id, array $meta_keys, bool $companions = true ): int {
+		foreach ( $meta_keys as $meta_key ) {
+			do_action( 'wpml_sync_custom_field', $post_id, $meta_key );
+
+			if ( $companions ) {
+				do_action( 'wpml_sync_custom_field', $post_id, '_' . $meta_key );
+			}
+		}
+
+		return $this->guard->sweep();
+	}
+
+	/**
+	 * Total callbacks swept across every {@see push()} — worth logging at the
+	 * end of a long import, since a non-zero figure is the leak still being
+	 * present in the installed ACFML.
+	 */
+	public function sweptTotal(): int {
+		return $this->guard->sweptTotal();
+	}
+}

--- a/tests/Unit/Acfml/LoadReferenceGuardTest.php
+++ b/tests/Unit/Acfml/LoadReferenceGuardTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Acfml;
+
+use Parisek\TimberKit\Acfml\LoadReferenceGuard;
+use PHPUnit\Framework\TestCase;
+
+class LoadReferenceGuardTest extends TestCase {
+
+	private \WP_Hook $hook;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->hook = new \WP_Hook();
+
+		$GLOBALS['wp_filter'] = [ LoadReferenceGuard::HOOK => $this->hook ];
+	}
+
+	protected function tearDown(): void {
+		unset( $GLOBALS['wp_filter'] );
+
+		parent::tearDown();
+	}
+
+	/** Simulates one ACFML sync: the closure is added and never removed. */
+	private function leakOne(): void {
+		$this->hook->add_filter( LoadReferenceGuard::HOOK, static fn( $reference ) => $reference );
+	}
+
+	public function test_removes_closures_added_after_construction(): void {
+		$guard = new LoadReferenceGuard();
+
+		$this->leakOne();
+		$this->leakOne();
+
+		$this->assertSame( 2, $guard->sweep() );
+		$this->assertSame( 0, $this->hook->count() );
+	}
+
+	public function test_preserves_callbacks_registered_before_construction(): void {
+		$theme_filter = static fn( $reference ) => $reference;
+		$this->hook->add_filter( LoadReferenceGuard::HOOK, $theme_filter );
+
+		$guard = new LoadReferenceGuard();
+		$this->leakOne();
+
+		$this->assertSame( 1, $guard->sweep(), 'only the leaked closure is removed' );
+		$this->assertSame( 1, $this->hook->count() );
+		$this->assertSame(
+			$theme_filter,
+			$this->hook->callbacks[10][ spl_object_hash( $theme_filter ) ]['function'],
+			'the pre-existing theme filter survives'
+		);
+	}
+
+	public function test_leaves_named_callbacks_alone(): void {
+		$guard = new LoadReferenceGuard();
+
+		// A plugin registering a named function mid-loop is a deliberate act,
+		// not a leak — the guard must not undo it.
+		$this->hook->add_filter( LoadReferenceGuard::HOOK, 'strtolower' );
+
+		$this->assertSame( 0, $guard->sweep() );
+		$this->assertSame( 1, $this->hook->count() );
+	}
+
+	public function test_sweeps_every_priority(): void {
+		$guard = new LoadReferenceGuard();
+
+		$this->hook->add_filter( LoadReferenceGuard::HOOK, static fn( $r ) => $r, 5 );
+		$this->hook->add_filter( LoadReferenceGuard::HOOK, static fn( $r ) => $r, 10 );
+		$this->hook->add_filter( LoadReferenceGuard::HOOK, static fn( $r ) => $r, 99 );
+
+		$this->assertSame( 3, $guard->sweep() );
+		$this->assertSame( 0, $this->hook->count() );
+	}
+
+	public function test_sweep_is_a_no_op_once_upstream_stops_leaking(): void {
+		$guard = new LoadReferenceGuard();
+
+		$this->assertSame( 0, $guard->sweep() );
+		$this->assertSame( 0, $guard->sweptTotal() );
+	}
+
+	public function test_tolerates_the_hook_never_having_been_registered(): void {
+		$GLOBALS['wp_filter'] = [];
+
+		$guard = new LoadReferenceGuard();
+
+		$this->assertSame( 0, $guard->sweep(), 'no hook object yet is the normal pre-ACFML state' );
+	}
+
+	public function test_accumulates_a_running_total_across_sweeps(): void {
+		$guard = new LoadReferenceGuard();
+
+		$this->leakOne();
+		$guard->sweep();
+		$this->leakOne();
+		$this->leakOne();
+		$guard->sweep();
+
+		$this->assertSame( 3, $guard->sweptTotal() );
+	}
+
+	public function test_baseline_is_taken_at_construction_not_at_first_sweep(): void {
+		$this->leakOne();
+
+		// Anything already present when the guard is built is somebody else's;
+		// a guard constructed late must not clean up before its own watch.
+		$guard = new LoadReferenceGuard();
+
+		$this->assertSame( 0, $guard->sweep() );
+		$this->assertSame( 1, $this->hook->count() );
+	}
+
+	public function test_around_sweeps_even_when_the_work_throws(): void {
+		$guard = new LoadReferenceGuard();
+
+		try {
+			$guard->around( function (): void {
+				$this->leakOne();
+				throw new \RuntimeException( 'sync failed' );
+			} );
+			$this->fail( 'the exception must propagate' );
+		} catch ( \RuntimeException ) {
+			// expected
+		}
+
+		$this->assertSame( 0, $this->hook->count(), 'a failed sync must not leave the leak behind' );
+		$this->assertSame( 1, $guard->sweptTotal() );
+	}
+
+	public function test_around_returns_the_work_result(): void {
+		$guard = new LoadReferenceGuard();
+
+		$this->assertSame( 'ok', $guard->around( static fn (): string => 'ok' ) );
+	}
+}

--- a/tests/Unit/Wpml/CopyFieldSyncTest.php
+++ b/tests/Unit/Wpml/CopyFieldSyncTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Wpml;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Parisek\TimberKit\Acfml\LoadReferenceGuard;
+use Parisek\TimberKit\Wpml\CopyFieldSync;
+use PHPUnit\Framework\TestCase;
+
+class CopyFieldSyncTest extends TestCase {
+
+	/** @var list<array{int, string}> */
+	private array $synced = [];
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		$this->synced         = [];
+		$GLOBALS['wp_filter'] = [];
+
+		Functions\when( 'do_action' )->alias(
+			function ( string $tag, mixed ...$args ): void {
+				if ( 'wpml_sync_custom_field' === $tag ) {
+					$this->synced[] = [ (int) $args[0], (string) $args[1] ];
+				}
+			}
+		);
+	}
+
+	protected function tearDown(): void {
+		unset( $GLOBALS['wp_filter'] );
+
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	public function test_syncs_each_key_with_its_companion(): void {
+		( new CopyFieldSync() )->push( 42, [ 'price', 'status' ] );
+
+		$this->assertSame(
+			[
+				[ 42, 'price' ],
+				[ 42, '_price' ],
+				[ 42, 'status' ],
+				[ 42, '_status' ],
+			],
+			$this->synced
+		);
+	}
+
+	public function test_companions_can_be_switched_off(): void {
+		( new CopyFieldSync() )->push( 42, [ 'price' ], false );
+
+		$this->assertSame( [ [ 42, 'price' ] ], $this->synced );
+	}
+
+	public function test_an_empty_key_list_syncs_nothing(): void {
+		// A post whose diff came back empty must cost nothing — the whole point
+		// of passing only the keys actually written.
+		$this->assertSame( 0, ( new CopyFieldSync() )->push( 42, [] ) );
+		$this->assertSame( [], $this->synced );
+	}
+
+	public function test_sweeps_the_leak_after_pushing(): void {
+		// Real guard over a fake hook rather than a doubled guard: what needs
+		// asserting is that the leak is gone afterwards, not that a method was
+		// called.
+		$hook                 = new \WP_Hook();
+		$GLOBALS['wp_filter'] = [ LoadReferenceGuard::HOOK => $hook ];
+
+		$sync = new CopyFieldSync();
+
+		Functions\when( 'do_action' )->alias(
+			static function ( string $tag ) use ( $hook ): void {
+				if ( 'wpml_sync_custom_field' === $tag ) {
+					$hook->add_filter( LoadReferenceGuard::HOOK, static fn( $reference ) => $reference );
+				}
+			}
+		);
+
+		$this->assertSame( 2, $sync->push( 42, [ 'price' ] ), 'key + companion each leak one closure' );
+		$this->assertSame( 0, $hook->count() );
+		$this->assertSame( 2, $sync->sweptTotal() );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -130,3 +130,42 @@ if ( ! class_exists( 'WP_User' ) ) {
 		}
 	}
 }
+
+// Minimal WP_Hook stub so production code can guard with `instanceof \WP_Hook`
+// and use the real add_filter/remove_filter API (cf. the wpdb stub above).
+// Only the members Acfml\LoadReferenceGuard touches are modelled: the public
+// `$callbacks` map and callback registration keyed the way core keys it —
+// `spl_object_hash` for closures, the string itself for named functions.
+if ( ! class_exists( 'WP_Hook' ) ) {
+	class WP_Hook {
+		/** @var array<int, array<string, array{function: callable, accepted_args: int}>> */
+		public array $callbacks = [];
+
+		public function add_filter( string $tag, callable $function, int $priority = 10, int $accepted_args = 1 ): void {
+			$this->callbacks[ $priority ][ self::unique_id( $function ) ] = [
+				'function'      => $function,
+				'accepted_args' => $accepted_args,
+			];
+		}
+
+		public function remove_filter( string $tag, callable $function, int $priority ): bool {
+			$id = self::unique_id( $function );
+
+			if ( ! isset( $this->callbacks[ $priority ][ $id ] ) ) {
+				return false;
+			}
+
+			unset( $this->callbacks[ $priority ][ $id ] );
+
+			return true;
+		}
+
+		public function count(): int {
+			return array_sum( array_map( 'count', $this->callbacks ) );
+		}
+
+		private static function unique_id( callable $function ): string {
+			return is_object( $function ) ? spl_object_hash( $function ) : (string) $function;
+		}
+	}
+}


### PR DESCRIPTION
## Why

Syncing Copy-marked custom fields post by post got slower with **every post already processed**. Measured on a live site (147 flats, 807 Copy keys), a single import that changed one field took 26 minutes.

The cause is not the database and not the posts. Query count stays flat at 30 per post while time grows 22x, and memory climbs. The same post costs **0.092s alone in a fresh process** and **4.64s at ordinal 40**.

`acfml` 2.2.4, `classes/class-wpml-acf-worker.php`:

```php
add_filter( 'acf/load_reference', $keepOnlyLastFieldReference );
$field = get_field_object( $metaKey, $objectFromId, false, false );
remove_filter( 'acf/$metaKey', $keepOnlyLastFieldReference );   // single-quoted
```

`$metaKey` is not interpolated, so the removal targets a literal hook name that never exists and the closure is never removed. ACFML runs that method **once per synced meta key**, so one `wpml_sync_all_custom_fields` over 807 Copy keys leaks 807 callbacks — confirmed by snapshotting `$wp_filter` around a single sync:

```
post 1220 — hooks gained by one sync_all:
  acf/load_reference   +807
      last: Closure wp-content/plugins/acfml/classes/class-wpml-acf-worker.php:97
```

## What

- **`Acfml\LoadReferenceGuard`** — removes callbacks added to `acf/load_reference` since its construction, restoring the state ACFML itself intends (the closure is scoped to one `get_field_object()` call and has no purpose after it).
- **`Wpml\CopyFieldSync`** — the sanctioned way to push Copy fields in a loop: sync only the keys the caller wrote, then sweep. Handles `_<name>` companions.
- README section under *ACFML preference sync*, CHANGELOG entry, `WP_Hook` test-bootstrap stub alongside the existing `wpdb`/`WP_Error` ones.

24 posts, 807 Copy keys, one process:

| | first post | last post | total |
|---|---|---|---|
| as shipped | 0.060s | 1.327s (22x) | 16.33s |
| swept after each post | 0.047s | 0.040s (0.8x) | **0.95s** |

The flat curve matters more than the 17x: cost stops depending on the iteration ordinal.

## Deliberately not done

- **No `wp_cache_flush()` between posts.** First hypothesis, measurably wrong — the leak lives in `$wp_filter`, not the object cache. Flushing left growth at 2.3x and pushed the total from 16.33s to 52.05s by re-querying everything.
- **No dictionary pruning here.** That treats the multiplier, not the mechanism; with the leak swept, syncing all 807 keys costs 0.040s/post. Pruning stays worth doing as hygiene (#106) but is no longer urgent.
- **No version check on acfml.** Once upstream fixes the typo, `sweep()` finds nothing and returns 0. Behaviour keyed to a plugin version would be one more thing to get wrong.
- **Named callbacks are never removed** — only closures. A plugin registering a named function mid-loop is a deliberate act; every leaked callback is anonymous, so the narrower rule loses nothing.

Reported upstream to WPML separately.

## Verification

`composer check` green — 1112 unit + 15 property tests, PHPStan level 8 clean, ADR index OK. 14 new tests cover baseline scoping, priority coverage, the named-callback exclusion, `around()` sweeping on throw, and the post-upstream-fix no-op case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKiM9NkCH6fCX4rC1Wuq32
