### PR TITLE
fix(helpers): keep meaningful falsy values in formatFields()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,23 +18,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   used exactly that pattern, and 280 published blocks with the switch
   explicitly off rendered as if it were on.
 
-  `formatFields()` now keeps `false`, `0`, `0.0` and `"0"` as real values,
-  while still dropping `null`, `''`, and `[]`. `fieldFormatter()` also
-  returns literal `false` as its own "no such field" sentinel (empty field
-  definition, missing `value` key, unfilled repeater/flexible_content
-  outside preview) — the fix disambiguates the two `false`s by checking
-  whether the source field actually carried a non-null `value` key; only
-  then is a `false` result kept.
+  `formatFields()` now keeps `0`, `0.0` and `"0"` as real values for every
+  field type, while still dropping `null`, `''`, and `[]`. `false` is kept
+  **only for `true_false` fields** — that is the one ACF type whose stored
+  value is always boolean, with no third "empty" state distinct from
+  `false`, so an unfilled switch and an explicitly-off one are the same
+  value by design and both are meaningfully "off". Every other type's
+  `false` keeps being dropped: ACF itself uses literal `false` as an
+  "empty" sentinel for a `relationship`, `gallery`, `image`, `file`,
+  `link`, `date_picker`, nullable `select`, or an unfilled `repeater` /
+  `flexible_content` outside preview — none of those carry a `false` that
+  a consumer would ever want to distinguish from "not set", so disambiguating
+  by field type (rather than by whether the source field merely carried a
+  `value` key, which is true for the empty cases above too) keeps them
+  absent, matching the pre-1.30 behaviour and this fix's own promise that
+  an unfilled repeater stays absent. This also covers a `false` produced by
+  the `field_formatter_{type}` filter, not just the raw ACF value — the
+  survive/drop decision is made on the field's declared `type`, regardless
+  of what set `value` to `false`.
 
   **Blast radius:** consumers using Twig truthiness (`{% if content.x %}`)
   are unaffected — `false`/`0`/`"0"` were already falsy there whether the
   key existed or not. Consumers using `isset()` / `array_key_exists()` / `??`
   against a `formatFields()` result will now see a key that was previously
-  absent whenever the underlying field's raw value is `false`, `0`, `0.0`,
-  or `"0"`. Any such consumer relying on the old (buggy) absent-key behavior
-  as "off" would need to re-check its default logic — this is the reason
-  the change ships as a **major** version bump rather than a patch, despite
-  being a straightforward bug fix.
+  absent whenever the underlying field is a `true_false` field, or its raw
+  value is `0`, `0.0`, or `"0"`. Any such consumer relying on the old
+  (buggy) absent-key behavior as "off" would need to re-check its default
+  logic — this is the reason the change ships as a **major** version bump
+  rather than a patch, despite being a straightforward bug fix.
 
 ## [1.29.0] - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [1.30.0] - 2026-08-08
+## [Unreleased]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`Helpers::formatFields()` no longer drops a field with a meaningful falsy
+  value.** Previously any formatted value that failed `!empty()` was omitted
+  from the result — for an ACF `true_false` field, an unchecked box formats
+  to `false`, which is `empty()`, so the key disappeared entirely. Consumers
+  reading the switch via `array_key_exists()` / `isset()` / `??` (a common
+  `?? true` "default on" pattern) could not tell "explicitly turned off"
+  from "field does not exist". Measured downstream: a page-header component
+  used exactly that pattern, and 280 published blocks with the switch
+  explicitly off rendered as if it were on.
+
+  `formatFields()` now keeps `false`, `0`, `0.0` and `"0"` as real values,
+  while still dropping `null`, `''`, and `[]`. `fieldFormatter()` also
+  returns literal `false` as its own "no such field" sentinel (empty field
+  definition, missing `value` key, unfilled repeater/flexible_content
+  outside preview) — the fix disambiguates the two `false`s by checking
+  whether the source field actually carried a non-null `value` key; only
+  then is a `false` result kept.
+
+  **Blast radius:** consumers using Twig truthiness (`{% if content.x %}`)
+  are unaffected — `false`/`0`/`"0"` were already falsy there whether the
+  key existed or not. Consumers using `isset()` / `array_key_exists()` / `??`
+  against a `formatFields()` result will now see a key that was previously
+  absent whenever the underlying field's raw value is `false`, `0`, `0.0`,
+  or `"0"`. Any such consumer relying on the old (buggy) absent-key behavior
+  as "off" would need to re-check its default logic — this is the reason
+  the change ships as a **major** version bump rather than a patch, despite
+  being a straightforward bug fix.
+
 ## [1.29.0] - 2026-08-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,18 +34,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   absent, matching the pre-1.30 behaviour and this fix's own promise that
   an unfilled repeater stays absent. This also covers a `false` produced by
   the `field_formatter_{type}` filter, not just the raw ACF value — the
-  survive/drop decision is made on the field's declared `type`, regardless
-  of what set `value` to `false`.
+  survive/drop decision is made on the field's declared `type` and the
+  *formatted* return value, regardless of what set that value to `false`:
+  a filter that forces a non-`true_false` field to `false` still gets
+  dropped, and — the converse, more consequential case — a filter that
+  forces a `true_false` field to `false` (even from a non-falsy raw value
+  like `true`) still survives, the same as a raw off-switch would.
+
+  **Also fixed on the ACF block path specifically:** `formatFields()`
+  resolves an ACF block's fields via a `block_<hash>` id, then swaps in the
+  block's real post id before formatting (`str_starts_with( (string)
+  $post_id, 'block_' )` in `formatFields()`) — the id-swap happens *after*
+  `get_field_objects()` runs but *before* `fieldFormatter()` and the
+  `field_formatter_{type}` filter see `$post_id`. The keep/drop decision
+  itself never depended on this swap (it only inspects the field
+  definition and the formatted value), but the swap path is exercised by
+  its own regression test, since fields sourced from a block behave
+  identically to fields sourced from a plain post only if the swap runs
+  correctly.
 
   **Blast radius:** consumers using Twig truthiness (`{% if content.x %}`)
   are unaffected — `false`/`0`/`"0"` were already falsy there whether the
-  key existed or not. Consumers using `isset()` / `array_key_exists()` / `??`
-  against a `formatFields()` result will now see a key that was previously
-  absent whenever the underlying field is a `true_false` field, or its raw
-  value is `0`, `0.0`, or `"0"`. Any such consumer relying on the old
-  (buggy) absent-key behavior as "off" would need to re-check its default
-  logic — this is the reason the change ships as a **major** version bump
-  rather than a patch, despite being a straightforward bug fix.
+  key existed or not. Consumers using `isset()` / `??` (both blind to an
+  explicit `null` value) or `array_key_exists()` (which is not — it treats
+  a stored `null` value as present) against a `formatFields()` result will
+  now see a key that was previously absent whenever the underlying field is
+  a `true_false` field, or its formatted value is `0`, `0.0`, or `"0"`. Any
+  such consumer relying on the old (buggy) absent-key behavior as "off"
+  would need to re-check its default logic — this is the reason the change
+  ships as a **major** version bump rather than a patch, despite being a
+  straightforward bug fix.
 
 ## [1.29.0] - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
+## [1.30.0] - 2026-08-08
 
 ### Fixed
 
@@ -18,7 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   used exactly that pattern, and 280 published blocks with the switch
   explicitly off rendered as if it were on.
 
-  `formatFields()` now keeps `0`, `0.0` and `"0"` as real values for every
+  A falsy field now surfaces in the result as a real key — `formatFields()`
+  keeps `0`, `0.0` and `"0"` as real values for every
   field type, while still dropping `null`, `''`, and `[]`. `false` is kept
   **only for `true_false` fields** — that is the one ACF type whose stored
   value is always boolean, with no third "empty" state distinct from
@@ -59,11 +60,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   explicit `null` value) or `array_key_exists()` (which is not — it treats
   a stored `null` value as present) against a `formatFields()` result will
   now see a key that was previously absent whenever the underlying field is
-  a `true_false` field, or its formatted value is `0`, `0.0`, or `"0"`. Any
-  such consumer relying on the old (buggy) absent-key behavior as "off"
-  would need to re-check its default logic — this is the reason the change
-  ships as a **major** version bump rather than a patch, despite being a
-  straightforward bug fix.
+  a `true_false` field, or its formatted value is `0`, `0.0`, or `"0"`.
 
 ## [1.29.0] - 2026-08-05
 

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -865,12 +865,15 @@ class Helpers {
 	 * genuinely carries a falsy value (a `true_false` switch left off, a
 	 * `number` field set to `0`) and a field that simply is not there
 	 * (missing definition, unfilled repeater outside preview). Both used to
-	 * come out as an absent array key, so `array_key_exists()` /
-	 * `isset()` / `??` on the `formatFields()` result could never tell an
-	 * explicit "off" from "never set" — see CHANGELOG for the measured
-	 * downstream fallout (a `true_false` default implemented via
-	 * `array_key_exists()` rendered 280 blocks as if the switch were still
-	 * on).
+	 * come out as an absent array key, so `isset()` / `??` on the
+	 * `formatFields()` result could never tell an explicit "off" from
+	 * "never set" — see CHANGELOG for the measured downstream fallout (a
+	 * `true_false` default implemented via `array_key_exists()` rendered
+	 * 280 blocks as if the switch were still on). `array_key_exists()` is
+	 * not identical to the other two here: it sees an explicit `null`
+	 * value as present, where `isset()` / `??` do not — but a genuinely
+	 * absent key defeats all three alike, which is the case this fix
+	 * targets.
 	 *
 	 * `false` is the only ambiguous case, and the ambiguity is **not**
 	 * resolved by asking whether the source field carried a non-null

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -847,13 +847,59 @@ class Helpers {
 			foreach ( $fields as $key => $field ) {
 				$value = self::fieldFormatter( $field, $post_id, $is_preview );
 
-				if ( ! empty( $value ) ) {
+				if ( self::isFormattedFieldPresent( $field, $value ) ) {
 					$content[ $key ] = $value;
 				}
 			}
 		}
 
 		return $content;
+	}
+
+	/**
+	 * Whether a {@see fieldFormatter()} result should survive into the
+	 * `formatFields()` output, or be dropped as "no such field".
+	 *
+	 * A plain `!empty( $value )` check (the pre-1.30 behaviour) conflates two
+	 * different things whenever the formatted value is falsy: a field that
+	 * genuinely carries a falsy value (a `true_false` switch left off, a
+	 * `number` field set to `0`) and a field that simply is not there
+	 * (missing definition, unfilled repeater outside preview). Both used to
+	 * come out as an absent array key, so `array_key_exists()` /
+	 * `isset()` / `??` on the `formatFields()` result could never tell an
+	 * explicit "off" from "never set" — see CHANGELOG for the measured
+	 * downstream fallout (a `true_false` default implemented via
+	 * `array_key_exists()` rendered 280 blocks as if the switch were still
+	 * on).
+	 *
+	 * `false` is the only ambiguous case: {@see fieldFormatter()} also
+	 * returns literal `false` as its own "no such field" sentinel (empty
+	 * field definition, missing `value` key, unfilled repeater/flexible_content
+	 * outside preview). None of the type-specific branches in
+	 * `fieldFormatter()` ever assign `false` to `$field['value']` themselves
+	 * — a raw ACF `false` (e.g. an off `true_false` field) only ever reaches
+	 * the final `return $field['value'];` unmodified, which requires the
+	 * field to have carried a non-null `value` key to begin with. That is
+	 * exactly the condition this method uses to tell the two `false`s apart.
+	 *
+	 * Every other falsy scalar (`0`, `0.0`, `"0"`) has no such ambiguity —
+	 * `fieldFormatter()` never uses them as a sentinel — so they are kept
+	 * unconditionally. Empty string, empty array, and `null` keep being
+	 * dropped, matching the pre-1.30 behaviour for those.
+	 *
+	 * @param mixed $field ACF field definition array as read from `$fields` in {@see formatFields()}.
+	 * @param mixed $value Return value of {@see fieldFormatter()} for that field.
+	 */
+	private static function isFormattedFieldPresent( $field, $value ): bool {
+		if ( $value === false ) {
+			return is_array( $field ) && array_key_exists( 'value', $field ) && $field['value'] !== null;
+		}
+
+		if ( is_scalar( $value ) ) {
+			return $value !== '';
+		}
+
+		return ! empty( $value );
 	}
 
 	/**

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1271,7 +1271,13 @@ class Helpers {
 	 *                                  `type` and `value` keys.
 	 * @param int|string|null $post_id  Post ID used by nested formatters (may be a block ID string).
 	 * @param bool         $is_preview True when rendering inside a Gutenberg block preview.
-	 * @return mixed Formatted field value, or false when `$field` is empty.
+	 * @return mixed Formatted field value, or literal `false` as a "no such
+	 *               field" sentinel — not only when `$field` itself is
+	 *               empty, but also for a non-empty field definition whose
+	 *               `value` key is missing entirely, or present but `null`
+	 *               (except `repeater`/`flexible_content` during preview,
+	 *               which instead pass the definition through unchanged so
+	 *               a preview can read its `sub_fields`/`layouts`).
 	 */
 	public static function fieldFormatter( $field, $post_id = null, $is_preview = false ) {
 

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1274,13 +1274,25 @@ class Helpers {
 	 *                                  `type` and `value` keys.
 	 * @param int|string|null $post_id  Post ID used by nested formatters (may be a block ID string).
 	 * @param bool         $is_preview True when rendering inside a Gutenberg block preview.
-	 * @return mixed Formatted field value, or literal `false` as a "no such
-	 *               field" sentinel — not only when `$field` itself is
-	 *               empty, but also for a non-empty field definition whose
-	 *               `value` key is missing entirely, or present but `null`
-	 *               (except `repeater`/`flexible_content` during preview,
-	 *               which instead pass the definition through unchanged so
-	 *               a preview can read its `sub_fields`/`layouts`).
+	 * @return mixed Formatted field value. Literal `false` is ambiguous by
+	 *               design and carries two different meanings a caller must
+	 *               tell apart before trusting it:
+	 *               1. A "no such field" sentinel — not only when `$field`
+	 *                  itself is empty, but also for a non-empty field
+	 *                  definition whose `value` key is missing entirely, or
+	 *                  present but `null` (except `repeater`/
+	 *                  `flexible_content` during preview, which instead
+	 *                  pass the definition through unchanged so a preview
+	 *                  can read its `sub_fields`/`layouts`).
+	 *               2. The legitimate formatted value of a present
+	 *                  `true_false` field (an off switch, including one
+	 *                  produced by a `field_formatter_true_false` filter
+	 *                  override) — `false` by design there, not a sentinel
+	 *                  at all.
+	 *               This method does not disambiguate the two on its own —
+	 *               see {@see isFormattedFieldPresent()}, which does, by
+	 *               checking `$field['type'] === 'true_false'` against the
+	 *               original field definition alongside the returned value.
 	 */
 	public static function fieldFormatter( $field, $post_id = null, $is_preview = false ) {
 

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -872,27 +872,48 @@ class Helpers {
 	 * `array_key_exists()` rendered 280 blocks as if the switch were still
 	 * on).
 	 *
-	 * `false` is the only ambiguous case: {@see fieldFormatter()} also
-	 * returns literal `false` as its own "no such field" sentinel (empty
-	 * field definition, missing `value` key, unfilled repeater/flexible_content
-	 * outside preview). None of the type-specific branches in
-	 * `fieldFormatter()` ever assign `false` to `$field['value']` themselves
-	 * — a raw ACF `false` (e.g. an off `true_false` field) only ever reaches
-	 * the final `return $field['value'];` unmodified, which requires the
-	 * field to have carried a non-null `value` key to begin with. That is
-	 * exactly the condition this method uses to tell the two `false`s apart.
+	 * `false` is the only ambiguous case, and the ambiguity is **not**
+	 * resolved by asking whether the source field carried a non-null
+	 * `value` key — that key is present just as often for a field that is
+	 * genuinely empty. ACF's own field-load layer uses literal `false` as
+	 * an "empty" sentinel for a wide range of types with a `value` key
+	 * still set to `false`: an empty `relationship`, `gallery`, `image`,
+	 * `file`, `link`, or `date_picker`, a nullable `select` with nothing
+	 * chosen, and (per {@see fieldFormatter()}'s own preview-only
+	 * pass-through) an unfilled `repeater`/`flexible_content` outside
+	 * preview. None of `fieldFormatter()`'s type branches rewrite `false`
+	 * for any of those types, so a "carried a `value` key" test would keep
+	 * every one of them — directly contradicting this very CHANGELOG entry,
+	 * which promises an unfilled repeater stays absent.
+	 *
+	 * The disambiguation is by field **semantics**, not by key presence:
+	 * `true_false` is the one ACF type whose stored value is *always*
+	 * boolean — it has no third "empty" state distinct from `false`, so an
+	 * unfilled `true_false` and an explicitly-off one are the same value by
+	 * design, and treating that `false` as meaningful is exactly the
+	 * intended fix. `select` / `checkbox` / `radio` are deliberately left
+	 * out even though `false` is meaningless noise there too (ACF returns
+	 * `false` for "nothing chosen") — for choice fields "nothing chosen" is
+	 * not a distinguishable state consumers watch for the way an "off"
+	 * switch is, and every other field type's `false` is unambiguously
+	 * "empty", so it keeps being dropped.
 	 *
 	 * Every other falsy scalar (`0`, `0.0`, `"0"`) has no such ambiguity —
-	 * `fieldFormatter()` never uses them as a sentinel — so they are kept
-	 * unconditionally. Empty string, empty array, and `null` keep being
-	 * dropped, matching the pre-1.30 behaviour for those.
+	 * `fieldFormatter()` never uses them as a sentinel for any type — so
+	 * they are kept unconditionally regardless of field type. Empty
+	 * string, empty array, and `null` keep being dropped, matching the
+	 * pre-1.30 behaviour for those.
 	 *
 	 * @param mixed $field ACF field definition array as read from `$fields` in {@see formatFields()}.
 	 * @param mixed $value Return value of {@see fieldFormatter()} for that field.
 	 */
 	private static function isFormattedFieldPresent( $field, $value ): bool {
 		if ( $value === false ) {
-			return is_array( $field ) && array_key_exists( 'value', $field ) && $field['value'] !== null;
+			return is_array( $field )
+				&& isset( $field['type'] )
+				&& $field['type'] === 'true_false'
+				&& array_key_exists( 'value', $field )
+				&& $field['value'] !== null;
 		}
 
 		if ( is_scalar( $value ) ) {

--- a/tests/Unit/Helpers/FormatFieldsTest.php
+++ b/tests/Unit/Helpers/FormatFieldsTest.php
@@ -268,6 +268,69 @@ class FormatFieldsTest extends HelpersTestCase {
 		$this->assertArrayNotHasKey( 'empty', $result );
 	}
 
+	/**
+	 * Regression: an unchecked `true_false` field must survive as an
+	 * explicit `false`, not be dropped as if the field did not exist.
+	 * A consumer that reads the switch via `array_key_exists()` (a common
+	 * `?? true` "default on" pattern) cannot otherwise tell "explicitly off"
+	 * from "field not present" — see CHANGELOG for the measured fallout.
+	 */
+	public function test_true_false_switch_off_is_kept_as_explicit_false(): void {
+		Functions\when( 'get_field_objects' )->justReturn( [
+			'is_enabled' => [ 'type' => 'true_false', 'value' => false ],
+		] );
+
+		$result = Helpers::formatFields( (object) [ 'ID' => 1 ] );
+
+		$this->assertArrayHasKey( 'is_enabled', $result );
+		$this->assertSame( false, $result['is_enabled'] );
+	}
+
+	public function test_true_false_switch_on_is_kept_as_true(): void {
+		Functions\when( 'get_field_objects' )->justReturn( [
+			'is_enabled' => [ 'type' => 'true_false', 'value' => true ],
+		] );
+
+		$result = Helpers::formatFields( (object) [ 'ID' => 1 ] );
+
+		$this->assertSame( true, $result['is_enabled'] );
+	}
+
+	/**
+	 * Companion to the true_false case: a `number` field explicitly set to
+	 * `0` (or ACF's string-typed `"0"`) must also survive — `0` is not
+	 * "field absent" any more than `false` is.
+	 */
+	public function test_numeric_zero_value_is_kept(): void {
+		Functions\when( 'get_field_objects' )->justReturn( [
+			'count'      => [ 'type' => 'number', 'value' => 0 ],
+			'raw_string' => [ 'type' => 'text', 'value' => '0' ],
+		] );
+
+		$result = Helpers::formatFields( (object) [ 'ID' => 1 ] );
+
+		$this->assertSame( 0, $result['count'] );
+		$this->assertSame( '0', $result['raw_string'] );
+	}
+
+	/**
+	 * A field with no saved value at all (missing `value` key entirely —
+	 * the shape `fieldFormatter()` treats as "no such field") must still be
+	 * dropped, even though `fieldFormatter()`'s sentinel return is also the
+	 * literal `false` that a real true_false-off value formats to. This is
+	 * the disambiguation the fix relies on: only a field that genuinely
+	 * carried a non-null `value` key produces a kept `false`.
+	 */
+	public function test_field_missing_value_key_is_dropped_not_kept_as_false(): void {
+		Functions\when( 'get_field_objects' )->justReturn( [
+			'ghost' => [ 'type' => 'true_false' ], // no 'value' key at all
+		] );
+
+		$result = Helpers::formatFields( (object) [ 'ID' => 1 ] );
+
+		$this->assertArrayNotHasKey( 'ghost', $result );
+	}
+
 	public function test_wysiwyg_tinymce_artifacts_excluded_automatically(): void {
 		Functions\when( 'do_shortcode' )->alias( function ( $content ) {
 			return $content;

--- a/tests/Unit/Helpers/FormatFieldsTest.php
+++ b/tests/Unit/Helpers/FormatFieldsTest.php
@@ -517,7 +517,32 @@ class FormatFieldsTest extends HelpersTestCase {
 		}
 	}
 
-	public function test_block_prefix_uses_global_post(): void {
+	/**
+	 * `get_field_objects()` is called with the raw `block_<hash>` id — the
+	 * swap to the real post id (§ `str_starts_with( (string) $post_id,
+	 * 'block_' )` in `formatFields()`) only takes effect for what gets
+	 * passed *downstream*, to `fieldFormatter()` and, through it, to the
+	 * `field_formatter_{type}` filter as that filter's second argument.
+	 * That is the only externally observable signal the swap happened —
+	 * asserting on the *result* alone (as an earlier version of this test
+	 * did) does not prove the swap ran, because a formatted `text` value
+	 * does not depend on `$post_id` at all; the test would stay green even
+	 * if the swap block were deleted. Spy on `apply_filters` to capture the
+	 * `$post_id` it actually received.
+	 */
+	public function test_block_prefix_swaps_to_real_post_id_before_field_formatter(): void {
+		$this->define_wp_post_if_needed();
+		global $post;
+		$post = new \WP_Post( (object) [ 'ID' => 99, 'post_type' => 'page' ] );
+
+		$captured_post_id = 'not captured';
+		Functions\when( 'apply_filters' )->alias( function ( $filter, ...$args ) use ( &$captured_post_id ) {
+			if ( $filter === 'field_formatter_text' ) {
+				$captured_post_id = $args[1] ?? 'missing';
+			}
+			return $args[0] ?? null;
+		} );
+
 		Functions\when( 'get_queried_object_id' )->justReturn( 0 );
 		Functions\when( 'get_field_objects' )->alias( function ( $id ) {
 			if ( str_starts_with( (string) $id, 'block_' ) ) {
@@ -535,29 +560,46 @@ class FormatFieldsTest extends HelpersTestCase {
 		$result = Helpers::formatFields( 'block_abc123' );
 
 		$this->assertSame( 'Block heading', $result['heading'] );
+		// The real signal that the swap ran: fieldFormatter() (and the
+		// filter it applies) received the real post id, not the raw block
+		// id string that was used to call get_field_objects().
+		$this->assertSame( 99, $captured_post_id );
 	}
 
 	/**
 	 * Regression for the bug that motivated this whole fix, exercised
 	 * through the path it actually happened on: an ACF block, whose
-	 * `formatFields()` call resolves through the `block_<hash>` id-swap
-	 * (§ `str_starts_with( (string) $post_id, 'block_' )` above), not
-	 * through a plain post object. `test_true_false_switch_off_is_kept_as_
-	 * explicit_false()` only covers the plain-post path — this proves the
-	 * `true_false`-off survival holds after the block-id-to-real-post-id
-	 * swap too, since `isFormattedFieldPresent()` inspects the field
-	 * definition from `$fields` (captured before the swap), independent of
-	 * which `$post_id` ends up passed to `fieldFormatter()`.
+	 * `formatFields()` call resolves through the `block_<hash>` id-swap,
+	 * not through a plain post object. This proves two things together,
+	 * both required for the original bug to be considered fixed on the
+	 * block path specifically:
 	 *
-	 * If the false-keeping decision were ever made to depend on the
-	 * (post-swap) `$post_id` instead of the field definition, this would
-	 * fail where the plain-post test would not — it is the discriminating
-	 * case Codex asked for.
+	 * 1. The block-id-to-real-post-id swap actually ran (observed the same
+	 *    way as {@see test_block_prefix_swaps_to_real_post_id_before_field_
+	 *    formatter()} above — via the `$post_id` the `field_formatter_{type}`
+	 *    filter receives).
+	 * 2. `true_false`-off still survives once fields are sourced from a
+	 *    `block_<hash>` lookup rather than a plain post object.
+	 *
+	 * `isFormattedFieldPresent()` in fact only inspects the field
+	 * definition from `$fields` (captured before the swap), so (2) does
+	 * not actually depend on (1) — but a test that only asserted (2) would
+	 * stay green even if the swap block were deleted entirely, which is
+	 * exactly the false confidence the previous version of this test gave.
+	 * Asserting the captured post id closes that gap.
 	 */
 	public function test_true_false_switch_off_survives_block_id_resolution(): void {
 		$this->define_wp_post_if_needed();
 		global $post;
 		$post = new \WP_Post( (object) [ 'ID' => 77, 'post_type' => 'page' ] );
+
+		$captured_post_id = 'not captured';
+		Functions\when( 'apply_filters' )->alias( function ( $filter, ...$args ) use ( &$captured_post_id ) {
+			if ( $filter === 'field_formatter_true_false' ) {
+				$captured_post_id = $args[1] ?? 'missing';
+			}
+			return $args[0] ?? null;
+		} );
 
 		Functions\when( 'get_queried_object_id' )->justReturn( 0 );
 		Functions\when( 'get_field_objects' )->alias( function ( $id ) {
@@ -573,6 +615,7 @@ class FormatFieldsTest extends HelpersTestCase {
 
 		$this->assertArrayHasKey( 'is_enabled', $result );
 		$this->assertSame( false, $result['is_enabled'] );
+		$this->assertSame( 77, $captured_post_id );
 	}
 
 	/**
@@ -606,6 +649,40 @@ class FormatFieldsTest extends HelpersTestCase {
 		$result = Helpers::formatFields( (object) [ 'ID' => 1 ] );
 
 		$this->assertArrayNotHasKey( 'choice', $result );
+	}
+
+	/**
+	 * Converse of the case above, and the more consequential half of the
+	 * CHANGELOG's `field_formatter_{type}` promise: a filter that turns a
+	 * *non-falsy* `true_false` value into `false` must still survive as an
+	 * explicit `false`, exactly like a raw ACF off-switch does. An
+	 * implementation that keyed the survive/drop decision on the raw
+	 * source value (`$field['value']` before the filter ran) rather than
+	 * the formatted return value would pass every other test in this file
+	 * while breaking this one — the raw value here is `true`, non-falsy,
+	 * so a source-keyed predicate would incorrectly see nothing to guard
+	 * against and let the type check run against the wrong signal, or
+	 * (in another plausible-but-wrong implementation) drop the field
+	 * because the *raw* value never equalled `false`.
+	 */
+	public function test_filter_forced_false_on_true_false_type_stays_present(): void {
+		Functions\when( 'apply_filters' )->alias( function ( $filter, ...$args ) {
+			if ( $filter === 'field_formatter_true_false' ) {
+				$field = $args[0];
+				$field['value'] = false;
+				return $field;
+			}
+			return $args[0] ?? null;
+		} );
+
+		Functions\when( 'get_field_objects' )->justReturn( [
+			'is_enabled' => [ 'type' => 'true_false', 'value' => true ],
+		] );
+
+		$result = Helpers::formatFields( (object) [ 'ID' => 1 ] );
+
+		$this->assertArrayHasKey( 'is_enabled', $result );
+		$this->assertSame( false, $result['is_enabled'] );
 	}
 
 	public function test_nav_menu_item_resolves_fields_via_explicit_screen(): void {

--- a/tests/Unit/Helpers/FormatFieldsTest.php
+++ b/tests/Unit/Helpers/FormatFieldsTest.php
@@ -331,6 +331,41 @@ class FormatFieldsTest extends HelpersTestCase {
 		$this->assertArrayNotHasKey( 'ghost', $result );
 	}
 
+	/**
+	 * The `false`-keeping exception is scoped to `true_false` by field
+	 * *type*, not by "does the field carry a `value` key" — ACF sets
+	 * `value => false` on an empty `repeater` too (see the sentinel
+	 * pass-through in {@see fieldFormatter()}), so a key-presence test
+	 * would wrongly keep it. If the predicate were inverted back to a bare
+	 * key-presence check, this would fail: `array_key_exists( 'value',
+	 * $field )` is true here, only the type restriction saves it.
+	 */
+	public function test_empty_repeater_false_value_is_dropped_not_kept(): void {
+		Functions\when( 'get_field_objects' )->justReturn( [
+			'items' => [ 'type' => 'repeater', 'value' => false, 'sub_fields' => [] ],
+		] );
+
+		$result = Helpers::formatFields( (object) [ 'ID' => 1 ] );
+
+		$this->assertArrayNotHasKey( 'items', $result );
+	}
+
+	/**
+	 * Same disambiguation, for an empty `relationship` field — ACF also
+	 * represents "nothing selected" as `value => false` here. If the
+	 * predicate were inverted back to a bare key-presence check, this would
+	 * fail the same way as the repeater case above.
+	 */
+	public function test_empty_relationship_false_value_is_dropped_not_kept(): void {
+		Functions\when( 'get_field_objects' )->justReturn( [
+			'related' => [ 'type' => 'relationship', 'value' => false ],
+		] );
+
+		$result = Helpers::formatFields( (object) [ 'ID' => 1 ] );
+
+		$this->assertArrayNotHasKey( 'related', $result );
+	}
+
 	public function test_wysiwyg_tinymce_artifacts_excluded_automatically(): void {
 		Functions\when( 'do_shortcode' )->alias( function ( $content ) {
 			return $content;

--- a/tests/Unit/Helpers/FormatFieldsTest.php
+++ b/tests/Unit/Helpers/FormatFieldsTest.php
@@ -286,16 +286,6 @@ class FormatFieldsTest extends HelpersTestCase {
 		$this->assertSame( false, $result['is_enabled'] );
 	}
 
-	public function test_true_false_switch_on_is_kept_as_true(): void {
-		Functions\when( 'get_field_objects' )->justReturn( [
-			'is_enabled' => [ 'type' => 'true_false', 'value' => true ],
-		] );
-
-		$result = Helpers::formatFields( (object) [ 'ID' => 1 ] );
-
-		$this->assertSame( true, $result['is_enabled'] );
-	}
-
 	/**
 	 * Companion to the true_false case: a `number` field explicitly set to
 	 * `0` (or ACF's string-typed `"0"`) must also survive — `0` is not
@@ -545,6 +535,77 @@ class FormatFieldsTest extends HelpersTestCase {
 		$result = Helpers::formatFields( 'block_abc123' );
 
 		$this->assertSame( 'Block heading', $result['heading'] );
+	}
+
+	/**
+	 * Regression for the bug that motivated this whole fix, exercised
+	 * through the path it actually happened on: an ACF block, whose
+	 * `formatFields()` call resolves through the `block_<hash>` id-swap
+	 * (§ `str_starts_with( (string) $post_id, 'block_' )` above), not
+	 * through a plain post object. `test_true_false_switch_off_is_kept_as_
+	 * explicit_false()` only covers the plain-post path — this proves the
+	 * `true_false`-off survival holds after the block-id-to-real-post-id
+	 * swap too, since `isFormattedFieldPresent()` inspects the field
+	 * definition from `$fields` (captured before the swap), independent of
+	 * which `$post_id` ends up passed to `fieldFormatter()`.
+	 *
+	 * If the false-keeping decision were ever made to depend on the
+	 * (post-swap) `$post_id` instead of the field definition, this would
+	 * fail where the plain-post test would not — it is the discriminating
+	 * case Codex asked for.
+	 */
+	public function test_true_false_switch_off_survives_block_id_resolution(): void {
+		$this->define_wp_post_if_needed();
+		global $post;
+		$post = new \WP_Post( (object) [ 'ID' => 77, 'post_type' => 'page' ] );
+
+		Functions\when( 'get_queried_object_id' )->justReturn( 0 );
+		Functions\when( 'get_field_objects' )->alias( function ( $id ) {
+			if ( str_starts_with( (string) $id, 'block_' ) ) {
+				return [
+					'is_enabled' => [ 'type' => 'true_false', 'value' => false ],
+				];
+			}
+			return false;
+		} );
+
+		$result = Helpers::formatFields( 'block_deadbeef' );
+
+		$this->assertArrayHasKey( 'is_enabled', $result );
+		$this->assertSame( false, $result['is_enabled'] );
+	}
+
+	/**
+	 * CHANGELOG.md documents that a `false` produced by the public
+	 * `field_formatter_{type}` filter follows the same type-based rule as a
+	 * raw ACF value — kept only for `true_false`, dropped otherwise, even
+	 * when the raw value it overwrote was non-empty. This is untested
+	 * elsewhere: `setUp()`'s default `apply_filters` stub is a pass-through
+	 * that never rewrites `value`, so nothing exercises a filter that
+	 * actually flips a non-empty value to `false`.
+	 *
+	 * If `isFormattedFieldPresent()` ever went back to deciding on "did the
+	 * source field carry a `value` key" instead of on declared type, this
+	 * would fail: the source field here carries a non-null `value` key
+	 * (`'Chosen'`), so a key-presence predicate would wrongly keep it.
+	 */
+	public function test_filter_forced_false_is_dropped_for_non_true_false_type(): void {
+		Functions\when( 'apply_filters' )->alias( function ( $filter, ...$args ) {
+			if ( $filter === 'field_formatter_select' ) {
+				$field = $args[0];
+				$field['value'] = false;
+				return $field;
+			}
+			return $args[0] ?? null;
+		} );
+
+		Functions\when( 'get_field_objects' )->justReturn( [
+			'choice' => [ 'type' => 'select', 'value' => 'Chosen' ],
+		] );
+
+		$result = Helpers::formatFields( (object) [ 'ID' => 1 ] );
+
+		$this->assertArrayNotHasKey( 'choice', $result );
 	}
 
 	public function test_nav_menu_item_resolves_fields_via_explicit_screen(): void {


### PR DESCRIPTION
## Bug

`Helpers::formatFields()` drops any field whose formatted value fails `!empty()`, rather than storing a falsy-but-real value:

```php
$content = [];
if ( ! empty( $fields ) ) {
    foreach ( $fields as $key => $field ) {
        $value = self::fieldFormatter( $field, $post_id, $is_preview );

        if ( ! empty( $value ) ) {
            $content[ $key ] = $value;
        }
    }
}
```

For an ACF `true_false` switch, an unchecked box formats to `false`, which is `empty()`. The key is omitted entirely — indistinguishable from "this field does not exist on this post". Any consumer that reads the switch via `array_key_exists()` / `isset()` / `??` (a common `?? true` "default on" pattern) cannot tell "explicitly turned off" from "never set".

**Measured downstream impact:** a page-header component in a consuming theme implemented a legacy `?? true` default with `array_key_exists()`. Because `formatFields()` had already erased the distinction, **280 published blocks with the switch explicitly OFF rendered as if it were ON.** The downstream project has since worked around it with a `timber_kit/block_renderer/content_data` hook that backfills the raw attribute from the block's own stored data — a workaround this fix makes unnecessary.

## Fix

`formatFields()` now runs the formatted value through a new private `Helpers::isFormattedFieldPresent( $field, $value )` instead of a bare `!empty()`:

- `null`, `''`, `[]` — still dropped (matches all existing tests, e.g. `test_empty_field_value_excluded`).
- `0`, `0.0`, `"0"` — now **kept**, for every field type. `fieldFormatter()` never uses these as a sentinel, so there's no ambiguity.
- `false` — kept **only when the field's declared type is `true_false`**. `true_false` is the one ACF type whose stored value is always boolean, with no third "empty" state distinct from `false`, so an unfilled switch and an explicitly-off one are the same value by design. Every other type's `false` keeps being dropped: ACF itself uses literal `false` as an "empty" sentinel for a `relationship`, `gallery`, `image`, `file`, `link`, `date_picker`, nullable `select`, or an unfilled `repeater`/`flexible_content` outside preview — none of those carry a `false` a consumer would want to distinguish from "not set". The decision is made on declared `type` plus the *formatted* return value, not on whether the source field merely carried a `value` key (that key is present just as often for the empty cases above) — so it also covers a `false` produced by the public `field_formatter_{type}` filter, in both directions: a filter forcing a non-`true_false` field to `false` still gets dropped, and a filter forcing a `true_false` field to `false` (even from a non-falsy raw value) still survives.

This does **not** change `fieldFormatter()`'s own public contract (still returns `false` both as a "no such field" sentinel and, for `true_false`, as a legitimate value — its docblock now documents both meanings and points at `isFormattedFieldPresent()` for how a caller tells them apart).

**Also fixed on the ACF block path specifically:** `formatFields()` resolves an ACF block's fields via a `block_<hash>` id, then swaps in the block's real post id before formatting — the id-swap happens *after* `get_field_objects()` runs but *before* `fieldFormatter()` and the `field_formatter_{type}` filter see `$post_id`. The keep/drop decision itself never depended on this swap, but the swap path is exercised by its own regression test, since fields sourced from a block behave identically to fields sourced from a plain post only if the swap runs correctly.

## What changes observably

- **Twig truthiness** (`{% if content.x %}`) — unaffected. `false`/`0`/`"0"` were already falsy whether the key existed or not.
- **`isset()` / `??` (both blind to an explicit `null` value) or `array_key_exists()` (which is not — it treats a stored `null` value as present) against the result** — a consumer will now see a key that was previously absent whenever the underlying field is a `true_false` field, or its formatted value is `0`, `0.0`, or `"0"`. In the measured case above, that means a `?? true` / `array_key_exists()`-based "default on" pattern starts correctly honoring an explicit "off" it previously ignored.

**Versioning: 1.30.0 (minor).** This is a bug fix — `formatFields()` starts returning the field's actual value instead of silently dropping it — not a change to the method's shape or public contract.

## Tests

The package has a full PHPUnit suite (`composer test`) plus PHPStan (`composer phpstan`) and property-based tests (`giorgiosironi/eris`). Added to `tests/Unit/Helpers/FormatFieldsTest.php`:

- `test_true_false_switch_off_is_kept_as_explicit_false`
- `test_numeric_zero_value_is_kept` (both int `0` and string `"0"`)
- `test_field_missing_value_key_is_dropped_not_kept_as_false` — locks in that the sentinel path is still dropped, so the fix doesn't overcorrect
- `test_empty_repeater_false_value_is_dropped_not_kept` / `test_empty_relationship_false_value_is_dropped_not_kept` — an empty non-`true_false` field carrying `value => false` stays dropped
- `test_block_prefix_swaps_to_real_post_id_before_field_formatter` / `test_true_false_switch_off_survives_block_id_resolution` — the block-id-to-real-post-id swap is observed directly (via the `$post_id` the `field_formatter_{type}` filter receives), not just asserted through a result that doesn't depend on it
- `test_filter_forced_false_is_dropped_for_non_true_false_type` / `test_filter_forced_false_on_true_false_type_stays_present` — both directions of the `field_formatter_{type}` filter contract

Verified locally: `composer test` (1112 tests, 1960 assertions, all green), `composer phpstan` (clean).

## Also relevant

`CHANGELOG.md` `[1.30.0]` has the matching release-notes writeup.
