### PR TITLE
fix(breadcrumb): read the listing links from the namespace the options page registered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The breadcrumb's listing step is no longer dropped on a theme that
+  namespaces its ACF options page.** `Breadcrumb::get_global_links()` read
+  `get_field( 'links', 'option' )` unconditionally, while
+  `StarterBase::register_options_page()` honours an explicit `'post_id'` in
+  `$options_pages` (e.g. `'mytheme_settings'`) and writes there. The package
+  therefore wrote the listing links to one store and read them from another:
+  `get_field()` returned `null`, `build_for_singular()` appended no listing
+  item, and every singular of a `list_page_map` post type rendered a trail one
+  step short — with nothing logged and no error anywhere.
+
+  `Breadcrumb` gains an `options_post_id` config key (default `'option'`, so
+  un-namespaced projects are byte-identical), and `StarterBase` passes the
+  namespace it actually registered, derived from the first `$options_pages`
+  entry declaring a `post_id`. Override with `$breadcrumb_options_post_id` when
+  the `links` group lives on a different page than the first.
+
+  Found downstream on a five-language WPML site whose seven listing links were
+  all populated and none of which reached the breadcrumb. The failure is easy
+  to misread as "the fields are empty": a term filter had been supplying a
+  middle step, so the trail looked complete (`Home > AI > title`) while the
+  listing step it should have carried was silently absent.
+
+  **Not fixed here, deliberately:** the `links` group is still addressed by the
+  literal selector `'links'`. Making the group name configurable is a wider
+  change to `list_page_map`'s contract and no downstream project needs it yet.
+
 ## [1.30.0] - 2026-08-08
 
 ### Fixed

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -19,6 +19,7 @@ namespace Parisek\TimberKit;
  *     'list_page_map'         => ['post' => 'article_list'],
  *     'menu_trail_post_types' => null,
  *     'include_pagination'    => false,
+ *     'options_post_id'       => 'mytheme_settings',
  *     'labels'                => [
  *         'home'       => _x('Home', 'theme', 'theme'),
  *         '404'        => _x('Page not found', 'theme', 'theme'),
@@ -48,6 +49,22 @@ class Breadcrumb {
 
 	/** @var bool Whether to add "Page N" item on paginated views */
 	protected bool $include_pagination = false;
+
+	/**
+	 * ACF storage namespace holding the `links` group that `list_page_map`
+	 * indexes into.
+	 *
+	 * Defaults to ACF's own `'option'` store. A theme that registers its
+	 * options page under a namespace (`$options_pages` entry with an explicit
+	 * `post_id`, e.g. `'mytheme_settings'`) MUST pass that namespace here, or
+	 * the listing step is silently dropped from every singular breadcrumb:
+	 * the values are written to one store and read from another, `get_field()`
+	 * returns null, and `build_for_singular()` simply appends no item. Nothing
+	 * errors. {@see StarterBase::timber_context()} wires this automatically.
+	 *
+	 * @var string
+	 */
+	protected string $options_post_id = 'option';
 
 	/** @var array{'home': string, '404': string, 'search': string, 'pagination': string, 'author': string} Label dict; pre-translated by the caller */
 	protected array $labels = [
@@ -406,6 +423,11 @@ class Breadcrumb {
 	 * URLs are resolved through `wpml_object_id` so a Czech site rendering
 	 * the English breadcrumb gets the English article-list page link.
 	 *
+	 * Reads from {@see $options_post_id}, NOT unconditionally from `'option'`.
+	 * The two differ whenever a theme namespaces its options page, and the
+	 * mismatch is invisible: `get_field()` returns null, the listing item is
+	 * never appended, and the trail still renders — one step shorter.
+	 *
 	 * @return array<string, array{id: int, title: string, url: string}>
 	 */
 	protected function get_global_links(): array {
@@ -414,7 +436,7 @@ class Breadcrumb {
 		}
 
 		$data = [];
-		$links = get_field( 'links', 'option' );
+		$links = get_field( 'links', $this->options_post_id );
 
 		if ( ! is_countable( $links ) ) {
 			return $data;

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -156,6 +156,25 @@ class StarterBase extends Site {
 	/** @var bool Whether to add "Page N" item on paginated views */
 	protected bool $breadcrumb_include_pagination = false;
 
+	/**
+	 * ACF storage namespace the breadcrumb reads its `links` group from.
+	 *
+	 * `null` (default) derives it from `$options_pages` — the first entry that
+	 * declares a `post_id` wins, falling back to ACF's `'option'` store when no
+	 * entry declares one. Set explicitly only when a theme registers several
+	 * namespaced options pages and the `links` group does not live in the first.
+	 *
+	 * Why this needs to exist at all: `$options_pages` may namespace the store
+	 * (`'post_id' => 'mytheme_settings'`), and the breadcrumb used to read
+	 * `'option'` unconditionally. A namespaced theme therefore wrote its listing
+	 * links to one store and read them from another, `get_field()` returned
+	 * null, and `Breadcrumb::build_for_singular()` appended no listing item —
+	 * every singular rendered a trail one step short, with nothing logged.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $breadcrumb_options_post_id = null;
+
 	/** @var array{home: string, '404': string, search: string, pagination: string, author: string} Default English labels */
 	protected array $breadcrumb_labels = [
 		'home'       => 'Home',
@@ -1179,6 +1198,7 @@ class StarterBase extends Site {
 				'list_page_map'         => $this->breadcrumb_list_page_map,
 				'menu_trail_post_types' => $this->breadcrumb_menu_trail_post_types,
 				'include_pagination'    => $this->breadcrumb_include_pagination,
+				'options_post_id'       => $this->resolve_breadcrumb_options_post_id(),
 				'labels'                => $this->breadcrumb_labels,
 			] );
 			$context['breadcrumb'] = $bc->get();
@@ -2477,6 +2497,32 @@ class StarterBase extends Site {
 		if ( has_action( 'breeze_clear_all_cache' ) ) {
 			do_action( 'breeze_clear_all_cache' );
 		}
+	}
+
+	/**
+	 * The ACF storage namespace the breadcrumb should read the `links` group from.
+	 *
+	 * Explicit `$breadcrumb_options_post_id` wins. Otherwise the first
+	 * `$options_pages` entry declaring a `post_id` supplies it — that entry is
+	 * the theme's own settings page in every shipped layout, and a sub-page
+	 * without its own `post_id` inherits the same namespace anyway
+	 * ({@see resolve_options_page_namespaces()}). With nothing declared the
+	 * result is `'option'`, i.e. exactly the pre-1.31 behaviour.
+	 *
+	 * @return string
+	 */
+	private function resolve_breadcrumb_options_post_id(): string {
+		if ( is_string( $this->breadcrumb_options_post_id ) && $this->breadcrumb_options_post_id !== '' ) {
+			return $this->breadcrumb_options_post_id;
+		}
+
+		foreach ( $this->options_pages as $page ) {
+			if ( isset( $page['post_id'] ) && is_string( $page['post_id'] ) && $page['post_id'] !== '' ) {
+				return $page['post_id'];
+			}
+		}
+
+		return 'option';
 	}
 
 	/**

--- a/tests/Unit/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Unit/Breadcrumb/BreadcrumbTest.php
@@ -380,6 +380,42 @@ final class BreadcrumbTest extends BreadcrumbTestCase {
 		$this->assertSame( [], $result );
 	}
 
+	public function test_get_global_links_reads_the_configured_options_namespace(): void {
+		// Regression: the namespace was hardcoded to 'option'. A theme whose
+		// options page declares `post_id => 'mytheme_settings'` wrote its listing
+		// links to that store, the breadcrumb read a different one, get_field()
+		// returned null, and every singular silently lost its listing step.
+		$seen = [];
+		Functions\when( 'get_field' )->alias( function ( $selector, $post_id = false ) use ( &$seen ) {
+			$seen[] = [ $selector, $post_id ];
+			return 'mytheme_settings' === $post_id
+				? [ 'article_list' => [ 'url' => 'https://example.test/blog/', 'title' => 'Blog' ] ]
+				: null;
+		} );
+		Functions\when( 'url_to_postid' )->justReturn( 42 );
+		Functions\when( 'get_permalink' )->justReturn( 'https://example.test/blog/' );
+		\Brain\Monkey\Filters\expectApplied( 'wpml_object_id' )->andReturn( 42 );
+
+		$bc = new Breadcrumb([ 'options_post_id' => 'mytheme_settings' ]);
+		$result = $this->invoke_protected( $bc, 'get_global_links' );
+
+		$this->assertSame( [ [ 'links', 'mytheme_settings' ] ], $seen );
+		$this->assertArrayHasKey( 'article_list', $result );
+	}
+
+	public function test_get_global_links_defaults_to_the_option_store(): void {
+		$seen = [];
+		Functions\when( 'get_field' )->alias( function ( $selector, $post_id = false ) use ( &$seen ) {
+			$seen[] = [ $selector, $post_id ];
+			return null;
+		} );
+
+		$bc = new Breadcrumb();
+		$this->invoke_protected( $bc, 'get_global_links' );
+
+		$this->assertSame( [ [ 'links', 'option' ] ], $seen );
+	}
+
 	public function test_get_global_links_normalises_array_entry_with_post_resolution(): void {
 		Functions\when( 'get_field' )->justReturn( [
 			'article_list' => [

--- a/tests/Unit/Breadcrumb/StarterBaseBreadcrumbTest.php
+++ b/tests/Unit/Breadcrumb/StarterBaseBreadcrumbTest.php
@@ -66,6 +66,60 @@ final class StarterBaseBreadcrumbTest extends TestCase {
 		$this->assertSame( [], $context['breadcrumb'] );
 	}
 
+	public function test_breadcrumb_options_namespace_comes_from_the_registered_options_page(): void {
+		// The theme's own settings page supplies the namespace, so a project that
+		// namespaces its store does not also have to remember a second setting.
+		$namespace = $this->resolve_namespace_for( [
+			'options_pages' => [
+				[ 'menu_slug' => 'settings', 'page_title' => 'Theme Settings', 'post_id' => 'mytheme_settings' ],
+			],
+		] );
+
+		$this->assertSame( 'mytheme_settings', $namespace );
+	}
+
+	public function test_breadcrumb_options_namespace_defaults_to_option_when_none_declared(): void {
+		// Pre-1.31 behaviour, preserved: a theme that never namespaces its options
+		// page keeps reading ACF's own store.
+		$namespace = $this->resolve_namespace_for( [
+			'options_pages' => [
+				[ 'menu_slug' => 'settings', 'page_title' => 'Theme Settings' ],
+			],
+		] );
+
+		$this->assertSame( 'option', $namespace );
+	}
+
+	public function test_explicit_breadcrumb_options_post_id_wins_over_the_options_page(): void {
+		// Escape hatch for a theme whose `links` group lives on a second,
+		// differently namespaced page.
+		$namespace = $this->resolve_namespace_for( [
+			'options_pages' => [
+				[ 'menu_slug' => 'settings', 'page_title' => 'Theme Settings', 'post_id' => 'mytheme_settings' ],
+			],
+			'breadcrumb_options_post_id' => 'mytheme_other_store',
+		] );
+
+		$this->assertSame( 'mytheme_other_store', $namespace );
+	}
+
+	/**
+	 * @param array<string, mixed> $properties Protected properties to set before resolving.
+	 */
+	private function resolve_namespace_for( array $properties ): string {
+		$reflection = new ReflectionClass( StarterBase::class );
+		$instance = $reflection->newInstanceWithoutConstructor();
+
+		foreach ( $properties as $name => $value ) {
+			$property = $reflection->getProperty( $name );
+			$property->setValue( $instance, $value );
+		}
+
+		$method = new ReflectionMethod( $instance, 'resolve_breadcrumb_options_post_id' );
+
+		return (string) $method->invoke( $instance );
+	}
+
 	/**
 	 * Stub the WordPress functions that timber_context() calls unconditionally.
 	 * These must be wired before invoke_timber_context() is called.


### PR DESCRIPTION
## The bug

`Breadcrumb::get_global_links()` reads

```php
$links = get_field( 'links', 'option' );
```

unconditionally, while `StarterBase::register_options_page()` honours an explicit `'post_id'` in `$options_pages`:

```php
protected array $options_pages = [
    [ 'menu_slug' => 'settings', 'page_title' => 'Theme Settings', 'post_id' => 'mytheme_settings' ],
];
```

So the package **writes the listing links to one store and reads them from another**. `get_field()` returns `null`, `build_for_singular()` appends no listing item, and every singular of a `list_page_map` post type renders a trail one step short.

**Nothing reports it.** No error, no log line, no empty output — the trail still renders, just shorter.

## How it surfaced

A five-language WPML site whose seven listing links were all populated and none of which reached the breadcrumb. It read as "the option fields were never filled in", which was checked first and was not the cause.

What made it hard to see: a project-side `timber_kit_breadcrumb_items` filter injects the post's term, so the trail looked complete —

```
Úvod > AI > AI a automatizace v HR…          ← term in the slot, listing absent
```

Proven by probing the two stores directly:

```
get_field( 'links', 'option' )            => NULL
get_field( 'links', 'sloneek_settings' )  => article_list, blog_list, case_studies_list, …
```

## The fix

- `Breadcrumb` gains an `options_post_id` config key, **default `'option'`** — a project that never namespaced its options page is byte-identical.
- `StarterBase` passes the namespace it actually registered, derived from the first `$options_pages` entry declaring a `post_id`.
- `$breadcrumb_options_post_id` overrides that, for a theme whose `links` group lives on a page other than the first.

## Left alone on purpose

- **The group selector stays the literal `'links'`.** Making it configurable widens `list_page_map`'s contract and no consumer needs it.
- **`is_options_post_id()` / `acf_decode_post_id()` were not reused.** They answer "is this an options id", not "which namespace does this theme use", and routing through them would make the resolver depend on ACF being loaded — the breadcrumb has to degrade without it.
- **Two pre-existing failures on `main` are untouched**: PHPStan `TypographyExtension` constructor arity (`StarterBase.php:1363`) and PHPUnit `TypographyLocaleResolverTest`. Both reproduce on a clean checkout of `8a61223`; fixing them here would blur which failures this branch owns.

## Verification

| | before | after |
|---|---|---|
| `composer test` | 1112 tests, 1 error (pre-existing) | **1117 tests, 1 error** (same one) |
| `composer phpstan` | 1 error (pre-existing) | **1 error** (same one) |

Five new tests: the configured namespace is the one `get_field()` receives; the default is still `'option'`; and the three `StarterBase` resolution paths (derived / defaulted / explicitly overridden).

Downstream, on the site that surfaced it — all four singular types, all five languages:

```
cs  Úvod            > Blog > AI                 > AI a automatizace v HR…
en  Home            > Blog > AI                 > AI and Automation in HR…
sk  Úvod            > Blog > AI                 > AI a automatizácia v HR…
pl  Strona główna   > Blog > AI                 > AI i Automatyzacja w HR…
it  Home            > Blog > Consigli e trucchi > Employee Absence Software…
```

Three steps before, four now.