### PR TITLE
feat(site-icon): emit the favicon set the theme ships, behind a flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- `StarterBase::$site_icon_tags` (default off) replaces WordPress's four legacy site-icon tags with the favicon set the theme ships. Core asks `get_site_icon_url()` for 32, 192, 180 and 270 px and a theme answering with one SVG gets that SVG four times — including as `apple-touch-icon`, which iOS cannot read — plus an `msapplication-TileImage` for a Windows 8 tile. The flag probes `static/images/touch/` for known filenames and writes a tag only for a file that exists, so both RealFaviconGenerator output generations (modern `favicon.svg` + `favicon-96x96.png`, and the 2017-era 16/32 set) are handled with nothing configured; PNG `sizes` come from the filename rather than from opening the file, and `theme-color` plus `apple-mobile-web-app-title` are read from the manifest's `theme_color` and `short_name`. An uploaded Site Icon now wins over the theme's files — the off-path overrides it silently, which is why the fix is a flag and not a correction in place. `safari-pinned-tab.svg` is knowingly skipped: its `mask-icon` tag needs a tint colour no file states, and a guessed one renders worse than no pinned-tab icon.
+
 ## [1.32.0] - 2026-08-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -583,6 +583,50 @@ class Base extends StarterBase {
 }
 ```
 
+## Site icon tags
+
+WordPress emits four site-icon tags: `icon` at 32 and 192 px, `apple-touch-icon`,
+and `msapplication-TileImage`. It asks `get_site_icon_url()` for each size, so a
+theme that answers with one SVG gets that SVG in all four — including
+`apple-touch-icon`, which iOS cannot read, and a Windows 8 tile nobody wants.
+Themes work around it by hardcoding their own `<link rel="icon">` block in the
+layout, and then both sets render.
+
+`$site_icon_tags` replaces core's set with the files the theme actually ships:
+
+```php
+class Base extends StarterBase {
+    public function __construct() {
+        $this->site_icon_tags = true;
+
+        parent::__construct();
+    }
+}
+```
+
+Nothing is configured. `static/images/touch/` is probed for known filenames and
+a tag is written only for a file that exists, so both RealFaviconGenerator
+output generations work unchanged:
+
+| Slot | Filenames, first hit wins | Tag |
+| --- | --- | --- |
+| SVG icon | `favicon.svg` | `<link rel="icon" type="image/svg+xml">` |
+| PNG icon | `favicon-96x96.png`, `favicon-32x32.png`, `favicon-16x16.png` | `<link rel="icon" type="image/png" sizes>` — sizes read from the filename |
+| Shortcut | `favicon.ico` | `<link rel="shortcut icon">` |
+| Apple touch | `apple-touch-icon.png` | `<link rel="apple-touch-icon" sizes="180x180">` |
+| Manifest | `site.webmanifest`, `manifest.json` | `<link rel="manifest">`, plus `theme-color` and `apple-mobile-web-app-title` read from its `theme_color` and `short_name` |
+
+Two deliberate omissions. `safari-pinned-tab.svg` gets no `mask-icon` tag,
+because that tag needs a tint colour no file states and a guessed one renders
+worse than no pinned-tab icon. `msapplication-TileImage` is dropped outright.
+
+An uploaded Site Icon wins. When one is set in Settings → General, this filter
+steps aside and WordPress uses it — the flag's off-path does the opposite, and
+overrides the editor's upload silently.
+
+A theme that shipped no favicon file wires nothing, so core keeps whatever it
+would have done.
+
 ## Configuration
 
 Override these properties in your child constructor before calling `parent::__construct()`:
@@ -617,7 +661,8 @@ For an admin label without a dedicated setup hook (e.g. an options-page `page_ti
 | `$search_post_types` | array | `['post']` | Post types for search |
 | `$article_post_types` | array | `['post']` | Post types treated as articles |
 | `$block_category` | array | `['slug' => 'custom', 'title' => 'Custom']` | Custom block category |
-| `$favicon_path` | string | `'images/touch/favicon.svg'` | Favicon path |
+| `$favicon_path` | string | `'images/touch/favicon.svg'` | Favicon path. Read only while `$site_icon_tags` is off |
+| `$site_icon_tags` | bool | `false` | Emit the favicon set found in `static/images/touch/` instead of WordPress's four legacy site-icon tags. Opt-in — it changes rendered `<head>` output. See [Site icon tags](#site-icon-tags) |
 | `$context_privacy_policy` | bool | `false` | Opt-in: populate the site's privacy-policy URL (`get_privacy_policy_url()`) into the Timber context under `$privacy_policy_context_key`. Off by default — the key typically drives a cookie-consent partial, which must not appear on projects that ship without one |
 | `$privacy_policy_context_key` | string | `'ccnstL'` | Context key for the privacy-policy URL. The default is deliberately non-semantic so cookie-consent markup keyed off it stays invisible to ad-block heuristics |
 

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -101,8 +101,19 @@ class StarterBase extends Site {
 		'core/block',
 	];
 
-	/** @var string Relative path to favicon SVG from the static/ directory. */
+	/** @var string Relative path to favicon SVG from the static/ directory. Read only on the legacy path, when $site_icon_tags is off. */
 	protected string $favicon_path = 'images/touch/favicon.svg';
+
+	/**
+	 * @var bool Replace WordPress's four legacy site-icon tags with the favicon
+	 * set discovered in static/images/touch/. Opt-in because it changes rendered
+	 * <head> output: core emits an SVG for apple-touch-icon (which iOS cannot
+	 * read) plus an msapplication-TileImage nobody wants, and a theme that
+	 * already hardcodes its own favicon markup would end up with both sets.
+	 * Off keeps the historical behaviour — $favicon_path overriding every
+	 * requested size, uploaded Site Icon included.
+	 */
+	protected bool $site_icon_tags = false;
 
 	/** @var string Relative path to typography YAML config from the static/ directory. */
 	protected string $typography_config = 'typography.yml';
@@ -749,7 +760,13 @@ class StarterBase extends Site {
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
 		add_filter( 'block_editor_settings_all', array( $this, 'inject_font_editor_styles' ), 10, 2 );
-		if ( is_file( get_template_directory() . '/static/' . $this->favicon_path ) ) {
+		if ( $this->site_icon_tags && $this->discover_favicons() !== array() ) {
+			// Both filters are needed. site_icon_meta_tags supplies the markup;
+			// get_site_icon_url exists to make has_site_icon() true, which is the
+			// gate wp_site_icon() returns on before any filter runs.
+			add_filter( 'get_site_icon_url', array( $this, 'get_site_icon_url' ), 10, 3 );
+			add_filter( 'site_icon_meta_tags', array( $this, 'site_icon_meta_tags' ) );
+		} elseif ( ! $this->site_icon_tags && is_file( get_template_directory() . '/static/' . $this->favicon_path ) ) {
 			add_filter( 'get_site_icon_url', array( $this, 'get_site_icon_url' ), 10, 3 );
 		}
 	}
@@ -3305,7 +3322,201 @@ class StarterBase extends Site {
 	 * @return string Favicon URL from theme's static directory.
 	 */
 	public function get_site_icon_url( $url, $size, $blog_id ) {
+		if ( $this->site_icon_tags ) {
+			// An uploaded Site Icon is the editor's explicit choice; do not override it.
+			if ( get_option( 'site_icon' ) ) {
+				return $url;
+			}
+
+			$found = $this->discover_favicons();
+
+			// Only used to satisfy has_site_icon(); site_icon_meta_tags() writes
+			// the real markup, so any shipped file answers here.
+			return $this->favicon_url( $found['svg'] ?? $found['png'] ?? $found['ico'] ?? '' );
+		}
+
 		return get_template_directory_uri() . '/static/' . $this->favicon_path;
+	}
+
+	/**
+	 * Directory, relative to the theme's static/ dir, probed for favicon files.
+	 */
+	private const FAVICON_DIR = 'images/touch/';
+
+	/**
+	 * Filenames probed per slot, first hit wins. Deliberately a convention and
+	 * not a configurable path list: the truth is already on disk, and the two
+	 * RealFaviconGenerator output generations in circulation (modern
+	 * favicon.svg + favicon-96x96.png, and the 2017-era 16/32 set) differ only
+	 * in which of these files they ship.
+	 *
+	 * safari-pinned-tab.svg is knowingly left out. Its mask-icon tag needs an
+	 * author-chosen tint colour that cannot be inferred from the file, and a
+	 * guessed colour renders worse than no pinned-tab icon.
+	 */
+	private const FAVICON_CANDIDATES = array(
+		'svg'      => array( 'favicon.svg' ),
+		'png'      => array( 'favicon-96x96.png', 'favicon-32x32.png', 'favicon-16x16.png' ),
+		'ico'      => array( 'favicon.ico' ),
+		'apple'    => array( 'apple-touch-icon.png' ),
+		'manifest' => array( 'site.webmanifest', 'manifest.json' ),
+	);
+
+	/** @var array<string,string>|null Memoized result of discover_favicons(). */
+	private ?array $favicons = null;
+
+	/**
+	 * Find which favicon files the theme actually ships.
+	 *
+	 * @return array<string,string> Slot => filename, for slots with a file on disk.
+	 */
+	private function discover_favicons(): array {
+		if ( null !== $this->favicons ) {
+			return $this->favicons;
+		}
+
+		$dir   = get_template_directory() . '/static/' . self::FAVICON_DIR;
+		$found = array();
+
+		foreach ( self::FAVICON_CANDIDATES as $slot => $candidates ) {
+			foreach ( $candidates as $filename ) {
+				if ( is_file( $dir . $filename ) ) {
+					$found[ $slot ] = $filename;
+					break;
+				}
+			}
+		}
+
+		$this->favicons = $found;
+
+		return $found;
+	}
+
+	private function favicon_url( string $filename ): string {
+		if ( '' === $filename ) {
+			return '';
+		}
+
+		return get_template_directory_uri() . '/static/' . self::FAVICON_DIR . $filename;
+	}
+
+	/**
+	 * Replace the site-icon tags WordPress builds with the set the theme ships.
+	 *
+	 * Core asks get_site_icon_url() for 32, 192, 180 and 270 px and gets the
+	 * same URL four times, so it emits an SVG as apple-touch-icon — which iOS
+	 * cannot read — plus an msapplication-TileImage for a Windows 8 tile. This
+	 * writes the files that exist instead, at the sizes they really are.
+	 *
+	 * Hooked to `site_icon_meta_tags` only when $site_icon_tags is on.
+	 *
+	 * @param string[] $meta_tags Tags core assembled.
+	 * @return string[]
+	 */
+	public function site_icon_meta_tags( $meta_tags ) {
+		if ( get_option( 'site_icon' ) ) {
+			return $meta_tags;
+		}
+
+		$found = $this->discover_favicons();
+
+		if ( array() === $found ) {
+			return $meta_tags;
+		}
+
+		$tags = array();
+
+		if ( isset( $found['svg'] ) ) {
+			$tags[] = sprintf(
+				'<link rel="icon" type="image/svg+xml" href="%s" />',
+				esc_url( $this->favicon_url( $found['svg'] ) )
+			);
+		}
+
+		if ( isset( $found['png'] ) ) {
+			$sizes  = $this->favicon_sizes( $found['png'] );
+			$tags[] = sprintf(
+				'<link rel="icon" type="image/png"%s href="%s" />',
+				'' === $sizes ? '' : sprintf( ' sizes="%s"', esc_attr( $sizes ) ),
+				esc_url( $this->favicon_url( $found['png'] ) )
+			);
+		}
+
+		if ( isset( $found['ico'] ) ) {
+			$tags[] = sprintf(
+				'<link rel="shortcut icon" href="%s" />',
+				esc_url( $this->favicon_url( $found['ico'] ) )
+			);
+		}
+
+		if ( isset( $found['apple'] ) ) {
+			$tags[] = sprintf(
+				'<link rel="apple-touch-icon" sizes="180x180" href="%s" />',
+				esc_url( $this->favicon_url( $found['apple'] ) )
+			);
+		}
+
+		if ( isset( $found['manifest'] ) ) {
+			$tags[] = sprintf(
+				'<link rel="manifest" href="%s" />',
+				esc_url( $this->favicon_url( $found['manifest'] ) )
+			);
+
+			$manifest = $this->read_manifest( $found['manifest'] );
+
+			if ( isset( $manifest['theme_color'] ) && is_string( $manifest['theme_color'] ) ) {
+				$tags[] = sprintf(
+					'<meta name="theme-color" content="%s" />',
+					esc_attr( $manifest['theme_color'] )
+				);
+			}
+
+			$title = $manifest['short_name'] ?? $manifest['name'] ?? null;
+
+			if ( is_string( $title ) && '' !== $title ) {
+				$tags[] = sprintf(
+					'<meta name="apple-mobile-web-app-title" content="%s" />',
+					esc_attr( $title )
+				);
+			}
+		}
+
+		return $tags;
+	}
+
+	/**
+	 * Read the pixel dimensions a favicon filename encodes (favicon-96x96.png).
+	 *
+	 * Filename-derived on purpose — getimagesize() would open the file on every
+	 * request to learn what the name already states.
+	 */
+	private function favicon_sizes( string $filename ): string {
+		if ( 1 === preg_match( '/-(\d+x\d+)\./', $filename, $matches ) ) {
+			return $matches[1];
+		}
+
+		return '';
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private function read_manifest( string $filename ): array {
+		$path = get_template_directory() . '/static/' . self::FAVICON_DIR . $filename;
+
+		if ( ! is_readable( $path ) ) {
+			return array();
+		}
+
+		$raw = file_get_contents( $path );
+
+		if ( false === $raw ) {
+			return array();
+		}
+
+		$decoded = json_decode( $raw, true );
+
+		return is_array( $decoded ) ? $decoded : array();
 	}
 
 	// =========================================================================

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -760,7 +760,7 @@ class StarterBase extends Site {
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
 		add_filter( 'block_editor_settings_all', array( $this, 'inject_font_editor_styles' ), 10, 2 );
-		if ( $this->site_icon_tags && $this->discover_favicons() !== array() ) {
+		if ( $this->site_icon_tags && '' !== $this->favicon_image_file() ) {
 			// Both filters are needed. site_icon_meta_tags supplies the markup;
 			// get_site_icon_url exists to make has_site_icon() true, which is the
 			// gate wp_site_icon() returns on before any filter runs.
@@ -3323,19 +3323,48 @@ class StarterBase extends Site {
 	 */
 	public function get_site_icon_url( $url, $size, $blog_id ) {
 		if ( $this->site_icon_tags ) {
-			// An uploaded Site Icon is the editor's explicit choice; do not override it.
-			if ( get_option( 'site_icon' ) ) {
+			// An uploaded Site Icon is the editor's explicit choice — but only
+			// while it still resolves. A site_icon option pointing at a deleted
+			// attachment leaves core with an empty URL, and deferring to that
+			// would suppress a perfectly good theme set over a dangling ID.
+			if ( get_option( 'site_icon' ) && '' !== (string) $url ) {
 				return $url;
 			}
 
-			$found = $this->discover_favicons();
-
-			// Only used to satisfy has_site_icon(); site_icon_meta_tags() writes
-			// the real markup, so any shipped file answers here.
-			return $this->favicon_url( $found['svg'] ?? $found['png'] ?? $found['ico'] ?? '' );
+			return $this->favicon_gate_url();
 		}
 
 		return get_template_directory_uri() . '/static/' . $this->favicon_path;
+	}
+
+	/**
+	 * URL answered to every requested size, only to make has_site_icon() true —
+	 * site_icon_meta_tags() writes the real markup at the real sizes.
+	 *
+	 * Restricted to the image slots. A manifest-only theme must not answer here:
+	 * get_site_icon_url() is public API that other code reads for a real picture
+	 * (an SEO plugin's schema logo, for one), and handing it a .webmanifest would
+	 * be worse than admitting there is no site icon.
+	 */
+	private function favicon_gate_url(): string {
+		return $this->favicon_url( $this->favicon_image_file() );
+	}
+
+	/**
+	 * The discovered filename of the first real image, or '' when the theme
+	 * ships only a manifest. Kept separate from favicon_gate_url() so hook
+	 * registration can ask the question without building a URL.
+	 */
+	private function favicon_image_file(): string {
+		$found = $this->discover_favicons();
+
+		foreach ( array( 'svg', 'png', 'ico', 'apple' ) as $slot ) {
+			if ( isset( $found[ $slot ] ) ) {
+				return $found[ $slot ];
+			}
+		}
+
+		return '';
 	}
 
 	/**
@@ -3392,6 +3421,24 @@ class StarterBase extends Site {
 		return $found;
 	}
 
+	/**
+	 * Whether the uploaded Site Icon is real, not just a nonzero option.
+	 *
+	 * A site_icon left pointing at a deleted attachment is truthy and resolves
+	 * to nothing. Reading the attachment directly rather than calling
+	 * get_site_icon_url() keeps this out of the filter this class registers on
+	 * that very function.
+	 */
+	private function uploaded_site_icon_resolves(): bool {
+		$site_icon = (int) get_option( 'site_icon' );
+
+		if ( $site_icon <= 0 ) {
+			return false;
+		}
+
+		return '' !== (string) wp_get_attachment_url( $site_icon );
+	}
+
 	private function favicon_url( string $filename ): string {
 		if ( '' === $filename ) {
 			return '';
@@ -3414,7 +3461,7 @@ class StarterBase extends Site {
 	 * @return string[]
 	 */
 	public function site_icon_meta_tags( $meta_tags ) {
-		if ( get_option( 'site_icon' ) ) {
+		if ( $this->uploaded_site_icon_resolves() ) {
 			return $meta_tags;
 		}
 

--- a/tests/Unit/StarterBase/RegisterAssetHooksTest.php
+++ b/tests/Unit/StarterBase/RegisterAssetHooksTest.php
@@ -81,4 +81,58 @@ class RegisterAssetHooksTest extends StarterBaseTestCase {
 
 		$this->assertNotContains( 'get_site_icon_url', $filters );
 	}
+
+	public function test_site_icon_tags_off_by_default_leaves_meta_tag_filter_unregistered(): void {
+		$tmpDir = sys_get_temp_dir() . '/timber-kit-hooks-' . uniqid();
+		@mkdir( $tmpDir . '/static/images/touch', 0777, true );
+		file_put_contents( $tmpDir . '/static/images/touch/favicon.svg', '<svg/>' );
+
+		$filters = [];
+		Functions\when( 'add_filter' )->alias( function ( $hook, ...$rest ) use ( &$filters ) {
+			$filters[] = $hook;
+		} );
+		Functions\when( 'add_action' )->justReturn( true );
+		Functions\when( 'get_template_directory' )->justReturn( $tmpDir );
+
+		$this->invokeRegisterAssetHooks( $this->bareInstance() );
+
+		$this->assertContains( 'get_site_icon_url', $filters, 'legacy path must stay wired' );
+		$this->assertNotContains( 'site_icon_meta_tags', $filters );
+	}
+
+	public function test_site_icon_tags_on_registers_the_meta_tag_filter(): void {
+		$tmpDir = sys_get_temp_dir() . '/timber-kit-hooks-' . uniqid();
+		@mkdir( $tmpDir . '/static/images/touch', 0777, true );
+		file_put_contents( $tmpDir . '/static/images/touch/favicon.svg', '<svg/>' );
+
+		$filters = [];
+		Functions\when( 'add_filter' )->alias( function ( $hook, ...$rest ) use ( &$filters ) {
+			$filters[] = $hook;
+		} );
+		Functions\when( 'add_action' )->justReturn( true );
+		Functions\when( 'get_template_directory' )->justReturn( $tmpDir );
+
+		$instance = $this->bareInstance();
+		$this->setProperty( $instance, 'site_icon_tags', true );
+		$this->invokeRegisterAssetHooks( $instance );
+
+		$this->assertContains( 'site_icon_meta_tags', $filters );
+		$this->assertContains( 'get_site_icon_url', $filters );
+	}
+
+	public function test_site_icon_tags_on_stays_unwired_when_the_theme_ships_no_favicon(): void {
+		$filters = [];
+		Functions\when( 'add_filter' )->alias( function ( $hook, ...$rest ) use ( &$filters ) {
+			$filters[] = $hook;
+		} );
+		Functions\when( 'add_action' )->justReturn( true );
+		Functions\when( 'get_template_directory' )->justReturn( '/nonexistent/path/that/will/not/exist' );
+
+		$instance = $this->bareInstance();
+		$this->setProperty( $instance, 'site_icon_tags', true );
+		$this->invokeRegisterAssetHooks( $instance );
+
+		$this->assertNotContains( 'site_icon_meta_tags', $filters );
+		$this->assertNotContains( 'get_site_icon_url', $filters );
+	}
 }

--- a/tests/Unit/StarterBase/SiteIconMetaTagsTest.php
+++ b/tests/Unit/StarterBase/SiteIconMetaTagsTest.php
@@ -97,15 +97,6 @@ class SiteIconMetaTagsTest extends StarterBaseTestCase {
 		$this->assertStringNotContainsString( 'msapplication-TileImage', $markup );
 	}
 
-	public function test_uploaded_site_icon_wins_over_the_theme_files(): void {
-		Functions\when( 'get_option' )->justReturn( 42 );
-		$this->ship( 'favicon.svg', 'favicon-96x96.png' );
-
-		$core = [ '<link rel="icon" href="core.png" sizes="32x32" />' ];
-
-		$this->assertSame( $core, $this->instance()->site_icon_meta_tags( $core ) );
-	}
-
 	public function test_reads_theme_color_and_app_title_from_the_manifest(): void {
 		Functions\when( 'get_option' )->justReturn( 0 );
 		$this->ship( 'favicon.svg' );
@@ -127,5 +118,65 @@ class SiteIconMetaTagsTest extends StarterBaseTestCase {
 		$core = [ '<link rel="icon" href="core.png" sizes="32x32" />' ];
 
 		$this->assertSame( $core, $this->instance()->site_icon_meta_tags( $core ) );
+	}
+
+	/**
+	 * Regression: an apple-only set discovered fine but answered no gate URL, so
+	 * has_site_icon() stayed false and wp_site_icon() returned before any tag
+	 * was written. Reported by Codex on PR #124.
+	 */
+	public function test_apple_only_set_still_answers_the_has_site_icon_gate(): void {
+		Functions\when( 'get_option' )->justReturn( 0 );
+		$this->ship( 'apple-touch-icon.png' );
+
+		$this->assertSame(
+			'https://example.test/theme/static/images/touch/apple-touch-icon.png',
+			$this->instance()->get_site_icon_url( '', 512, 0 )
+		);
+	}
+
+	/**
+	 * A manifest is not a picture. get_site_icon_url() is read by other code
+	 * (an SEO plugin's schema logo) that expects an image, so a manifest-only
+	 * theme must answer nothing rather than a .webmanifest.
+	 */
+	public function test_manifest_only_set_answers_no_gate_url(): void {
+		Functions\when( 'get_option' )->justReturn( 0 );
+		$this->ship( 'site.webmanifest' );
+
+		$this->assertSame( '', $this->instance()->get_site_icon_url( '', 512, 0 ) );
+	}
+
+	/**
+	 * Regression: a site_icon option pointing at a deleted attachment is truthy
+	 * but resolves to nothing, and deferring to it suppressed every tag despite
+	 * a valid theme set. Reported by Codex on PR #124.
+	 */
+	public function test_dangling_site_icon_does_not_suppress_the_theme_set(): void {
+		Functions\when( 'get_option' )->justReturn( 42 );
+		Functions\when( 'wp_get_attachment_url' )->justReturn( false );
+		$this->ship( 'favicon.svg', 'favicon-96x96.png' );
+
+		$markup = implode( "\n", $this->tags( $this->instance() ) );
+
+		$this->assertStringContainsString( 'favicon-96x96.png', $markup );
+		$this->assertSame(
+			'https://example.test/theme/static/images/touch/favicon.svg',
+			$this->instance()->get_site_icon_url( '', 512, 0 )
+		);
+	}
+
+	public function test_resolving_site_icon_still_wins_over_the_theme_set(): void {
+		Functions\when( 'get_option' )->justReturn( 42 );
+		Functions\when( 'wp_get_attachment_url' )->justReturn( 'https://example.test/uploads/icon.png' );
+		$this->ship( 'favicon.svg' );
+
+		$core = [ '<link rel="icon" href="core.png" sizes="32x32" />' ];
+
+		$this->assertSame( $core, $this->instance()->site_icon_meta_tags( $core ) );
+		$this->assertSame(
+			'https://example.test/uploads/icon.png',
+			$this->instance()->get_site_icon_url( 'https://example.test/uploads/icon.png', 512, 0 )
+		);
 	}
 }

--- a/tests/Unit/StarterBase/SiteIconMetaTagsTest.php
+++ b/tests/Unit/StarterBase/SiteIconMetaTagsTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\StarterBase;
+
+use Brain\Monkey\Functions;
+use Parisek\TimberKit\StarterBase;
+use Tests\Unit\StarterBaseTestCase;
+
+/**
+ * Verifies the opt-in site-icon tag set: the favicon files are discovered on
+ * disk by convention (no configured paths), an uploaded Site Icon wins over
+ * them, and the emitted markup replaces WordPress's four legacy tags.
+ */
+class SiteIconMetaTagsTest extends StarterBaseTestCase {
+
+	private string $themeDir;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->themeDir = sys_get_temp_dir() . '/timber-kit-site-icon-' . uniqid();
+		@mkdir( $this->themeDir . '/static/images/touch', 0777, true );
+
+		Functions\when( 'get_template_directory' )->justReturn( $this->themeDir );
+		Functions\when( 'get_template_directory_uri' )->justReturn( 'https://example.test/theme' );
+		Functions\when( 'esc_url' )->returnArg();
+		Functions\when( 'esc_attr' )->returnArg();
+		Functions\when( 'get_bloginfo' )->justReturn( 'Example' );
+	}
+
+	protected function tearDown(): void {
+		foreach ( glob( $this->themeDir . '/static/images/touch/*' ) ?: [] as $file ) {
+			@unlink( $file );
+		}
+		parent::tearDown();
+	}
+
+	private function ship( string ...$files ): void {
+		foreach ( $files as $file ) {
+			file_put_contents( $this->themeDir . '/static/images/touch/' . $file, 'x' );
+		}
+	}
+
+	private function instance(): StarterBase {
+		$instance = ( new \ReflectionClass( StarterBase::class ) )->newInstanceWithoutConstructor();
+		$prop     = ( new \ReflectionClass( StarterBase::class ) )->getProperty( 'site_icon_tags' );
+		$prop->setValue( $instance, true );
+
+		return $instance;
+	}
+
+	private function tags( StarterBase $instance ): array {
+		return $instance->site_icon_meta_tags( [ '<link rel="icon" href="core.png" sizes="32x32" />' ] );
+	}
+
+	public function test_discovers_the_modern_favicon_set_without_configuration(): void {
+		Functions\when( 'get_option' )->justReturn( 0 );
+		$this->ship( 'favicon.svg', 'favicon-96x96.png', 'favicon.ico', 'apple-touch-icon.png' );
+
+		$markup = implode( "\n", $this->tags( $this->instance() ) );
+
+		$this->assertStringContainsString( 'type="image/svg+xml"', $markup );
+		$this->assertStringContainsString( 'favicon-96x96.png', $markup );
+		$this->assertStringContainsString( 'sizes="96x96"', $markup );
+		$this->assertStringContainsString( 'rel="shortcut icon"', $markup );
+	}
+
+	public function test_discovers_the_legacy_favicon_set_without_configuration(): void {
+		Functions\when( 'get_option' )->justReturn( 0 );
+		$this->ship( 'favicon-32x32.png', 'favicon.ico', 'apple-touch-icon.png' );
+
+		$markup = implode( "\n", $this->tags( $this->instance() ) );
+
+		$this->assertStringContainsString( 'favicon-32x32.png', $markup );
+		$this->assertStringContainsString( 'sizes="32x32"', $markup );
+		$this->assertStringNotContainsString( 'image/svg+xml', $markup );
+	}
+
+	public function test_apple_touch_icon_is_never_an_svg(): void {
+		Functions\when( 'get_option' )->justReturn( 0 );
+		$this->ship( 'favicon.svg' );
+
+		$markup = implode( "\n", $this->tags( $this->instance() ) );
+
+		$this->assertStringNotContainsString( 'apple-touch-icon', $markup );
+	}
+
+	public function test_drops_the_core_legacy_tags(): void {
+		Functions\when( 'get_option' )->justReturn( 0 );
+		$this->ship( 'favicon.svg' );
+
+		$markup = implode( "\n", $this->tags( $this->instance() ) );
+
+		$this->assertStringNotContainsString( 'core.png', $markup );
+		$this->assertStringNotContainsString( 'msapplication-TileImage', $markup );
+	}
+
+	public function test_uploaded_site_icon_wins_over_the_theme_files(): void {
+		Functions\when( 'get_option' )->justReturn( 42 );
+		$this->ship( 'favicon.svg', 'favicon-96x96.png' );
+
+		$core = [ '<link rel="icon" href="core.png" sizes="32x32" />' ];
+
+		$this->assertSame( $core, $this->instance()->site_icon_meta_tags( $core ) );
+	}
+
+	public function test_reads_theme_color_and_app_title_from_the_manifest(): void {
+		Functions\when( 'get_option' )->justReturn( 0 );
+		$this->ship( 'favicon.svg' );
+		file_put_contents(
+			$this->themeDir . '/static/images/touch/site.webmanifest',
+			'{"short_name":"Sloneek","theme_color":"#123456"}'
+		);
+
+		$markup = implode( "\n", $this->tags( $this->instance() ) );
+
+		$this->assertStringContainsString( 'rel="manifest"', $markup );
+		$this->assertStringContainsString( 'name="theme-color" content="#123456"', $markup );
+		$this->assertStringContainsString( 'apple-mobile-web-app-title" content="Sloneek"', $markup );
+	}
+
+	public function test_leaves_core_alone_when_no_favicon_file_is_shipped(): void {
+		Functions\when( 'get_option' )->justReturn( 0 );
+
+		$core = [ '<link rel="icon" href="core.png" sizes="32x32" />' ];
+
+		$this->assertSame( $core, $this->instance()->site_icon_meta_tags( $core ) );
+	}
+}


### PR DESCRIPTION
## From-Project

`sloneek`, redesign instance. Removing `favicon-by-realfavicongenerator` left two favicon sets in `<head>`. The second one was not the plugin — it was `StarterBase`.

## Why

Three defects, all fleet-wide rather than project-local.

1. **`apple-touch-icon` gets an SVG.** Core asks `get_site_icon_url()` for 32, 192, 180 and 270 px; `StarterBase` returned `$favicon_path` for every one. iOS cannot read an SVG here. Today only the theme's own hardcoded PNG saves it — which is the markup this change is meant to let themes delete.
2. **Duplication is the default.** Measured across the fleet: **22 of 22** timber-kit projects with a favicon on disk hardcode the block in `layout.twig`, and **none** relies on the filter as its only source.
3. **An uploaded Site Icon is silently ignored.** `get_site_icon_url` overrides it unconditionally. The editor uploads, saves, and nothing changes.

A fourth thing is worth naming because it explains the shape of the fix: `has_site_icon()` is `(bool) get_site_icon_url( 512 )`. Filtering the getter is what opens `wp_site_icon()`'s early return. Nobody intended that; it was a side effect. It is now deliberate and commented.

## What

`$site_icon_tags`, default off per the flag doctrine in AGENTS.md. On, it filters `site_icon_meta_tags` and writes the files the theme ships.

**Discovery is by convention, not configuration** — no path property, and none added. `static/images/touch/` is probed for known filenames; a tag is written only where a file exists. That is what lets one code path serve both RealFaviconGenerator generations in circulation:

| Generation | Projects | Result |
| --- | --- | --- |
| modern (`favicon.svg`, `favicon-96x96.png`, …) | 20 | SVG + 96px PNG + ico + apple-touch + manifest |
| 2017-era (`favicon-16x16.png`, `safari-pinned-tab.svg`, …) | 6 | 32px PNG + ico + apple-touch + manifest |

A fixed path map would have emitted dead links on those six.

`theme-color` and `apple-mobile-web-app-title` come from the manifest's `theme_color` / `short_name`, so they need no configuration either — which is what lets a consuming theme drop its favicon block from the layout entirely rather than only partly.

## Rejected

- **Removing `$favicon_path`.** No project in the fleet overrides it, but it still drives the off-path, and deleting a `protected` property breaks a consumer silently instead of loudly.
- **`getimagesize()` for PNG `sizes`.** The filename already states them. Opening two files per request to learn what the name says is a poor trade.
- **A `mask-icon` tag** for the `safari-pinned-tab.svg` that 6 projects ship. It needs an author-chosen tint colour no file states; a guessed colour renders worse than no pinned-tab icon.
- **Fixing it in place instead of behind a flag.** Correct per the letter of the bug, wrong per AGENTS.md § Feature flags — it changes rendered output on upgrade.

## Downstream

Nothing changes until a project sets the flag. A follow-up PR in `tailwind-base` / `wordpress-base` drops the favicon block from `templates/layout/layout.twig`; it must land only after this is released, or the window between them leaves a site with no favicon at all.

## Verification

`composer test` 1277 green (7 new tests for the tag set, 3 for both flag branches), `composer phpstan` level 8 clean.
