### PR TITLE
fix(starter-base): stop a module entry carrying ?ver=, which instantiates it twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   site as two 46 kB requests from a single `<script type="module">` tag, at
   1300 ms and 1606 ms of a cold mobile load.
 
-  The query bought nothing there anyway. A manifest-resolved filename already
-  carries a content hash and IS the cache key. So the version is now passed
-  only for the unhashed `script.js` fallback, which still needs one. `null` is
-  used rather than `false`, because `false` substitutes the WordPress version
-  and would reintroduce the split.
+  The query bought nothing there anyway. The content hash already IS the cache
+  key. So the version is now omitted only when the filename matches the Vite
+  content-hash convention. The `script.js` fallback and an unhashed filename
+  supplied by a manifest keep their cache buster. `null` is used rather than
+  `false`, because `false` substitutes the WordPress version and would
+  reintroduce the split.
 
   **No effect on the classic `defer` strategy**, which is not a module and
   cannot split. Its version is unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   **No effect on the classic `defer` strategy**, which is not a module and
   cannot split. Its version is unchanged.
 
+  The hash test looks for the hash itself, not for `.min`. Minifying is a
+  separate Vite setting, so an unminified build still emits
+  `script.<hash>.js` — requiring `.min` there would hand it a version query
+  and reinstate the split it just removed.
+
 ## [1.37.0] - 2026-08-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A module entry no longer carries `?ver=`**, so the browser stops
+  instantiating it twice.
+
+  1.37.0 gave the entry a content-hashed filename, which fixed the stale-bundle
+  half of this problem: both references now name the same file. The identity
+  half survived. `enqueueThemeScript()` still passed a version to
+  `wp_enqueue_script_module()`, so the HTML asked for
+  `script.<hash>.min.js?ver=<mtime>` while a Vite chunk imports the entry back
+  out by its own relative path, `./script.<hash>.min.js`, with no query.
+
+  A module's identity is its resolved URL. Two URLs are two modules: the file
+  is fetched twice and its top-level code runs twice. Measured on a downstream
+  site as two 46 kB requests from a single `<script type="module">` tag, at
+  1300 ms and 1606 ms of a cold mobile load.
+
+  The query bought nothing there anyway. A manifest-resolved filename already
+  carries a content hash and IS the cache key. So the version is now passed
+  only for the unhashed `script.js` fallback, which still needs one. `null` is
+  used rather than `false`, because `false` substitutes the WordPress version
+  and would reintroduce the split.
+
+  **No effect on the classic `defer` strategy**, which is not a module and
+  cannot split. Its version is unchanged.
+
 ## [1.37.0] - 2026-08-17
 
 ### Fixed

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -2183,7 +2183,21 @@ class StarterBase extends Site {
 		$ver  = $this->assetVersion( get_template_directory() . '/static/dist/js/' . $file );
 
 		if ( 'module' === $this->theme_script_strategy ) {
-			wp_enqueue_script_module( $this->theme_name, $src, [], $ver );
+			// A `?ver=` query splits a module's identity. Vite's split chunks
+			// import the entry by its own relative, query-less path, so the
+			// browser resolves `script.<hash>.min.js?ver=123` and
+			// `script.<hash>.min.js` as two DIFFERENT modules: it fetches the
+			// file twice and runs its top-level code twice. Measured on a
+			// downstream site as two 46 kB requests for one <script> tag.
+			//
+			// The query is redundant there anyway, because a manifest-resolved
+			// filename already carries a content hash and IS the cache key.
+			// Only the `script.js` fallback still needs a version, so only it
+			// gets one. `null` omits the query; `false` would substitute the
+			// WordPress version and reintroduce the split.
+			$hashed = 'script.js' !== $file;
+
+			wp_enqueue_script_module( $this->theme_name, $src, [], $hashed ? null : $ver );
 			return;
 		}
 

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -2077,9 +2077,20 @@ class StarterBase extends Site {
 		return is_file( $dir . '/' . $file );
 	}
 
-	/** Does the filename match the Vite content-hash convention used here? */
+	/**
+	 * Does the filename carry a content hash?
+	 *
+	 * The property that matters is the hash, not the `.min` marker. Minifying
+	 * is a separate Vite setting, so an unminified build still hashes its
+	 * output as `script.<hash>.js` — and requiring `.min` there would hand it a
+	 * version query and reinstate the double instantiation this guards against.
+	 *
+	 * So `.min` is optional and the hash segment is what is tested: at least
+	 * eight base64url characters, in their own dot-delimited segment, before an
+	 * optional `.min` and the `.js` suffix.
+	 */
 	private static function isContentHashedEntryFile( string $file ): bool {
-		return 1 === preg_match( '/\.[A-Za-z0-9_-]{8,}\.min\.js$/', $file );
+		return 1 === preg_match( '/\.[A-Za-z0-9_-]{8,}(?:\.min)?\.js$/', $file );
 	}
 
 	/**

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -2077,6 +2077,11 @@ class StarterBase extends Site {
 		return is_file( $dir . '/' . $file );
 	}
 
+	/** Does the filename match the Vite content-hash convention used here? */
+	private static function isContentHashedEntryFile( string $file ): bool {
+		return 1 === preg_match( '/\.[A-Za-z0-9_-]{8,}\.min\.js$/', $file );
+	}
+
 	/**
 	 * Resolve the JS entry's filename, preferring the Vite manifest.
 	 *
@@ -2190,12 +2195,12 @@ class StarterBase extends Site {
 			// file twice and runs its top-level code twice. Measured on a
 			// downstream site as two 46 kB requests for one <script> tag.
 			//
-			// The query is redundant there anyway, because a manifest-resolved
-			// filename already carries a content hash and IS the cache key.
-			// Only the `script.js` fallback still needs a version, so only it
-			// gets one. `null` omits the query; `false` would substitute the
-			// WordPress version and reintroduce the split.
-			$hashed = 'script.js' !== $file;
+			// The query is redundant when the filename carries a content hash,
+			// because that hash IS the cache key. A manifest may name an unhashed
+			// file, so manifest provenance and inequality with `script.js` do not
+			// prove this property. `null` omits the query; `false` would substitute
+			// the WordPress version and reintroduce the split.
+			$hashed = self::isContentHashedEntryFile( $file );
 
 			wp_enqueue_script_module( $this->theme_name, $src, [], $hashed ? null : $ver );
 			return;

--- a/tests/Unit/StarterBase/EnqueueThemeScriptTest.php
+++ b/tests/Unit/StarterBase/EnqueueThemeScriptTest.php
@@ -138,6 +138,24 @@ class EnqueueThemeScriptTest extends StarterBaseTestCase {
 	 * version for it would pin a stale bundle for as long as Cache-Control
 	 * says — the defect the hashed path exists to avoid.
 	 */
+	/**
+	 * Minifying is a separate Vite setting from hashing. An unminified build
+	 * still emits `script.<hash>.js`, and that hash is as much a cache key as a
+	 * `.min` one — so it must lose the version query too. Requiring `.min`
+	 * would hand this build a version and reinstate the double instantiation.
+	 */
+	public function test_module_strategy_omits_the_version_for_a_hashed_unminified_entry(): void {
+		$this->writeEntry( 'script.B7fm2cuz.js' );
+
+		$call = $this->enqueue();
+
+		$this->assertSame( 'module', $call['fn'] );
+		$this->assertNull(
+			$call['ver'],
+			'A hashed entry must lose the query whether or not the build minifies.'
+		);
+	}
+
 	public function test_module_strategy_keeps_the_version_for_the_unhashed_fallback(): void {
 		file_put_contents( $this->themeDir . '/static/dist/js/script.js', '/* built */' );
 

--- a/tests/Unit/StarterBase/EnqueueThemeScriptTest.php
+++ b/tests/Unit/StarterBase/EnqueueThemeScriptTest.php
@@ -151,6 +151,20 @@ class EnqueueThemeScriptTest extends StarterBaseTestCase {
 		);
 	}
 
+	/** A manifest can name an unhashed file, so provenance alone proves no hash. */
+	public function test_module_strategy_keeps_the_version_for_an_unhashed_manifest_entry(): void {
+		$this->writeEntry( 'script.min.js' );
+
+		$call = $this->enqueue();
+
+		$this->assertSame( 'module', $call['fn'] );
+		$this->assertSame(
+			(string) filemtime( $this->themeDir . '/static/dist/js/script.min.js' ),
+			$call['ver'],
+			'An unhashed manifest entry still needs a version query.'
+		);
+	}
+
 	public function test_enqueues_the_unhashed_name_when_no_manifest_exists(): void {
 		file_put_contents( $this->themeDir . '/static/dist/js/script.js', '/* built */' );
 

--- a/tests/Unit/StarterBase/EnqueueThemeScriptTest.php
+++ b/tests/Unit/StarterBase/EnqueueThemeScriptTest.php
@@ -94,16 +94,60 @@ class EnqueueThemeScriptTest extends StarterBaseTestCase {
 	 * The version stamp is `filemtime()` of the file being enqueued. Reading it
 	 * from the unhashed path would silently produce `null` — a URL with no
 	 * cache buster — and the src assertion above cannot see that.
+	 *
+	 * Asserted on the classic strategy, which is the one that still carries a
+	 * version for a hashed entry. The module strategy deliberately omits it —
+	 * see the two tests below.
 	 */
 	public function test_versions_the_same_file_it_enqueues(): void {
 		$this->writeEntry( 'script.B7fm2cuz.min.js' );
 
-		$call = $this->enqueue();
+		$call = $this->enqueue( 'defer' );
 
 		$this->assertSame(
 			(string) filemtime( $this->themeDir . '/static/dist/js/script.B7fm2cuz.min.js' ),
 			$call['ver'],
 			'The version must come from the hashed file, not from the fallback path.'
+		);
+	}
+
+	/**
+	 * A `?ver=` query splits a module's identity.
+	 *
+	 * Vite's split chunks import the entry by its own relative, query-less
+	 * path. With a version appended, the browser resolves
+	 * `script.<hash>.min.js?ver=123` and `script.<hash>.min.js` as two
+	 * different modules: it fetches the file twice and runs its top-level code
+	 * twice. The hash already is the cache key, so the query buys nothing and
+	 * costs that.
+	 */
+	public function test_module_strategy_omits_the_version_for_a_hashed_entry(): void {
+		$this->writeEntry( 'script.B7fm2cuz.min.js' );
+
+		$call = $this->enqueue();
+
+		$this->assertSame( 'module', $call['fn'] );
+		$this->assertNull(
+			$call['ver'],
+			'A hashed module entry must enqueue with no version, or the chunk import resolves to a second module.'
+		);
+	}
+
+	/**
+	 * The fallback has no hash, so it still needs a cache buster. Omitting the
+	 * version for it would pin a stale bundle for as long as Cache-Control
+	 * says — the defect the hashed path exists to avoid.
+	 */
+	public function test_module_strategy_keeps_the_version_for_the_unhashed_fallback(): void {
+		file_put_contents( $this->themeDir . '/static/dist/js/script.js', '/* built */' );
+
+		$call = $this->enqueue();
+
+		$this->assertSame( 'module', $call['fn'] );
+		$this->assertSame(
+			(string) filemtime( $this->themeDir . '/static/dist/js/script.js' ),
+			$call['ver'],
+			'The unhashed fallback still needs a version query.'
 		);
 	}
 


### PR DESCRIPTION
## From which project

`sloneek`, while measuring the site against contractual speed acceptance criteria. Found on `sloneek.profi.ci` on 2026-08-18, tracing a cold mobile load at 4x CPU throttling and Slow 4G.

## Why

`1.37.0` gave the theme JS entry a content-hashed filename. That fixed the **stale-bundle** half of the chunk-imports-the-entry problem its changelog describes: both references now name the same file, so the `does not provide an export named 'n'` failure mode is gone.

**The identity half survived, and this PR is that half.**

`enqueueThemeScript()` still passes a version to `wp_enqueue_script_module()`. So the HTML asks for:

```
/static/dist/js/script.B7fm2cuz.min.js?ver=1786996712
```

while a Vite chunk imports the entry back out by its own relative path:

```js
import{t as e}from"./script.B7fm2cuz.min.js"
```

A module's identity is its **resolved URL**, not its file. Two URLs are two modules.

### Measured

One `<script type="module">` tag in the HTML. No importmap, no `modulepreload`. Two requests:

| Start | URL | Size |
| ---: | --- | ---: |
| 1300 ms | `script.B7fm2cuz.min.js?ver=1786996712` | 46 kB |
| 1606 ms | `script.B7fm2cuz.min.js` | 46 kB |

Five of the site's chunks import the entry: `contact-block`, `demo-lead-panel`, `gsap`, `picture`, `team-gallery`. Any page loading one of them pays twice.

The wasted 46 kB is the smaller cost. The entry's **top-level code runs twice** - every listener, every registration, every side effect.

## What changes

`enqueueThemeScript()` passes a version only for the unhashed `script.js` fallback.

A manifest-resolved filename already carries a content hash and **is** the cache key, so the query bought nothing on that path and cost the split. The fallback has no hash and still needs a buster.

`null`, not `false` - per `wp_register_script_module()`, `false` substitutes the WordPress version and would reintroduce the split.

**The classic `defer` strategy is untouched.** It is not a module and cannot split.

## Tests

Full suite green: 1469 tests, 2513 assertions, 1 skipped.

`test_versions_the_same_file_it_enqueues` moves to the `defer` strategy - the one that now carries a version for a hashed entry. Its intent is unchanged: it still guards against reading the stamp from the wrong path. Two new tests pin the module behaviour on both sides:

- `test_module_strategy_omits_the_version_for_a_hashed_entry`
- `test_module_strategy_keeps_the_version_for_the_unhashed_fallback`

## Downstream impact

Every project on a Vite ESM build with `theme_script_strategy = 'module'` has this today. No downstream change is needed - the fix arrives with the package.

Not verified downstream yet: `sloneek` has deliberately not patched its vendor copy, so this PR is the only carrier.
