### PR TITLE
docs(changelog): finalize 1.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.39.0] - 2026-08-24
+
 ### Changed
 
 - Everything that knows about the Breeze plugin now lives under


### PR DESCRIPTION
Cuts 1.39.0 over the two Breeze warmup changes already on `main`: #134 (order the preload list by importance) and #137 (move Breeze code under `src/Breeze`).

No code changes — this only stamps the `[Unreleased]` section with a version and a date, the same shape as 9766ccc did for 1.38.0.

## Why now

The ordering in #134 is the difference between the feature working and not working, measured on a real site rather than argued. On `sloneek` (2873 sitemap URLs, five languages, 10 sub-sitemaps), the pre-#134 behaviour spends the whole 200-URL cap inside the first sub-sitemap:

| Page | before #134 | with #134 |
| --- | --- | --- |
| `/blog/` | 261 — missed | **17** |
| `/sk/`, `/it/`, `/pl/` blog | 262–264 — missed | **18–20** |
| 53 category archives | unreachable (last sub-sitemap) | **27–30** |
| `/pricing/` | 64 | 7 |

Those are the site's most expensive pages: 4.0–4.4 s cold TTFB against 0.07 s warm. Without ordering, the cap warmed 200 cheap pages and left every expensive one cold — which is why the flag read as pointless before this landed.

Simulated by applying the weights `StarterBase` declares on `main` to the site's real sitemap, `lastmod` dates, 262 menu targets and Breeze's own manual list.

## One thing the measurement also showed

Category archives score only through Breeze's **manual list** (weight 800). They are in no menu, are not a homepage, and their `lastmod` is old — so with the manual list absent they fall to position ~2864 of 2873. That list lives in a `wp_options` row, so a database import wipes it.

Not a blocker for this release, and not something #134 claims to solve. Worth recording as the gap: a code-side curated list (`$breeze_warmup_urls`, scored like `manual`) would be the missing link, since the kit currently has no property or filter for explicit URLs — `SignalCollector::manualKeys()` reads the admin row.

## Verification

`main` is green (PHP 8.3, PHP 8.4, PHPStan, composer hygiene). Locally: 1627 tests, 2707 assertions, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMYy6JHLf4mU4H4Hd47spb