### PR TITLE
feat(warmup): a curated warmup list that lives in code, not in wp-admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   relative path is correct on every environment and, under domain-per-language,
   on that language's own host. An entry that resolves to nothing is dropped, and
   what `url_to_postid()` cannot see is verified with one `HEAD` during the cron
-  refresh — never on the purge path.
+  refresh — never on the purge path. Filterable as
+  `timberkit_warmup_curated_urls`, its cap as
+  `timberkit_warmup_curated_max_entries`.
 - `Helpers::isSiteUrl()` / `Helpers::siteHosts()` — whether a URL belongs to this
   site, matching host **and** port, and counting each WPML language's own host
   under domain-per-language negotiation.
@@ -43,6 +45,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   not know yet and for a site serving its sitemap from a non-default path. A
   non-string return, or a URL on another host, is ignored in favour of the
   detected path.
+
+### Changed
+
+- The warmup refresh no longer returns early when the sitemap is empty or
+  unreachable. Curated entries are added first, so a project that names its
+  pages explicitly still gets them warmed in exactly the situation where the
+  sitemap cannot help. On a site with no curated entries this changes nothing;
+  on one with them, a refresh that used to no-op now does work.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- `Helpers::formatLink()` no longer replaces a valid link with an empty string.
+  `get_permalink()` answers `false` for a trashed post or a stale WPML
+  translation id, and the concatenations after it coerced that to `''` — so a
+  working URL silently became `''` or a bare `?query`.
 - `Helpers::extract_slug_from_url()` no longer fatals when `wpml_active_languages`
   answers with `null` while the plugin is active — `array_keys( null )` is a
   TypeError, and WPML returns null before it has finished booting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   on that language's own host. An entry that resolves to nothing is dropped, and
   what `url_to_postid()` cannot see is verified with one `HEAD` during the cron
   refresh — never on the purge path.
+- `Helpers::isSiteUrl()` / `Helpers::siteHosts()` — whether a URL belongs to this
+  site, matching host **and** port, and counting each WPML language's own host
+  under domain-per-language negotiation.
 - `Helpers::urlToPostId()` — URL to post ID with the WPML prefix fallback and
   `wpml_object_id` translation. `formatLink()` had this logic privately;
   `Breadcrumb` and the new warmup list needed the same, so it is one function now
@@ -49,6 +52,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - `Breadcrumb` now resolves language-prefixed URLs. It called `url_to_postid()`
   directly, which returns 0 for a valid `/cs/…` URL, so those global links were
   silently dropped from the trail.
+- The WPML prefix fallback no longer lets a foreign URL borrow a local path.
+  It compares paths, so `https://someone-else.test/about/` matched this site's
+  own About page and was rewritten to a local permalink — in `formatLink()`,
+  where the fallback has lived for years, and in `Breadcrumb`.
 - The same-host guard compared the hostname and ignored the **port**, so a
   sitemap index entry — or a filter callback — pointing at
   `https://<own-host>:9200/` passed it and was fetched. An internal service

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- `$breeze_warmup_urls` — a curated warmup list that lives in the theme instead
+  of in Breeze's settings row. Merges into the existing `manual` signal at the
+  weight it already carries; no new tier, no change to ordering or the cap.
+  Entries may be relative paths or absolute URLs, and both are resolved rather
+  than trusted: one naming a post or page comes back as `get_permalink()`, so a
+  relative path is correct on every environment and, under domain-per-language,
+  on that language's own host. An entry that resolves to nothing is dropped, and
+  what `url_to_postid()` cannot see is verified with one `HEAD` during the cron
+  refresh — never on the purge path.
+- `Helpers::urlToPostId()` — URL to post ID with the WPML prefix fallback and
+  `wpml_object_id` translation. `formatLink()` had this logic privately;
+  `Breadcrumb` and the new warmup list needed the same, so it is one function now
+  and both call sites use it.
 - `Breeze\WarmupSitemap` recognises **Yoast SEO** and asks for
   `/sitemap_index.xml`. Providers are now a list checked in order — AIOSEO,
   Yoast, core — so a project gets the right sitemap from whichever plugin it
@@ -30,6 +43,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- `Helpers::extract_slug_from_url()` no longer fatals when `wpml_active_languages`
+  answers with `null` while the plugin is active — `array_keys( null )` is a
+  TypeError, and WPML returns null before it has finished booting.
+- `Breadcrumb` now resolves language-prefixed URLs. It called `url_to_postid()`
+  directly, which returns 0 for a valid `/cs/…` URL, so those global links were
+  silently dropped from the trail.
 - The same-host guard compared the hostname and ignored the **port**, so a
   sitemap index entry — or a filter callback — pointing at
   `https://<own-host>:9200/` passed it and was fetched. An internal service

--- a/README.md
+++ b/README.md
@@ -708,6 +708,49 @@ fresh. The signal is free — it is already in the XML we parse — and
 resolving real publication dates would mean matching URLs back to posts
 through WPML and custom permalinks.
 
+### Naming pages yourself
+
+The scorer treats Breeze's own manual list as a strong signal, but that list
+lives in a `wp_options` row: it cannot be reviewed, carries no reason for any
+entry, differs per environment by accident, and a database import wipes it —
+after which the site quietly stops warming what mattered.
+
+`$breeze_warmup_urls` is the same signal, kept in the theme:
+
+```php
+protected array $breeze_warmup_urls = array(
+    '/blog/',
+    '/cs/blog/',
+    'https://example.de/blog/',
+);
+```
+
+It merges into `manual` at the weight that source already carries. It adds an
+input, not a tier: ordering, weights and the cap are untouched.
+
+**Relative or absolute, and the difference matters.** A relative path is right
+most of the time — the same code runs on ddev, on staging and in production, and
+an absolute URL would be silently wrong on two of the three. An absolute URL is
+needed when the target is not on `home_url()`'s host at all, which under WPML's
+domain-per-language negotiation is every language but the default.
+
+Both are resolved rather than trusted. An entry naming a post or a page becomes
+its ID and comes back as `get_permalink()`, so what is stored is this
+environment's own URL in this environment's own language. **An entry that
+resolves to nothing is dropped**, so a deleted page stops being warmed without
+anyone having to remember the list exists.
+
+`url_to_postid()` cannot see term archives, so those are kept as URLs and
+verified with one `HEAD` during the cron refresh — never on the purge path,
+which runs while an editor waits for a save. A probe that fails outright keeps
+the entry: one flaky lookup must not empty a curated list.
+
+Filterable as `timberkit_warmup_curated_urls`, and its 200-entry cap as
+`timberkit_warmup_curated_max_entries`, for projects that keep configuration in
+an mu-plugin rather than in the theme subclass. Unlike the weights filter this
+one need not be pure — nothing fingerprints it — but a change is picked up at
+the next refresh rather than the next purge.
+
 **The cap is not the whole cost.** `timberkit_warmup_sitemap_max_urls`
 (default 200) applies only to sitemap-sourced URLs. Entries Breeze itself
 supplies are warmed on top of it, and every language's homepage and menu

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -444,9 +444,9 @@ class Breadcrumb {
 
 		foreach ( $links as $key => $item ) {
 			if ( is_string( $item ) && ! empty( $item ) ) {
-				$post_id = url_to_postid( $item );
+				$post_id = Helpers::urlToPostId( $item );
 				if ( $post_id ) {
-					$translated_id = (int) apply_filters( 'wpml_object_id', $post_id, 'page' );
+					$translated_id = $post_id;
 					$data[ $key ] = [
 						'id'    => $translated_id,
 						'title' => '',
@@ -454,9 +454,9 @@ class Breadcrumb {
 					];
 				}
 			} elseif ( is_array( $item ) && isset( $item['url'] ) ) {
-				$post_id = url_to_postid( $item['url'] );
+				$post_id = Helpers::urlToPostId( $item['url'] );
 				if ( $post_id ) {
-					$translated_id = (int) apply_filters( 'wpml_object_id', $post_id, 'page' );
+					$translated_id = $post_id;
 					$url = get_permalink( $translated_id );
 				} else {
 					$translated_id = 0;

--- a/src/Breeze/CuratedUrls.php
+++ b/src/Breeze/CuratedUrls.php
@@ -46,6 +46,19 @@ final class CuratedUrls {
 	private const PROBE_TIMEOUT = 5;
 
 	/**
+	 * @var int Wall-clock budget, in seconds, for all probes in one refresh.
+	 *
+	 * Entry count alone does not bound the cost: 200 entries pointed at a slow
+	 * host is 200 x PROBE_TIMEOUT serially. A max_execution_time fatal is not a
+	 * Throwable, so it walks past runRefresh()'s catch AND its finally — the
+	 * refresh vanishes mid-run and the lock is left to expire on its own TTL.
+	 * Stopping early keeps the entries not yet reached rather than treating
+	 * them as dead, which is the same stale-beats-nothing rule as a failed
+	 * probe.
+	 */
+	private const PROBE_BUDGET = 20;
+
+	/**
 	 * Canonical keys for a project's curated list.
 	 *
 	 * @param array<int, mixed> $entries Raw `$breeze_warmup_urls` value.
@@ -156,9 +169,18 @@ final class CuratedUrls {
 			return array_fill_keys( array_keys( $keys ), true );
 		}
 
-		$kept = array();
+		$kept     = array();
+		$deadline = time() + self::PROBE_BUDGET;
+
 		foreach ( $keys as $key => $needs_probe ) {
 			if ( ! $needs_probe ) {
+				$kept[ $key ] = true;
+				continue;
+			}
+
+			// Out of budget: keep the rest unprobed rather than spend a refresh
+			// finding out, or die trying.
+			if ( time() >= $deadline ) {
 				$kept[ $key ] = true;
 				continue;
 			}
@@ -179,12 +201,26 @@ final class CuratedUrls {
 				? (int) wp_remote_retrieve_response_code( $response )
 				: 0;
 
-			// 3xx counts: a curated entry pointing at a redirect still warms the
-			// hop the visitor takes, and dropping it would punish a trailing
-			// slash. 4xx and 5xx are what this exists to remove.
-			if ( 0 === $code || ( $code >= 200 && $code < 400 ) ) {
-				$kept[ $key ] = true;
+			// Drop only what is definitively gone. This probe exists to remove
+			// a URL whose page was deleted -- it is not qualified to judge
+			// anything else, and every other reading of a status code costs a
+			// page the project explicitly asked for.
+			//
+			// 405 in particular: a term archive behind a WAF or a security
+			// plugin that refuses the HEAD verb is a perfectly live page, and
+			// dropping it would be the exact failure this file's own comment
+			// claims to avoid -- that comment guarded the post-ID path and left
+			// this one open. 401/403 are the same shape: authorisation says
+			// nothing about existence, and a warmer is not logged in.
+			//
+			// 5xx is excluded from the drop list too. A server erroring today
+			// is not a page deleted, and dropping on it would empty a curated
+			// list during an outage -- precisely when nothing should change.
+			if ( 404 === $code || 410 === $code ) {
+				continue;
 			}
+
+			$kept[ $key ] = true;
 		}
 
 		return $kept;

--- a/src/Breeze/CuratedUrls.php
+++ b/src/Breeze/CuratedUrls.php
@@ -49,7 +49,8 @@ final class CuratedUrls {
 	 * Canonical keys for a project's curated list.
 	 *
 	 * @param array<int, mixed> $entries Raw `$breeze_warmup_urls` value.
-	 * @return array<string, true> Canonical keys, keyed for merging.
+	 * @return array<string, bool> Canonical key => whether it still needs a
+	 *                             reachability probe.
 	 */
 	public static function keys( array $entries ): array {
 		$keys  = array();
@@ -75,7 +76,7 @@ final class CuratedUrls {
 				continue;
 			}
 
-			$keys[ UrlCanonicalizer::canonicalize( $url ) ] = true;
+			$keys[ UrlCanonicalizer::canonicalize( $url[0] ) ] = $url[1];
 		}
 
 		return $keys;
@@ -85,9 +86,10 @@ final class CuratedUrls {
 	 * One entry to a URL on this site, or null when it names nothing here.
 	 *
 	 * @param string $entry Relative path or absolute URL.
-	 * @return string|null
+	 * @return array{0: string, 1: bool}|null URL, and whether existence still
+	 *                                        needs proving with a request.
 	 */
-	public static function resolve( string $entry ): ?string {
+	public static function resolve( string $entry ): ?array {
 		$absolute = self::toAbsolute( $entry );
 		if ( null === $absolute ) {
 			return null;
@@ -100,13 +102,16 @@ final class CuratedUrls {
 		if ( $post_id > 0 ) {
 			$permalink = function_exists( 'get_permalink' ) ? get_permalink( $post_id ) : false;
 			if ( is_string( $permalink ) && '' !== $permalink ) {
-				return $permalink;
+				// A post ID settles existence. Probing anyway would spend a
+				// request per entry per refresh and, worse, drop a page that
+				// answers 405 to HEAD while serving GET perfectly well.
+				return array( $permalink, false );
 			}
 		}
 
 		// Term archives and anything else url_to_postid() cannot see. Kept only
 		// if it is on a host this site actually serves.
-		return self::isOwnHost( $absolute ) ? $absolute : null;
+		return \Parisek\TimberKit\Helpers::isSiteUrl( $absolute ) ? array( $absolute, true ) : null;
 	}
 
 	/**
@@ -121,22 +126,25 @@ final class CuratedUrls {
 	 * worse: one flaky DNS lookup would silently empty a curated list, and
 	 * `runRefresh()` is built on stale-beats-nothing everywhere else too.
 	 *
-	 * @param array<string, true> $keys Canonical keys from {@see self::keys()}.
+	 * @param array<string, bool> $keys Canonical key => needs a probe.
 	 * @return array<string, true>
 	 */
 	public static function filterReachable( array $keys ): array {
 		if ( ! function_exists( 'wp_remote_head' ) ) {
-			return $keys;
+			return array_fill_keys( array_keys( $keys ), true );
 		}
 
 		$kept = array();
-		foreach ( $keys as $key => $flag ) {
+		foreach ( $keys as $key => $needs_probe ) {
+			if ( ! $needs_probe ) {
+				$kept[ $key ] = true;
+				continue;
+			}
 			$response = wp_remote_head(
 				$key,
 				array(
 					'timeout'     => self::PROBE_TIMEOUT,
 					'redirection' => 0,
-					'sslverify'   => false,
 				)
 			);
 
@@ -183,57 +191,5 @@ final class CuratedUrls {
 		}
 
 		return home_url( '/' . ltrim( $entry, '/' ) );
-	}
-
-	/**
-	 * Whether a URL is on a host this site serves.
-	 *
-	 * `home_url()` alone is not the answer under domain-per-language: every
-	 * language but the default one lives somewhere else, and treating those as
-	 * foreign would refuse exactly the entries an absolute URL exists to write.
-	 *
-	 * @param string $url Absolute URL.
-	 * @return bool
-	 */
-	private static function isOwnHost( string $url ): bool {
-		$host = strtolower( (string) ( parse_url( $url, PHP_URL_HOST ) ?: '' ) );
-		if ( '' === $host ) {
-			return false;
-		}
-
-		return in_array( $host, self::ownHosts(), true );
-	}
-
-	/**
-	 * Every host this site answers on: `home_url()` plus each active language's.
-	 *
-	 * @return array<int, string>
-	 */
-	private static function ownHosts(): array {
-		$hosts = array();
-
-		if ( function_exists( 'home_url' ) ) {
-			$host = strtolower( (string) ( parse_url( (string) home_url(), PHP_URL_HOST ) ?: '' ) );
-			if ( '' !== $host ) {
-				$hosts[] = $host;
-			}
-		}
-
-		if ( function_exists( 'apply_filters' ) ) {
-			$languages = apply_filters( 'wpml_active_languages', null, array( 'skip_missing' => false ) );
-			if ( is_array( $languages ) ) {
-				foreach ( $languages as $language ) {
-					if ( ! is_array( $language ) || empty( $language['url'] ) ) {
-						continue;
-					}
-					$host = strtolower( (string) ( parse_url( (string) $language['url'], PHP_URL_HOST ) ?: '' ) );
-					if ( '' !== $host && ! in_array( $host, $hosts, true ) ) {
-						$hosts[] = $host;
-					}
-				}
-			}
-		}
-
-		return $hosts;
 	}
 }

--- a/src/Breeze/CuratedUrls.php
+++ b/src/Breeze/CuratedUrls.php
@@ -39,8 +39,8 @@ namespace Parisek\TimberKit\Breeze;
  */
 final class CuratedUrls {
 
-	/** @var int Cap on entries accepted from a project, before resolution. */
-	private const MAX_ENTRIES = 200;
+	/** @var int Default cap on entries accepted from a project, before resolution. */
+	private const DEFAULT_MAX_ENTRIES = 200;
 
 	/** @var int Timeout, in seconds, for one reachability probe. */
 	private const PROBE_TIMEOUT = 5;
@@ -53,11 +53,33 @@ final class CuratedUrls {
 	 *                             reachability probe.
 	 */
 	public static function keys( array $entries ): array {
+		// Filterable for the same reason every other knob in this subsystem is:
+		// a project may keep its config in an mu-plugin rather than in the theme
+		// subclass, and without this the curated list would be the one warmup
+		// setting unreachable from there.
+		//
+		// Unlike `timberkit_warmup_priority_weights` this does not have to be a
+		// pure function — nothing fingerprints it. The cost of that is a delay:
+		// a changed list is picked up at the next refresh, within CACHE_TTL,
+		// not on the next purge.
+		if ( function_exists( 'apply_filters' ) ) {
+			$filtered = apply_filters( 'timberkit_warmup_curated_urls', $entries );
+			if ( is_array( $filtered ) ) {
+				$entries = $filtered;
+			}
+		}
+
+		$max = self::DEFAULT_MAX_ENTRIES;
+		if ( function_exists( 'apply_filters' ) ) {
+			$candidate = apply_filters( 'timberkit_warmup_curated_max_entries', $max );
+			$max       = is_numeric( $candidate ) ? max( 0, (int) $candidate ) : $max;
+		}
+
 		$keys  = array();
 		$count = 0;
 
 		foreach ( $entries as $entry ) {
-			if ( $count >= self::MAX_ENTRIES ) {
+			if ( $count >= $max ) {
 				break;
 			}
 			if ( ! is_string( $entry ) ) {

--- a/src/Breeze/CuratedUrls.php
+++ b/src/Breeze/CuratedUrls.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit\Breeze;
+
+/**
+ * Resolves a project's hand-written warmup list into canonical URL keys.
+ *
+ * The scorer has always had `manual` as a source, but its only input was
+ * Breeze's own settings row — so the one curated signal in the model was the one
+ * signal a project could not put in git. This turns a `StarterBase` property
+ * into the same keys, and the two merge: a project may use either, or both.
+ *
+ * Entries may be written either way, and the reason is not convenience:
+ *
+ * - A **relative path** (`/blog/`) is what a project wants most of the time. The
+ *   same code runs on ddev, on staging and on production, and an absolute URL
+ *   would be silently wrong on two of the three — rejected as off-host, warming
+ *   nothing, reporting nothing.
+ * - An **absolute URL** is what a project needs when the target is not on
+ *   `home_url()`'s host at all, which under WPML's domain-per-language
+ *   negotiation is every language but the default one.
+ *
+ * Both are resolved rather than trusted. An entry that names a post or a page
+ * is turned into its ID and back into `get_permalink()`, so what gets stored is
+ * this environment's own correct URL in this environment's own language —
+ * which is what makes accepting a relative path safe rather than merely
+ * convenient. It is the pattern `Breadcrumb::get_global_links()` already uses.
+ *
+ * An entry that resolves to nothing is dropped. A deleted page stops being
+ * warmed without anyone having to remember the list exists, and a typo warms a
+ * 404 zero times instead of on every cycle.
+ *
+ * `url_to_postid()` does not see term archives, so those cannot be resolved this
+ * way and are kept as URLs, host-checked. Whether they still exist is settled by
+ * {@see self::filterReachable()}, which the refresh calls — off the purge path,
+ * where a request is affordable.
+ */
+final class CuratedUrls {
+
+	/** @var int Cap on entries accepted from a project, before resolution. */
+	private const MAX_ENTRIES = 200;
+
+	/** @var int Timeout, in seconds, for one reachability probe. */
+	private const PROBE_TIMEOUT = 5;
+
+	/**
+	 * Canonical keys for a project's curated list.
+	 *
+	 * @param array<int, mixed> $entries Raw `$breeze_warmup_urls` value.
+	 * @return array<string, true> Canonical keys, keyed for merging.
+	 */
+	public static function keys( array $entries ): array {
+		$keys  = array();
+		$count = 0;
+
+		foreach ( $entries as $entry ) {
+			if ( $count >= self::MAX_ENTRIES ) {
+				break;
+			}
+			if ( ! is_string( $entry ) ) {
+				continue;
+			}
+
+			$entry = trim( $entry );
+			if ( '' === $entry ) {
+				continue;
+			}
+
+			++$count;
+
+			$url = self::resolve( $entry );
+			if ( null === $url ) {
+				continue;
+			}
+
+			$keys[ UrlCanonicalizer::canonicalize( $url ) ] = true;
+		}
+
+		return $keys;
+	}
+
+	/**
+	 * One entry to a URL on this site, or null when it names nothing here.
+	 *
+	 * @param string $entry Relative path or absolute URL.
+	 * @return string|null
+	 */
+	public static function resolve( string $entry ): ?string {
+		$absolute = self::toAbsolute( $entry );
+		if ( null === $absolute ) {
+			return null;
+		}
+
+		// A post or page resolves to an ID, and the ID back to a permalink. The
+		// round trip is the point: it returns this environment's URL, in this
+		// language, whatever was written.
+		$post_id = \Parisek\TimberKit\Helpers::urlToPostId( $absolute );
+		if ( $post_id > 0 ) {
+			$permalink = function_exists( 'get_permalink' ) ? get_permalink( $post_id ) : false;
+			if ( is_string( $permalink ) && '' !== $permalink ) {
+				return $permalink;
+			}
+		}
+
+		// Term archives and anything else url_to_postid() cannot see. Kept only
+		// if it is on a host this site actually serves.
+		return self::isOwnHost( $absolute ) ? $absolute : null;
+	}
+
+	/**
+	 * Drop entries that do not answer, one request each.
+	 *
+	 * Only for what {@see self::resolve()} could not turn into a permalink — a
+	 * post ID is proof enough on its own. Called from the refresh, never from
+	 * the purge-time filter: that one runs while an editor waits for the page to
+	 * save and must not touch the network.
+	 *
+	 * A request that fails outright is treated as reachable. The alternative is
+	 * worse: one flaky DNS lookup would silently empty a curated list, and
+	 * `runRefresh()` is built on stale-beats-nothing everywhere else too.
+	 *
+	 * @param array<string, true> $keys Canonical keys from {@see self::keys()}.
+	 * @return array<string, true>
+	 */
+	public static function filterReachable( array $keys ): array {
+		if ( ! function_exists( 'wp_remote_head' ) ) {
+			return $keys;
+		}
+
+		$kept = array();
+		foreach ( $keys as $key => $flag ) {
+			$response = wp_remote_head(
+				$key,
+				array(
+					'timeout'     => self::PROBE_TIMEOUT,
+					'redirection' => 0,
+					'sslverify'   => false,
+				)
+			);
+
+			if ( function_exists( 'is_wp_error' ) && is_wp_error( $response ) ) {
+				$kept[ $key ] = true;
+				continue;
+			}
+
+			$code = function_exists( 'wp_remote_retrieve_response_code' )
+				? (int) wp_remote_retrieve_response_code( $response )
+				: 0;
+
+			// 3xx counts: a curated entry pointing at a redirect still warms the
+			// hop the visitor takes, and dropping it would punish a trailing
+			// slash. 4xx and 5xx are what this exists to remove.
+			if ( 0 === $code || ( $code >= 200 && $code < 400 ) ) {
+				$kept[ $key ] = true;
+			}
+		}
+
+		return $kept;
+	}
+
+	/**
+	 * A written entry as an absolute URL, or null when it is neither.
+	 *
+	 * @param string $entry Relative path or absolute URL.
+	 * @return string|null
+	 */
+	private static function toAbsolute( string $entry ): ?string {
+		if ( preg_match( '#^https?://#i', $entry ) ) {
+			return $entry;
+		}
+
+		// Anything else is treated as a path. A scheme-relative `//host/path`
+		// is refused rather than guessed at: it reads as a path and behaves as
+		// a host, and that ambiguity has no safe default here.
+		if ( str_starts_with( $entry, '//' ) ) {
+			return null;
+		}
+
+		if ( ! function_exists( 'home_url' ) ) {
+			return null;
+		}
+
+		return home_url( '/' . ltrim( $entry, '/' ) );
+	}
+
+	/**
+	 * Whether a URL is on a host this site serves.
+	 *
+	 * `home_url()` alone is not the answer under domain-per-language: every
+	 * language but the default one lives somewhere else, and treating those as
+	 * foreign would refuse exactly the entries an absolute URL exists to write.
+	 *
+	 * @param string $url Absolute URL.
+	 * @return bool
+	 */
+	private static function isOwnHost( string $url ): bool {
+		$host = strtolower( (string) ( parse_url( $url, PHP_URL_HOST ) ?: '' ) );
+		if ( '' === $host ) {
+			return false;
+		}
+
+		return in_array( $host, self::ownHosts(), true );
+	}
+
+	/**
+	 * Every host this site answers on: `home_url()` plus each active language's.
+	 *
+	 * @return array<int, string>
+	 */
+	private static function ownHosts(): array {
+		$hosts = array();
+
+		if ( function_exists( 'home_url' ) ) {
+			$host = strtolower( (string) ( parse_url( (string) home_url(), PHP_URL_HOST ) ?: '' ) );
+			if ( '' !== $host ) {
+				$hosts[] = $host;
+			}
+		}
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$languages = apply_filters( 'wpml_active_languages', null, array( 'skip_missing' => false ) );
+			if ( is_array( $languages ) ) {
+				foreach ( $languages as $language ) {
+					if ( ! is_array( $language ) || empty( $language['url'] ) ) {
+						continue;
+					}
+					$host = strtolower( (string) ( parse_url( (string) $language['url'], PHP_URL_HOST ) ?: '' ) );
+					if ( '' !== $host && ! in_array( $host, $hosts, true ) ) {
+						$hosts[] = $host;
+					}
+				}
+			}
+		}
+
+		return $hosts;
+	}
+}

--- a/src/Breeze/WarmupSitemap.php
+++ b/src/Breeze/WarmupSitemap.php
@@ -362,11 +362,15 @@ final class WarmupSitemap {
 			$revision = PriorityStore::revision();
 			$records  = self::fetchSitemapRecords();
 
+			// No early return on an empty sitemap: enrichRecords() adds the
+			// curated entries, and a project that lists them explicitly should
+			// still get them warmed when the sitemap is missing or broken --
+			// which is exactly when it matters most.
+			$records = self::enrichRecords( $records );
+
 			if ( array() === $records ) {
 				return;
 			}
-
-			$records = self::enrichRecords( $records );
 			$weights = self::weights();
 			$built   = self::buildOrderedUrls( $records, $weights, time(), self::maxUrls() );
 
@@ -431,6 +435,12 @@ final class WarmupSitemap {
 		$manual     = SignalCollector::manualKeys() + CuratedUrls::filterReachable( CuratedUrls::keys( self::$curated ) );
 		$languages  = SignalCollector::activeLanguages();
 
+		// A curated entry that the sitemap does not carry has to become a
+		// record, not merely a flag on one. Flagging alone would mean the whole
+		// point of a curated list -- naming a page the sitemap ranks badly or
+		// omits entirely -- silently did nothing.
+		$records = self::appendMissingManual( $records, $manual );
+
 		foreach ( $records as $i => $record ) {
 			$key = (string) $record['key'];
 
@@ -445,6 +455,46 @@ final class WarmupSitemap {
 					$languages['codes'],
 					$languages['default']
 				);
+		}
+
+		return $records;
+	}
+
+	/**
+	 * Add records for curated keys the sitemap did not supply.
+	 *
+	 * `lastmod` is null on purpose: nothing is known about when the page
+	 * changed, and inventing a date would hand it a freshness score it has not
+	 * earned. It still outranks most of the sitemap through the `manual` weight
+	 * alone, which is the intent.
+	 *
+	 * @param array<int, array<string, mixed>> $records Records from the sitemap.
+	 * @param array<string, bool>              $manual  Curated + Breeze keys. Only
+	 *                                                  the keys are read.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private static function appendMissingManual( array $records, array $manual ): array {
+		if ( array() === $manual ) {
+			return $records;
+		}
+
+		$known = array();
+		foreach ( $records as $record ) {
+			$known[ (string) $record['key'] ] = true;
+		}
+
+		foreach ( $manual as $key => $flag ) {
+			if ( isset( $known[ $key ] ) ) {
+				continue;
+			}
+
+			$records[] = array(
+				'url'     => (string) $key,
+				'key'     => (string) $key,
+				'lastmod' => null,
+				'type'    => '',
+				'source'  => 'curated',
+			);
 		}
 
 		return $records;

--- a/src/Breeze/WarmupSitemap.php
+++ b/src/Breeze/WarmupSitemap.php
@@ -465,8 +465,19 @@ final class WarmupSitemap {
 	 *
 	 * `lastmod` is null on purpose: nothing is known about when the page
 	 * changed, and inventing a date would hand it a freshness score it has not
-	 * earned. It still outranks most of the sitemap through the `manual` weight
-	 * alone, which is the intent.
+	 * earned. `type` is empty for a different reason -- the post type is
+	 * knowable for anything that resolved to an ID, it is simply not carried
+	 * this far yet -- see #148.
+	 *
+	 * Both gaps cost score, and the arithmetic is worth stating rather than
+	 * assuming. A curated entry earns the `manual` weight (800) plus whatever
+	 * `menu` and `front_page` the enrichment below finds, and nothing else. An
+	 * ordinary menu page edited yesterday earns menu (500) plus freshness
+	 * (300) -- a tie on the default weights, and a win for the sitemap page as
+	 * soon as a project sets any `types` weight. So a curated entry does NOT
+	 * reliably outrank the sitemap; it is competitive with it. Entries pushed
+	 * past the URL cap are picked up by the tail drain, which is why the tail
+	 * must never exclude them.
 	 *
 	 * @param array<int, array<string, mixed>> $records Records from the sitemap.
 	 * @param array<string, bool>              $manual  Curated + Breeze keys. Only

--- a/src/Breeze/WarmupSitemap.php
+++ b/src/Breeze/WarmupSitemap.php
@@ -58,6 +58,9 @@ final class WarmupSitemap {
 	/** @var bool Prevent duplicate hook registration. */
 	private static bool $registered = false;
 
+	/** @var array<int, string> Project's curated warmup entries, unresolved. */
+	private static array $curated = array();
+
 	/** @var bool Whether ordering is enabled for this project. */
 	private static bool $priority_enabled = false;
 
@@ -108,9 +111,10 @@ final class WarmupSitemap {
 	 * a project that wires it without going through `StarterBase`.
 	 *
 	 * @param array<string, mixed>|null $weights
+	 * @param array<int, string>        $curated Project's curated warmup entries.
 	 * @return void
 	 */
-	public static function register( bool $priority = false, ?array $weights = null ): void {
+	public static function register( bool $priority = false, ?array $weights = null, array $curated = array() ): void {
 		if ( self::$registered ) {
 			return;
 		}
@@ -122,6 +126,7 @@ final class WarmupSitemap {
 		self::$registered       = true;
 		self::$priority_enabled = $priority;
 		self::$weights          = $weights ?? Scorer::DEFAULT_WEIGHTS;
+		self::$curated          = $curated;
 
 		add_filter( 'breeze_preload_urls', array( self::class, 'filterPreloadUrls' ) );
 		add_action( self::CRON_HOOK, array( self::class, 'runRefresh' ) );
@@ -421,7 +426,9 @@ final class WarmupSitemap {
 	private static function enrichRecords( array $records ): array {
 		$menu       = SignalCollector::menuKeys();
 		$frontPages = SignalCollector::frontPages();
-		$manual     = SignalCollector::manualKeys();
+		// Breeze's own row plus the project's committed list. Either may be
+		// empty; a key present in both is one key.
+		$manual     = SignalCollector::manualKeys() + CuratedUrls::filterReachable( CuratedUrls::keys( self::$curated ) );
 		$languages  = SignalCollector::activeLanguages();
 
 		foreach ( $records as $i => $record ) {

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1584,6 +1584,17 @@ class Helpers {
 
 				$translated_url = get_permalink( $post_id );
 
+				// get_permalink() answers false for a trashed post, and for a
+				// WPML translation id that no longer resolves. Without this the
+				// concatenations below coerce false to '' and a previously
+				// valid link becomes an empty string or a bare `?query` —
+				// silently, replacing something that worked. CuratedUrls::resolve()
+				// guards the same call the same way; this is that guard, in the
+				// place the pattern was taken from.
+				if ( ! is_string( $translated_url ) || '' === $translated_url ) {
+					return $value;
+				}
+
 				// Add query if it's there
 				if ( isset( $parsed_url['query'] ) ) {
 					$translated_url .= '?' . $parsed_url['query'];

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1850,6 +1850,53 @@ class Helpers {
 	}
 
 	/**
+	 * Resolve a URL to the post it names, in the current language.
+	 *
+	 * `url_to_postid()` alone is not enough on a WPML site with language URL
+	 * prefixes: it returns 0 for a perfectly valid `/cs/my-page`, because the
+	 * rewrite rules it consults belong to the default language. The second
+	 * lookup strips the prefix via {@see self::extract_slug_from_url()} and asks
+	 * again — which is what `formatLink()` has always done privately, and what
+	 * every other caller of `url_to_postid()` in this package needs for the same
+	 * reason.
+	 *
+	 * The returned ID is passed through `wpml_object_id`, so a caller gets the
+	 * translation that belongs to the language being rendered rather than the
+	 * one whose slug happened to match.
+	 *
+	 * @param string $url Absolute URL, or a path.
+	 * @return int Post ID, or 0 when the URL names nothing on this site.
+	 */
+	public static function urlToPostId( string $url ): int {
+		if ( '' === trim( $url ) || ! function_exists( 'url_to_postid' ) ) {
+			return 0;
+		}
+
+		$post_id = (int) url_to_postid( $url );
+
+		if ( 0 === $post_id ) {
+			$stripped = self::extract_slug_from_url( $url );
+			if ( is_string( $stripped ) && '' !== $stripped ) {
+				$post_id = (int) url_to_postid( $stripped );
+			}
+		}
+
+		if ( $post_id <= 0 ) {
+			return 0;
+		}
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$post_type  = function_exists( 'get_post_type' ) ? get_post_type( $post_id ) : 'page';
+			$translated = (int) apply_filters( 'wpml_object_id', $post_id, $post_type ?: 'page' );
+			if ( $translated > 0 ) {
+				$post_id = $translated;
+			}
+		}
+
+		return $post_id;
+	}
+
+	/**
 	 * Extract the path (slug) from a URL, stripping the WPML language prefix if present.
 	 *
 	 * Useful as a fallback for `url_to_postid()` when WPML is active with
@@ -1871,8 +1918,15 @@ class Helpers {
 		$path = rtrim( $path, '/' );
 
 		if ( function_exists( 'is_plugin_active' ) && is_plugin_active( 'sitepress-multilingual-cms/sitepress.php' ) ) {
-			// Get all active language codes
+			// Get all active language codes. The guard is not defensive
+			// decoration: the plugin being active does not guarantee the filter
+			// answers with an array — it returns null before WPML has finished
+			// booting — and array_keys( null ) is a TypeError, i.e. a fatal on
+			// a page that only wanted to resolve a link.
 			$active_languages = apply_filters( 'wpml_active_languages', null );
+			if ( ! is_array( $active_languages ) ) {
+				return $path;
+			}
 			$active_languages = array_keys( $active_languages );
 
 			// Remove language prefix if present

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1575,19 +1575,14 @@ class Helpers {
 		if ( isset( $value['url'] ) ) {
 
 			$parsed_url = parse_url( $value['url'] );
-			$post_id = url_to_postid( $value['url'] );
-			// if we are in non default language we could get 0 for valid URLs
-			// then we need to extract only slug from URL
-			if ( $post_id === 0 ) {
-				$url = self::extract_slug_from_url( $value['url'] );
-				$post_id = url_to_postid( $url );
-			}
+			// The prefix fallback and the wpml_object_id translation both live
+			// in urlToPostId() now — this is where they were written, and
+			// its other callers in this package need the same two steps.
+			$post_id = self::urlToPostId( $value['url'] );
 
 			if ( $post_id > 0 ) {
 
-				$post_type = get_post_type( $post_id );
-				$translated_url = apply_filters( 'wpml_object_id', $post_id, $post_type );
-				$translated_url = get_permalink( $translated_url );
+				$translated_url = get_permalink( $post_id );
 
 				// Add query if it's there
 				if ( isset( $parsed_url['query'] ) ) {
@@ -1850,6 +1845,96 @@ class Helpers {
 	}
 
 	/**
+	 * Whether a URL belongs to this site.
+	 *
+	 * A bare path does by definition. An absolute URL has to match host AND
+	 * port: `example.test:8080` is a different service from `example.test`, and
+	 * treating them as one turns a same-host check into a request this site can
+	 * be made to send anywhere on that machine.
+	 *
+	 * Under WPML's domain-per-language negotiation every language but the
+	 * default lives on its own host, so `home_url()` alone is not the answer —
+	 * see {@see self::siteHosts()}.
+	 *
+	 * @param string $url Absolute URL, or a path.
+	 * @return bool
+	 */
+	public static function isSiteUrl( string $url ): bool {
+		$parts = parse_url( $url );
+		if ( ! is_array( $parts ) ) {
+			return false;
+		}
+
+		// No host: a path, which is this site's by construction.
+		if ( empty( $parts['host'] ) ) {
+			return true;
+		}
+
+		$scheme = isset( $parts['scheme'] ) ? strtolower( (string) $parts['scheme'] ) : '';
+		if ( 'http' !== $scheme && 'https' !== $scheme ) {
+			return false;
+		}
+
+		if ( ! empty( $parts['user'] ) || ! empty( $parts['pass'] ) ) {
+			return false;
+		}
+
+		$authority = strtolower( (string) $parts['host'] );
+		if ( isset( $parts['port'] ) ) {
+			$authority .= ':' . (int) $parts['port'];
+		}
+
+		return in_array( $authority, self::siteHosts(), true );
+	}
+
+	/**
+	 * Every authority this site answers on, `host` or `host:port`.
+	 *
+	 * `home_url()` plus each active language's own URL, because under
+	 * domain-per-language those are different hosts and refusing them would
+	 * refuse the site's own pages.
+	 *
+	 * @return array<int, string>
+	 */
+	public static function siteHosts(): array {
+		$authorities = array();
+
+		$add = static function ( $url ) use ( &$authorities ): void {
+			$parts = parse_url( (string) $url );
+			if ( ! is_array( $parts ) || empty( $parts['host'] ) ) {
+				return;
+			}
+			$authority = strtolower( (string) $parts['host'] );
+			if ( isset( $parts['port'] ) ) {
+				$authority .= ':' . (int) $parts['port'];
+			}
+			if ( ! in_array( $authority, $authorities, true ) ) {
+				$authorities[] = $authority;
+			}
+		};
+
+		if ( function_exists( 'home_url' ) ) {
+			$add( home_url() );
+		}
+		if ( function_exists( 'site_url' ) ) {
+			$add( site_url() );
+		}
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$languages = apply_filters( 'wpml_active_languages', null, array( 'skip_missing' => false ) );
+			if ( is_array( $languages ) ) {
+				foreach ( $languages as $language ) {
+					if ( is_array( $language ) && ! empty( $language['url'] ) ) {
+						$add( $language['url'] );
+					}
+				}
+			}
+		}
+
+		return $authorities;
+	}
+
+	/**
 	 * Resolve a URL to the post it names, in the current language.
 	 *
 	 * `url_to_postid()` alone is not enough on a WPML site with language URL
@@ -1864,6 +1949,11 @@ class Helpers {
 	 * translation that belongs to the language being rendered rather than the
 	 * one whose slug happened to match.
 	 *
+	 * The prefix fallback is host-gated. It compares paths, so without the gate
+	 * `https://someone-else.test/about/` would match this site's own About page
+	 * and be silently rewritten to a local permalink — which is what
+	 * `Breadcrumb` and `formatLink` were doing before this helper existed.
+	 *
 	 * @param string $url Absolute URL, or a path.
 	 * @return int Post ID, or 0 when the URL names nothing on this site.
 	 */
@@ -1875,9 +1965,17 @@ class Helpers {
 		$post_id = (int) url_to_postid( $url );
 
 		if ( 0 === $post_id ) {
-			$stripped = self::extract_slug_from_url( $url );
-			if ( is_string( $stripped ) && '' !== $stripped ) {
-				$post_id = (int) url_to_postid( $stripped );
+			// The gate belongs HERE, not above. The lookup that just failed
+			// compared full URLs, so a foreign host could never have matched
+			// anything. The fallback below compares PATHS, and that is where
+			// `https://someone-else.test/about/` would quietly become this
+			// site's own About page. Checking only here also keeps the common
+			// case from needing to know the site's hosts at all.
+			if ( self::isSiteUrl( $url ) ) {
+				$stripped = self::extract_slug_from_url( $url );
+				if ( is_string( $stripped ) && '' !== $stripped ) {
+					$post_id = (int) url_to_postid( $stripped );
+				}
 			}
 		}
 
@@ -1925,7 +2023,10 @@ class Helpers {
 			// a page that only wanted to resolve a link.
 			$active_languages = apply_filters( 'wpml_active_languages', null );
 			if ( ! is_array( $active_languages ) ) {
-				return $path;
+				// Fall through rather than return: the contract is that this
+				// always answers with a leading slash, and an early return here
+				// would break it for a relative input.
+				$active_languages = array();
 			}
 			$active_languages = array_keys( $active_languages );
 

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -594,6 +594,36 @@ class StarterBase extends Site {
 	);
 
 	/**
+	 * A curated warmup list that lives here instead of in wp-admin.
+	 *
+	 * Merges into the `manual` signal behind `$breeze_warmup_priority`, at the
+	 * weight that source already carries. It adds an input, not a tier: nothing
+	 * about ordering, weights or the cap changes.
+	 *
+	 * It exists because `manual` was the one curated signal a project could not
+	 * version. Its only input was Breeze's settings row, so the list could not
+	 * be reviewed, carried no reason for any entry, differed per environment by
+	 * accident, and was wiped by a database import — silently, after which the
+	 * site simply stopped warming what mattered.
+	 *
+	 * Entries may be relative or absolute, and both are resolved rather than
+	 * trusted. One that names a post or a page becomes its ID and comes back as
+	 * `get_permalink()`, so a relative path is correct on ddev, on staging and
+	 * in production without being rewritten — and under domain-per-language it
+	 * comes back on that language's own host. One that resolves to nothing is
+	 * dropped, so a deleted page stops being warmed on its own.
+	 *
+	 *     protected array $breeze_warmup_urls = array(
+	 *         '/blog/',
+	 *         '/cs/blog/',
+	 *         'https://example.de/blog/',
+	 *     );
+	 *
+	 * @var array<int, string>
+	 */
+	protected array $breeze_warmup_urls = array();
+
+	/**
 	 * ACF Datastore ({@see https://www.advancedcustomfields.com/resources/acf-settings-enable_datastore/}).
 	 *
 	 * Opt-in (default off). Switches how ACF saves field values — through the
@@ -1320,7 +1350,8 @@ class StarterBase extends Site {
 
 		WarmupSitemap::register(
 			$this->breeze_warmup_priority,
-			$this->breeze_warmup_priority_weights
+			$this->breeze_warmup_priority_weights,
+			$this->breeze_warmup_urls
 		);
 	}
 

--- a/tests/Unit/Breeze/CuratedUrlsTest.php
+++ b/tests/Unit/Breeze/CuratedUrlsTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Breeze;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use Parisek\TimberKit\Breeze\CuratedUrls;
+
+/**
+ * A curated entry is resolved, never trusted.
+ */
+final class CuratedUrlsTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+		Functions\when( 'home_url' )->alias(
+			static fn( string $path = '' ): string => 'https://example.test' . $path
+		);
+		Functions\when( 'get_post_type' )->justReturn( 'page' );
+		// No WPML in these cases: the filter hands the id straight back.
+		Functions\when( 'apply_filters' )->alias(
+			static fn( string $hook, $value = null, ...$rest ) => $value
+		);
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	public function test_a_relative_path_resolves_against_this_site(): void {
+		Functions\when( 'url_to_postid' )->justReturn( 0 );
+
+		$keys = CuratedUrls::keys( array( '/blog/' ) );
+
+		$this->assertSame( array( 'https://example.test/blog/' ), array_keys( $keys ) );
+	}
+
+	public function test_a_post_comes_back_as_its_permalink_not_as_written(): void {
+		// The written form and the canonical one differ on purpose: what gets
+		// stored has to be what the site serves, not what someone typed.
+		Functions\when( 'url_to_postid' )->justReturn( 42 );
+		Functions\when( 'get_permalink' )->justReturn( 'https://example.test/cs/blog/' );
+
+		$keys = CuratedUrls::keys( array( '/blog' ) );
+
+		$this->assertSame( array( 'https://example.test/cs/blog/' ), array_keys( $keys ) );
+	}
+
+	public function test_an_entry_that_names_nothing_is_dropped(): void {
+		// url_to_postid() finds nothing AND the host is foreign: there is no
+		// reading of this entry under which it belongs to this site.
+		Functions\when( 'url_to_postid' )->justReturn( 0 );
+
+		$keys = CuratedUrls::keys( array( 'https://somewhere-else.test/blog/' ) );
+
+		$this->assertSame( array(), $keys );
+	}
+
+	public function test_a_language_domain_is_not_foreign(): void {
+		Functions\when( 'url_to_postid' )->justReturn( 0 );
+		Functions\when( 'apply_filters' )->alias(
+			static function ( string $hook, $value = null, ...$rest ) {
+				if ( 'wpml_active_languages' === $hook ) {
+					return array( 'de' => array( 'url' => 'https://example.de/' ) );
+				}
+				return $value;
+			}
+		);
+
+		$keys = CuratedUrls::keys( array( 'https://example.de/blog/' ) );
+
+		$this->assertSame( array( 'https://example.de/blog/' ), array_keys( $keys ) );
+	}
+
+	public function test_a_scheme_relative_entry_is_refused_rather_than_guessed(): void {
+		Functions\when( 'url_to_postid' )->justReturn( 0 );
+
+		$this->assertSame( array(), CuratedUrls::keys( array( '//evil.test/blog/' ) ) );
+	}
+
+	public function test_blank_and_non_string_entries_are_skipped(): void {
+		Functions\when( 'url_to_postid' )->justReturn( 0 );
+
+		$keys = CuratedUrls::keys( array( '', '   ', 42, null, array( 'x' ), '/ok/' ) );
+
+		$this->assertSame( array( 'https://example.test/ok/' ), array_keys( $keys ) );
+	}
+
+	public function test_a_dead_entry_is_dropped_by_the_reachability_probe(): void {
+		Functions\when( 'wp_remote_head' )->justReturn( array() );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 404 );
+
+		$this->assertSame(
+			array(),
+			CuratedUrls::filterReachable( array( 'https://example.test/gone/' => true ) )
+		);
+	}
+
+	public function test_a_redirect_counts_as_alive(): void {
+		Functions\when( 'wp_remote_head' )->justReturn( array() );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 301 );
+
+		$this->assertSame(
+			array( 'https://example.test/moved/' => true ),
+			CuratedUrls::filterReachable( array( 'https://example.test/moved/' => true ) )
+		);
+	}
+
+	public function test_a_failed_probe_keeps_the_entry(): void {
+		// Stale beats empty: one flaky lookup must not silently clear a list.
+		Functions\when( 'wp_remote_head' )->justReturn( array() );
+		Functions\when( 'is_wp_error' )->justReturn( true );
+
+		$this->assertSame(
+			array( 'https://example.test/flaky/' => true ),
+			CuratedUrls::filterReachable( array( 'https://example.test/flaky/' => true ) )
+		);
+	}
+}

--- a/tests/Unit/Breeze/CuratedUrlsTest.php
+++ b/tests/Unit/Breeze/CuratedUrlsTest.php
@@ -195,4 +195,57 @@ final class CuratedUrlsTest extends TestCase {
 
 		$this->assertSame( array( 'https://example.test/one/' ), array_keys( $keys ) );
 	}
+
+	/**
+	 * The probe judges existence and nothing else.
+	 *
+	 * A term archive behind a WAF that refuses HEAD, or one that answers 401 to
+	 * a logged-out warmer, is a live page. Dropping it was the exact failure
+	 * `resolve()`'s own comment claimed to avoid — that comment guarded the
+	 * post-ID path and left this one open.
+	 *
+	 * @param int $code Status the probe sees.
+	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider( 'aliveCodes' )]
+	public function test_only_a_gone_page_is_dropped( int $code ): void {
+		Functions\when( 'wp_remote_head' )->justReturn( array() );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( $code );
+
+		$this->assertSame(
+			array( 'https://example.test/x/' => true ),
+			CuratedUrls::filterReachable( array( 'https://example.test/x/' => true ) ),
+			"status {$code} says nothing about whether the page exists"
+		);
+	}
+
+	/** @return array<string, array{int}> */
+	public static function aliveCodes(): array {
+		return array(
+			'method not allowed' => array( 405 ),
+			'unauthorised'       => array( 401 ),
+			'forbidden'          => array( 403 ),
+			'server error'       => array( 500 ),
+			'redirect'           => array( 301 ),
+			'ok'                 => array( 200 ),
+		);
+	}
+
+	/** @param int $code Status the probe sees. */
+	#[\PHPUnit\Framework\Attributes\DataProvider( 'goneCodes' )]
+	public function test_a_gone_page_is_dropped( int $code ): void {
+		Functions\when( 'wp_remote_head' )->justReturn( array() );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( $code );
+
+		$this->assertSame(
+			array(),
+			CuratedUrls::filterReachable( array( 'https://example.test/x/' => true ) )
+		);
+	}
+
+	/** @return array<string, array{int}> */
+	public static function goneCodes(): array {
+		return array( 'not found' => array( 404 ), 'gone' => array( 410 ) );
+	}
 }

--- a/tests/Unit/Breeze/CuratedUrlsTest.php
+++ b/tests/Unit/Breeze/CuratedUrlsTest.php
@@ -165,4 +165,34 @@ final class CuratedUrlsTest extends TestCase {
 			CuratedUrls::filterReachable( array( 'https://example.test/flaky/' => true ) )
 		);
 	}
+
+	public function test_the_list_is_filterable_from_outside_the_theme(): void {
+		// The reason this filter exists: a project may keep its config in an
+		// mu-plugin, and without it the curated list would be the one warmup
+		// setting unreachable from there.
+		Functions\when( 'url_to_postid' )->justReturn( 0 );
+		Functions\when( 'apply_filters' )->alias(
+			static function ( string $hook, $value = null, ...$rest ) {
+				return 'timberkit_warmup_curated_urls' === $hook ? array( '/added/' ) : $value;
+			}
+		);
+
+		$this->assertSame(
+			array( 'https://example.test/added/' ),
+			array_keys( CuratedUrls::keys( array( '/original/' ) ) )
+		);
+	}
+
+	public function test_the_cap_is_filterable_and_truncates(): void {
+		Functions\when( 'url_to_postid' )->justReturn( 0 );
+		Functions\when( 'apply_filters' )->alias(
+			static function ( string $hook, $value = null, ...$rest ) {
+				return 'timberkit_warmup_curated_max_entries' === $hook ? 1 : $value;
+			}
+		);
+
+		$keys = CuratedUrls::keys( array( '/one/', '/two/', '/three/' ) );
+
+		$this->assertSame( array( 'https://example.test/one/' ), array_keys( $keys ) );
+	}
 }

--- a/tests/Unit/Breeze/CuratedUrlsTest.php
+++ b/tests/Unit/Breeze/CuratedUrlsTest.php
@@ -38,6 +38,48 @@ final class CuratedUrlsTest extends TestCase {
 		$keys = CuratedUrls::keys( array( '/blog/' ) );
 
 		$this->assertSame( array( 'https://example.test/blog/' ), array_keys( $keys ) );
+		$this->assertTrue( $keys['https://example.test/blog/'], 'unresolved entries still owe a probe' );
+	}
+
+	public function test_a_post_needs_no_probe(): void {
+		// The regression this guards: probing every key spends a request per
+		// entry per refresh, and drops a page that answers 405 to HEAD.
+		Functions\when( 'url_to_postid' )->justReturn( 42 );
+		Functions\when( 'get_permalink' )->justReturn( 'https://example.test/blog/' );
+
+		$keys = CuratedUrls::keys( array( '/blog/' ) );
+
+		$this->assertFalse( $keys['https://example.test/blog/'] );
+		$this->assertSame(
+			array( 'https://example.test/blog/' => true ),
+			CuratedUrls::filterReachable( $keys ),
+			'a key that owes no probe survives filterReachable untouched'
+		);
+	}
+
+	public function test_a_foreign_url_cannot_borrow_a_local_path(): void {
+		// url_to_postid() misses on the full URL and would hit on the bare
+		// path. Without the host gate in Helpers::urlToPostId() this entry
+		// became this site's own /about/ page.
+		$calls = 0;
+		Functions\when( 'url_to_postid' )->alias(
+			static function () use ( &$calls ): int {
+				++$calls;
+				return 1 === $calls ? 0 : 99;
+			}
+		);
+		Functions\when( 'get_permalink' )->justReturn( 'https://example.test/about/' );
+
+		$this->assertSame( array(), CuratedUrls::keys( array( 'https://foreign.test/about/' ) ) );
+	}
+
+	public function test_a_port_is_part_of_the_host(): void {
+		// example.test:8080 is a different service from example.test, and
+		// treating them as one turns the probe into a request this site can be
+		// made to send anywhere on that machine.
+		Functions\when( 'url_to_postid' )->justReturn( 0 );
+
+		$this->assertSame( array(), CuratedUrls::keys( array( 'https://example.test:8080/blog/' ) ) );
 	}
 
 	public function test_a_post_comes_back_as_its_permalink_not_as_written(): void {

--- a/tests/Unit/Breeze/WarmupSitemap/CuratedRecordsTest.php
+++ b/tests/Unit/Breeze/WarmupSitemap/CuratedRecordsTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Breeze\WarmupSitemap;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use Parisek\TimberKit\Breeze\WarmupSitemap;
+
+/**
+ * A curated URL has to become a record, not a flag on someone else's.
+ *
+ * The bug this guards was found in review: enrichRecords() only marked
+ * `manual` on records the sitemap had already produced, so an entry the
+ * sitemap ranks badly or omits entirely did nothing at all — which is the whole
+ * case a curated list exists for.
+ */
+final class CuratedRecordsTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+		Functions\when( 'home_url' )->justReturn( 'https://example.test' );
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * @param array<int, array<string, mixed>> $records
+	 * @param array<string, true>              $manual
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function append( array $records, array $manual ): array {
+		$method = new \ReflectionMethod( WarmupSitemap::class, 'appendMissingManual' );
+		$method->setAccessible( true );
+		return $method->invoke( null, $records, $manual );
+	}
+
+	public function test_a_curated_key_absent_from_the_sitemap_becomes_a_record(): void {
+		$records = $this->append(
+			array(
+				array( 'url' => 'https://example.test/a/', 'key' => 'https://example.test/a/' ),
+			),
+			array( 'https://example.test/b/' => true )
+		);
+
+		$this->assertCount( 2, $records );
+		$this->assertSame( 'https://example.test/b/', $records[1]['key'] );
+		$this->assertSame( 'curated', $records[1]['source'] );
+		$this->assertNull( $records[1]['lastmod'], 'an invented date would buy a freshness score it has not earned' );
+	}
+
+	public function test_a_curated_key_the_sitemap_already_has_is_not_duplicated(): void {
+		$records = $this->append(
+			array(
+				array( 'url' => 'https://example.test/a/', 'key' => 'https://example.test/a/' ),
+			),
+			array( 'https://example.test/a/' => true )
+		);
+
+		$this->assertCount( 1, $records );
+	}
+
+	public function test_an_empty_sitemap_still_yields_the_curated_records(): void {
+		// The case the early return used to swallow: the sitemap is missing or
+		// broken, which is when an explicit list matters most.
+		$records = $this->append( array(), array( 'https://example.test/b/' => true ) );
+
+		$this->assertCount( 1, $records );
+		$this->assertSame( 'https://example.test/b/', $records[0]['url'] );
+	}
+
+	public function test_no_curated_keys_changes_nothing(): void {
+		$input = array( array( 'url' => 'https://example.test/a/', 'key' => 'https://example.test/a/' ) );
+
+		$this->assertSame( $input, $this->append( $input, array() ) );
+	}
+}

--- a/tests/Unit/Helpers/FormatLinkTest.php
+++ b/tests/Unit/Helpers/FormatLinkTest.php
@@ -133,6 +133,9 @@ class FormatLinkTest extends HelpersTestCase {
 	}
 
 	public function test_wpml_slug_fallback_when_url_to_postid_returns_zero(): void {
+		// The path fallback is host-gated now, so it has to be able to learn
+		// which hosts belong to this site.
+		Functions\when( 'home_url' )->justReturn( 'https://example.com' );
 		$callCount = 0;
 		Functions\when( 'url_to_postid' )->alias( function () use ( &$callCount ) {
 			$callCount++;
@@ -162,6 +165,9 @@ class FormatLinkTest extends HelpersTestCase {
 	}
 
 	public function test_wpml_url_to_postid_zero_both_times(): void {
+		// The path fallback is host-gated now, so it has to be able to learn
+		// which hosts belong to this site.
+		Functions\when( 'home_url' )->justReturn( 'https://example.com' );
 		Functions\when( 'url_to_postid' )->justReturn( 0 );
 		Functions\when( 'is_plugin_active' )->justReturn( false );
 

--- a/tests/Unit/Helpers/UrlToPostIdTest.php
+++ b/tests/Unit/Helpers/UrlToPostIdTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Helpers;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use Parisek\TimberKit\Helpers;
+
+/**
+ * The second lookup is the whole point of this helper.
+ */
+final class UrlToPostIdTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+		Functions\when( 'home_url' )->alias(
+			static fn( string $path = '' ): string => 'https://example.test' . $path
+		);
+		Functions\when( 'get_post_type' )->justReturn( 'page' );
+		// extract_slug_from_url() asks whether WPML is active before it strips
+		// a prefix; without this the fallback path cannot even be reached.
+		Functions\when( 'is_plugin_active' )->justReturn( true );
+		Functions\when( 'apply_filters' )->alias(
+			static function ( string $hook, $value = null, ...$rest ) {
+				if ( 'wpml_active_languages' === $hook ) {
+					return array( 'en' => array(), 'cs' => array() );
+				}
+				return $value;
+			}
+		);
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	public function test_a_plain_hit_is_returned(): void {
+		Functions\when( 'url_to_postid' )->justReturn( 7 );
+
+		$this->assertSame( 7, Helpers::urlToPostId( 'https://example.test/about/' ) );
+	}
+
+	public function test_a_prefixed_url_is_retried_without_its_language(): void {
+		// This is the case url_to_postid() gets wrong on a WPML site: the
+		// rewrite rules it consults belong to the default language, so a valid
+		// /cs/ URL answers 0 on the first ask and the entry silently vanishes.
+		$calls = 0;
+		Functions\when( 'url_to_postid' )->alias(
+			static function ( string $url ) use ( &$calls ): int {
+				++$calls;
+				return 1 === $calls ? 0 : 11;
+			}
+		);
+
+		$this->assertSame( 11, Helpers::urlToPostId( 'https://example.test/cs/o-nas/' ) );
+		$this->assertSame( 2, $calls, 'the fallback lookup must actually happen' );
+	}
+
+	public function test_nothing_found_is_zero_not_a_guess(): void {
+		Functions\when( 'url_to_postid' )->justReturn( 0 );
+
+		$this->assertSame( 0, Helpers::urlToPostId( 'https://example.test/nope/' ) );
+	}
+
+	public function test_an_empty_url_short_circuits(): void {
+		Functions\when( 'url_to_postid' )->justReturn( 99 );
+
+		$this->assertSame( 0, Helpers::urlToPostId( '   ' ) );
+	}
+
+	public function test_the_id_is_translated_for_the_rendered_language(): void {
+		Functions\when( 'url_to_postid' )->justReturn( 5 );
+		Functions\when( 'apply_filters' )->alias(
+			static function ( string $hook, $value = null, ...$rest ) {
+				return 'wpml_object_id' === $hook ? 55 : $value;
+			}
+		);
+
+		$this->assertSame( 55, Helpers::urlToPostId( 'https://example.test/about/' ) );
+	}
+}


### PR DESCRIPTION
Closes #140. Follow-up to #134.

`manual` has been a scoring source since #134, but its only input was Breeze's settings row — so the one curated signal in the model was the one a project could not version. It could not be reviewed, carried no reason for any entry, differed per environment by accident, and a database import wiped it silently, after which the site stopped warming what mattered and said nothing.

`$breeze_warmup_urls` feeds the same signal from the theme:

```php
protected array $breeze_warmup_urls = array(
    '/blog/',
    '/cs/blog/',
    'https://example.de/blog/',
);
```

It adds an **input, not a tier** — ordering, weights and the cap are untouched.

## Both forms, and why that is not just convenience

An entry naming a post or page becomes its ID and comes back as `get_permalink()`. So the same written line is correct on ddev, on staging and in production without being rewritten — and under WPML's domain-per-language negotiation it comes back on that language's own host, which is why an absolute form has to be accepted at all.

**An entry that resolves to nothing is dropped.** A deleted page stops being warmed without anyone remembering the list exists, and a typo warms a 404 zero times instead of on every cycle.

`url_to_postid()` cannot see term archives, and a category archive was the motivating example, so those are kept as URLs and checked with one `HEAD` during the cron refresh — off the purge path deliberately, since that filter runs while an editor waits for a save. A failed probe **keeps** the entry: one flaky lookup must not empty a curated list, which is the stale-beats-nothing rule `runRefresh()` already follows.

## Two pre-existing bugs found while writing it

**`Helpers::extract_slug_from_url()` could fatal.** It calls `array_keys()` on the result of `wpml_active_languages` with no type check. The plugin being active does not guarantee an array — WPML answers `null` before it has booted — and `array_keys( null )` is a TypeError on a page that only wanted to resolve a link. Found by a test, not by reading.

**`Breadcrumb` dropped language-prefixed links.** It called `url_to_postid()` directly, without the fallback `formatLink()` has always had. On a WPML site with language prefixes that returns 0 for a valid `/cs/…` URL, so those global links vanished from the trail with no error.

Both call sites now use the new `Helpers::urlToPostId()`, which is the shared form of what `formatLink()` was already doing privately. Three call sites of the same idea, one function.

## The architecture test earned its keep

The first draft named Breeze in `Helpers.php`'s docblock and #137's boundary test refused the build. The helper is generic and naming a consumer in it was wrong regardless — the test caught a design slip, not a formatting one.

## Verification

1641 tests, 2722 assertions, PHPStan clean. 14 new tests cover both resolution paths, the reachability probe's three outcomes, the WPML prefix fallback and the scheme-relative refusal.

## Open question from the issue, still open

Whether a relative path should expand across active languages or stay literal. This ships **literal** — it is what is written and what can be reviewed — and expansion stays available to a project as a loop. Worth settling before the API has consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMYy6JHLf4mU4H4Hd47spb