### PR TITLE
feat(warmup): resolve the sitemap per SEO plugin, Yoast included

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   Yoast, core — so a project gets the right sitemap from whichever plugin it
   runs, and the order is stated rather than implied. AIOSEO stays first, so a
   site that already had it resolves exactly the path it resolved before.
+- A Site Health check, `warmup_sitemap_resolved`, registered only when
+  `$breeze_warmup_sitemap` is on. The module degrades silently by design — an
+  empty sitemap result is a normal return value and the refresh job swallows
+  throwables by contract — which is right for the purge path and wrong for the
+  administrator, who was left with a warmup that preloads nothing and says
+  nothing. The check reports the one fact worth acting on: the feature is on
+  and the list is empty. A store that has never been refreshed is reported as
+  good, because a fresh install waits for its first purge through no fault of
+  its own.
 - `timberkit_warmup_sitemap_url` filter, receiving the resolved URL and the
   detected provider key. It is the escape hatch for a provider the list does
   not know yet and for a site serving its sitemap from a non-default path. A
@@ -21,6 +30,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- The same-host guard compared the hostname and ignored the **port**, so a
+  sitemap index entry — or a filter callback — pointing at
+  `https://<own-host>:9200/` passed it and was fetched. An internal service
+  bound to another port on the site's own host was reachable that way. Ports
+  are now compared, normalised by scheme first so one origin written two ways
+  still matches. Pre-existing; the sitemap-index path carried it before this
+  branch added a second way to reach the guard.
 - A Yoast site produced an **empty** warmup list, silently. Yoast redirects
   `/wp-sitemap.xml` to its own index with a 301 and every fetch sends
   `redirection => 0` (the SSRF guard, deliberately kept), so the core fallback
@@ -29,6 +45,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   because an empty result is a normal return value and `runRefresh()` swallows
   throwables by contract. Measured on a live Yoast Premium site: 0 records from
   the requested path, 1113 from the one Yoast serves.
+- Yoast is detected on its sitemap switch, not on its symbol alone. Yoast can
+  be loaded with its XML sitemap turned off, and core then serves
+  `/wp-sitemap.xml` again — detecting on the symbol would have sent exactly
+  those sites to an address that 404s, breaking a configuration that worked
+  before Yoast was recognised here.
 
 ## [1.39.0] - 2026-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- `Breeze\WarmupSitemap` recognises **Yoast SEO** and asks for
+  `/sitemap_index.xml`. Providers are now a list checked in order — AIOSEO,
+  Yoast, core — so a project gets the right sitemap from whichever plugin it
+  runs, and the order is stated rather than implied. AIOSEO stays first, so a
+  site that already had it resolves exactly the path it resolved before.
+- `timberkit_warmup_sitemap_url` filter, receiving the resolved URL and the
+  detected provider key. It is the escape hatch for a provider the list does
+  not know yet and for a site serving its sitemap from a non-default path. A
+  non-string return, or a URL on another host, is ignored in favour of the
+  detected path.
+
+### Fixed
+
+- A Yoast site produced an **empty** warmup list, silently. Yoast redirects
+  `/wp-sitemap.xml` to its own index with a 301 and every fetch sends
+  `redirection => 0` (the SSRF guard, deliberately kept), so the core fallback
+  did not degrade to a slower answer — it degraded to no answer at all. With
+  `$breeze_warmup_sitemap` on, the refresh stored nothing and reported nothing,
+  because an empty result is a normal return value and `runRefresh()` swallows
+  throwables by contract. Measured on a live Yoast Premium site: 0 records from
+  the requested path, 1113 from the one Yoast serves.
+
 ## [1.39.0] - 2026-08-24
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -577,12 +577,27 @@ order — the first provider that answers wins:
 | Provider | Detected by | Root |
 | --- | --- | --- |
 | AIOSEO | `aioseo()` / `\AIOSEO\Plugin\AIOSEO` | `/sitemap.xml` |
-| Yoast SEO | `WPSEO_VERSION` / `\WPSEO_Sitemaps` | `/sitemap_index.xml` |
+| Yoast SEO | `WPSEO_VERSION` / `\WPSEO_Sitemaps`, **and** its XML-sitemap switch on | `/sitemap_index.xml` |
 | WordPress core | nothing else answered | `/wp-sitemap.xml` |
 
 Each plugin is recognised by a symbol it defines, never by the active-plugin
 list: a must-use load, a renamed directory or a bundled copy all keep the
 symbol and lose the list entry.
+
+Yoast additionally has to be *serving* a sitemap. It carries a switch that
+turns its XML sitemap off, and when it is off core serves `/wp-sitemap.xml`
+again — so a site in that state answers on the core path and 404s on Yoast's.
+A symbol proves the plugin is loaded; it does not prove the plugin does the
+thing being asked about.
+
+**When the list is empty, Site Health says so.** With `$breeze_warmup_sitemap`
+on, the `warmup_sitemap_resolved` check reports a stored-but-empty URL list as
+critical. Everything upstream of it degrades quietly on purpose — an empty
+sitemap result is a normal return value and the refresh job swallows
+throwables by contract, because a sitemap outage must never surface as a fatal
+in cron. That is right for the purge path and useless to an administrator, and
+this check is the one place the silence is broken. A list that has simply not
+been built yet counts as good; the first purge after activation schedules it.
 
 **Yoast is named rather than left to the core fallback**, and that is not a
 convenience. Yoast redirects `/wp-sitemap.xml` to its own index with a 301, and

--- a/README.md
+++ b/README.md
@@ -568,9 +568,45 @@ the site's XML sitemap via the `breeze_preload_urls` filter.
 Breeze 2.5 re-warms the cache after a full purge, but its own URL sources are
 the homepage, a few auto-detected pages, and a manual list capped at 30 entries
 — so on a real site most pages are rebuilt by the first visitor to ask for them.
-The class discovers the sitemap (AIOSEO's `/sitemap.xml` when active, otherwise
-core's `/wp-sitemap.xml`), follows a sitemap index recursively within bounded
-limits, and merges the result in.
+The class discovers the sitemap, follows a sitemap index recursively within
+bounded limits, and merges the result in.
+
+**Which sitemap it asks for** depends on what the project runs, checked in this
+order — the first provider that answers wins:
+
+| Provider | Detected by | Root |
+| --- | --- | --- |
+| AIOSEO | `aioseo()` / `\AIOSEO\Plugin\AIOSEO` | `/sitemap.xml` |
+| Yoast SEO | `WPSEO_VERSION` / `\WPSEO_Sitemaps` | `/sitemap_index.xml` |
+| WordPress core | nothing else answered | `/wp-sitemap.xml` |
+
+Each plugin is recognised by a symbol it defines, never by the active-plugin
+list: a must-use load, a renamed directory or a bundled copy all keep the
+symbol and lose the list entry.
+
+**Yoast is named rather than left to the core fallback**, and that is not a
+convenience. Yoast redirects `/wp-sitemap.xml` to its own index with a 301, and
+every fetch here sends `redirection => 0` on purpose — following a redirect is
+the SSRF surface this module closes. So on a Yoast site the core path does not
+degrade to a slower answer, it degrades to **no** answer: the response code
+lands outside 200-299 and the body is dropped. The refresh then stores an empty
+list and says nothing, because an empty result is a normal return value and the
+cron job swallows throwables by contract.
+
+**`timberkit_warmup_sitemap_url`** overrides the resolved address — for a
+provider this list does not know yet, or a site serving its sitemap from a
+non-default path. It receives the resolved URL and the detected provider key:
+
+```php
+add_filter( 'timberkit_warmup_sitemap_url', function ( string $url, string $provider ): string {
+    return 'https://example.com/custom-sitemap.xml';
+}, 10, 2 );
+```
+
+A returned value that is not a string, or a URL on another host, is ignored and
+the detected path is used instead. The same-host guard would reject it at fetch
+time anyway; refusing it here keeps the guard and still warms the site, rather
+than silently warming nothing because one callback was wrong.
 
 `fetchSitemapUrls()` deduplicates by **canonical URL form**, not by exact
 string: two spellings of the same page — differing only in trailing slash,
@@ -637,11 +673,14 @@ class Base extends StarterBase {
 ```
 
 The post type is derived from the **sub-sitemap filename**, not looked up in
-the database: `wp-sitemap-posts-<type>-N.xml` for core,
-`<type>-sitemap.xml` for AIOSEO. A URL whose sub-sitemap doesn't match either
-shape gets no type, so its `types` weight is 0. AIOSEO's structural indexes
-(`author`, `date`, `product_attributes`, `rss`, `additional`) are excluded on
-purpose — they share the `<name>-sitemap.xml` shape but aren't post types. A
+the database: `wp-sitemap-posts-<type>-N.xml` for core, `<type>-sitemap.xml`
+for AIOSEO and Yoast alike (Yoast appends an index when a type spills over one
+file — `blog-sitemap2.xml` — which the pattern allows for). A URL whose
+sub-sitemap doesn't match either shape gets no type, so its `types` weight is
+0. The structural indexes (`author`, `date`, `product_attributes`, `rss`,
+`additional`) are excluded on purpose — they share the `<name>-sitemap.xml`
+shape but aren't post types. `author` comes from both plugins, the rest from
+AIOSEO. A
 taxonomy sitemap can't be told apart from a post-type one by filename either,
 so it falls through to weight 0 as well. If a `types` weight seems to have no
 effect, check the sub-sitemap's filename first.

--- a/src/Breeze/Health/WarmupSitemapResolved.php
+++ b/src/Breeze/Health/WarmupSitemapResolved.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Parisek\TimberKit\Breeze\Health;
+
+use Parisek\TimberKit\Breeze\PriorityStore;
+use Parisek\TimberKit\Health\HealthCheck;
+use Parisek\TimberKit\Health\Result;
+
+/**
+ * Effect check: `WarmupSitemap` is switched on but has no URLs to warm with.
+ *
+ * The module degrades silently by design — an empty sitemap result is a normal
+ * return value, and the refresh job swallows throwables by contract so a
+ * sitemap outage can never surface as a fatal in cron. Those are the right
+ * choices for the purge path and the wrong ones for an administrator, who is
+ * left with a warmup that preloads nothing and says nothing.
+ *
+ * Every cause looks identical from the outside — wrong provider, a sitemap
+ * behind auth, a transport failure, a genuinely empty site. This check does not
+ * try to tell them apart. It reports the one fact that is worth acting on: the
+ * feature is on and the list is empty.
+ */
+final class WarmupSitemapResolved implements HealthCheck {
+
+	public function id(): string {
+		return 'warmup_sitemap_resolved';
+	}
+
+	public function label(): string {
+		return __( 'Warmup list has URLs', 'timber-kit' );
+	}
+
+	public function category(): string {
+		return 'caching';
+	}
+
+	public function method(): string {
+		return self::METHOD_EFFECT;
+	}
+
+	public function run(): Result {
+		$stored = PriorityStore::read();
+
+		// Never refreshed is not the same as refreshed-and-empty. The first
+		// purge after activation schedules the refresh, so a fresh install
+		// sits here for a few minutes through no fault of its own — calling
+		// that a failure would train an administrator to ignore this check.
+		if ( null === $stored ) {
+			return Result::good( __( 'The warmup list has not been built yet.', 'timber-kit' ) );
+		}
+
+		$count = count( PriorityStore::readUrls() );
+
+		if ( 0 === $count ) {
+			return Result::critical(
+				__( 'The sitemap warmup is on, but its URL list is empty.', 'timber-kit' ),
+				__( 'The sitemap could not be read. Check that the site serves the sitemap of the SEO plugin it runs, and override the address with the timberkit_warmup_sitemap_url filter if it lives elsewhere.', 'timber-kit' )
+			);
+		}
+
+		return Result::good(
+			sprintf(
+				/* translators: %d: number of URLs stored for warmup. */
+				__( '%d URL(s) ready to warm.', 'timber-kit' ),
+				$count
+			)
+		);
+	}
+}

--- a/src/Breeze/SourceNaming.php
+++ b/src/Breeze/SourceNaming.php
@@ -19,21 +19,25 @@ namespace Parisek\TimberKit\Breeze;
 final class SourceNaming {
 
 	/**
-	 * AIOSEO archive index names that share the `<name>-sitemap.xml` shape
-	 * with a post-type sitemap but are not post types at all. A taxonomy
-	 * sitemap cannot be told apart from a post-type one by filename alone;
-	 * that case is not solved here and simply falls through to weight 0,
-	 * the safe default the rest of the design already relies on.
+	 * Archive index names that share the `<name>-sitemap.xml` shape with a
+	 * post-type sitemap but are not post types at all. AIOSEO and Yoast both
+	 * use that shape, so the list is not specific to either: `author` is
+	 * emitted by both, the rest only by AIOSEO. A taxonomy sitemap cannot be
+	 * told apart from a post-type one by filename alone; that case is not
+	 * solved here and simply falls through to weight 0, the safe default the
+	 * rest of the design already relies on.
 	 *
 	 * @var string[]
 	 */
-	private const AIOSEO_NON_POST_TYPE_INDEXES = array( 'author', 'date', 'product_attributes', 'rss', 'additional' );
+	private const NON_POST_TYPE_INDEXES = array( 'author', 'date', 'product_attributes', 'rss', 'additional' );
 
 	/**
 	 * Post type from a sub-sitemap URL.
 	 *
-	 * Core emits `wp-sitemap-posts-<type>-<N>.xml`; AIOSEO emits
-	 * `<type>-sitemap.xml`. The result is not validated against
+	 * Core emits `wp-sitemap-posts-<type>-<N>.xml`; AIOSEO and Yoast both emit
+	 * `<type>-sitemap.xml`, and Yoast appends an index to the name when a type
+	 * spills over one file (`blog-sitemap2.xml`), which the pattern already
+	 * allows for. The result is not validated against
 	 * `get_post_types()` — it is only a key into the weight map, and an
 	 * unknown key scores 0 exactly like an unrecognised name would.
 	 *
@@ -62,7 +66,7 @@ final class SourceNaming {
 				return '';
 			}
 
-			return in_array( $candidate, self::AIOSEO_NON_POST_TYPE_INDEXES, true ) ? '' : $candidate;
+			return in_array( $candidate, self::NON_POST_TYPE_INDEXES, true ) ? '' : $candidate;
 		}
 
 		return '';

--- a/src/Breeze/WarmupSitemap.php
+++ b/src/Breeze/WarmupSitemap.php
@@ -608,11 +608,47 @@ final class WarmupSitemap {
 			return 'aioseo';
 		}
 
-		if ( defined( 'WPSEO_VERSION' ) || class_exists( '\WPSEO_Sitemaps' ) ) {
+		if ( self::isYoastSitemapActive() ) {
 			return 'yoast';
 		}
 
 		return 'core';
+	}
+
+	/**
+	 * Whether Yoast is loaded *and* serving its own sitemap.
+	 *
+	 * The symbol alone is not enough. Yoast carries a switch that turns its
+	 * XML sitemap off, and when it is off WordPress core serves
+	 * `/wp-sitemap.xml` again -- so a site in that state answers on the core
+	 * path and 404s on `/sitemap_index.xml`. Detecting on the symbol alone
+	 * would send exactly those sites to the address that does not exist,
+	 * breaking a configuration that worked before Yoast was recognised here.
+	 *
+	 * A symbol proves the plugin is loaded. It does not prove the plugin does
+	 * the thing being asked about.
+	 *
+	 * The option is read directly rather than through `WPSEO_Options`, to keep
+	 * this a soft dependency. An absent or unreadable value counts as on,
+	 * which is Yoast's own default.
+	 *
+	 * @return bool
+	 */
+	private static function isYoastSitemapActive(): bool {
+		if ( ! defined( 'WPSEO_VERSION' ) && ! class_exists( '\WPSEO_Sitemaps' ) ) {
+			return false;
+		}
+
+		if ( ! function_exists( 'get_option' ) ) {
+			return true;
+		}
+
+		$options = get_option( 'wpseo' );
+		if ( ! is_array( $options ) || ! array_key_exists( 'enable_xml_sitemap', $options ) ) {
+			return true;
+		}
+
+		return (bool) $options['enable_xml_sitemap'];
 	}
 
 	/**
@@ -881,9 +917,46 @@ final class WarmupSitemap {
 			return false;
 		}
 
-		$home_host = strtolower( (string) ( parse_url( (string) home_url(), PHP_URL_HOST ) ?: '' ) );
+		$home      = (string) home_url();
+		$home_host = strtolower( (string) ( parse_url( $home, PHP_URL_HOST ) ?: '' ) );
 
-		return '' !== $home_host && strtolower( $parts['host'] ) === $home_host;
+		if ( '' === $home_host || strtolower( $parts['host'] ) !== $home_host ) {
+			return false;
+		}
+
+		// Host alone is not the same origin. Without this, a URL on the site's
+		// own hostname but a different port passes the guard and is fetched --
+		// an internal service bound to :8080 or :9200 on that host becomes
+		// reachable through a sitemap index entry or a filter callback. Ports
+		// are normalised by scheme first, so one origin written two ways
+		// (`https://site` and `https://site:443`) still compares equal.
+		$home_port = parse_url( $home, PHP_URL_PORT );
+		$url_port  = self::effectivePort( $scheme, isset( $parts['port'] ) ? (int) $parts['port'] : null );
+		$site_port = self::effectivePort(
+			strtolower( (string) ( parse_url( $home, PHP_URL_SCHEME ) ?: '' ) ),
+			is_int( $home_port ) ? $home_port : null
+		);
+
+		return $url_port === $site_port;
+	}
+
+	/**
+	 * Port a URL actually connects on, with the scheme's default filled in.
+	 *
+	 * @param string   $scheme Lowercased URL scheme.
+	 * @param int|null $port   Explicit port, or null when the URL omits one.
+	 * @return int 0 when no port is given and the scheme is neither http nor https.
+	 */
+	private static function effectivePort( string $scheme, ?int $port ): int {
+		if ( null !== $port ) {
+			return $port;
+		}
+
+		return match ( $scheme ) {
+			'https' => 443,
+			'http'  => 80,
+			default => 0,
+		};
 	}
 
 	/**

--- a/src/Breeze/WarmupSitemap.php
+++ b/src/Breeze/WarmupSitemap.php
@@ -14,8 +14,11 @@ namespace Parisek\TimberKit\Breeze;
  * a manually maintained list capped at 30 entries. This class closes that
  * gap fleet-wide by discovering the sitemap URL set and merging it in.
  *
- * Sitemap source order: AIOSEO (`/sitemap.xml`) when active, otherwise core
- * (`/wp-sitemap.xml`). Both formats may be a sitemap index that points at
+ * Sitemap source order: AIOSEO (`/sitemap.xml`), then Yoast
+ * (`/sitemap_index.xml`), then core (`/wp-sitemap.xml`) — see
+ * {@see self::SITEMAP_PROVIDERS}. A project overrides the resolved address
+ * with the `timberkit_warmup_sitemap_url` filter. Every format may be a
+ * sitemap index that points at
  * per-post-type sub-sitemaps — those are followed recursively, bounded by
  * {@see self::MAX_SUBSITEMAPS} and {@see self::MAX_DEPTH} so a pathological
  * or malicious sitemap can never cause a runaway fetch chain. Every URL
@@ -534,7 +537,39 @@ final class WarmupSitemap {
 	}
 
 	/**
-	 * AIOSEO-first sitemap root URL resolution, falling back to WordPress core.
+	 * Sitemap root path per provider, in detection order.
+	 *
+	 * The order is the contract, not an accident of layout: a site can carry
+	 * more than one SEO plugin, and the first provider that answers wins.
+	 * AIOSEO stays first so an existing AIOSEO site resolves exactly the path
+	 * it resolved before this map existed. `core` is last and always matches.
+	 *
+	 * @var array<string, string>
+	 */
+	private const SITEMAP_PROVIDERS = array(
+		'aioseo' => '/sitemap.xml',
+		'yoast'  => '/sitemap_index.xml',
+		'core'   => '/wp-sitemap.xml',
+	);
+
+	/**
+	 * Sitemap root URL for whichever provider this site runs.
+	 *
+	 * Yoast is named explicitly rather than left to the core fallback. Yoast
+	 * redirects `/wp-sitemap.xml` to its own index with a 301, and
+	 * {@see self::fetchBody()} sends `redirection => 0` on purpose — following
+	 * a redirect is the SSRF surface this module closes. So on a Yoast site the
+	 * core path does not degrade to a slower answer, it degrades to no answer:
+	 * the response code lands outside 200-299 and the body is discarded. The
+	 * refresh then stores an empty list and says nothing, because an empty
+	 * `fetchSitemapRecords()` is a normal return value and `runRefresh()`
+	 * swallows throwables by contract.
+	 *
+	 * The filter is the escape hatch for the provider this list does not know
+	 * yet, and for the site that serves its sitemap from a non-default path.
+	 * Returning a non-string, or a URL off this site's own host, falls back to
+	 * the detected path — {@see self::isFetchableSameHostUrl()} would reject it
+	 * on fetch anyway, and failing here says so while the caller can still act.
 	 *
 	 * @return string Empty string when `home_url()` is unavailable.
 	 */
@@ -543,18 +578,41 @@ final class WarmupSitemap {
 			return '';
 		}
 
-		$path = self::isAioseoActive() ? '/sitemap.xml' : '/wp-sitemap.xml';
+		$provider = self::detectSitemapProvider();
+		$resolved = (string) home_url( self::SITEMAP_PROVIDERS[ $provider ] );
 
-		return (string) home_url( $path );
+		if ( ! function_exists( 'apply_filters' ) ) {
+			return $resolved;
+		}
+
+		$filtered = apply_filters( 'timberkit_warmup_sitemap_url', $resolved, $provider );
+
+		return ( is_string( $filtered ) && self::isFetchableSameHostUrl( $filtered ) )
+			? $filtered
+			: $resolved;
 	}
 
 	/**
-	 * Detect an active AIOSEO installation without a hard dependency on it.
+	 * Which sitemap provider is active, without a hard dependency on any of
+	 * them.
 	 *
-	 * @return bool
+	 * Each plugin is detected by a symbol it defines, never by reading the
+	 * active-plugin list: a must-use load, a renamed directory or a bundled
+	 * copy all keep the symbol and lose the list entry.
+	 *
+	 * @return string A key of {@see self::SITEMAP_PROVIDERS}; `core` when no
+	 *                SEO plugin answers.
 	 */
-	private static function isAioseoActive(): bool {
-		return function_exists( 'aioseo' ) || class_exists( '\AIOSEO\Plugin\AIOSEO' );
+	private static function detectSitemapProvider(): string {
+		if ( function_exists( 'aioseo' ) || class_exists( '\AIOSEO\Plugin\AIOSEO' ) ) {
+			return 'aioseo';
+		}
+
+		if ( defined( 'WPSEO_VERSION' ) || class_exists( '\WPSEO_Sitemaps' ) ) {
+			return 'yoast';
+		}
+
+		return 'core';
 	}
 
 	/**

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -24,6 +24,7 @@ use Parisek\Twig\AttributeExtension;
 use Parisek\Twig\TypographyExtension;
 use Parisek\TimberKit\BlockRenderer;
 use Parisek\TimberKit\Breeze\Health\PreloadChainHealthy;
+use Parisek\TimberKit\Breeze\Health\WarmupSitemapResolved;
 use Parisek\TimberKit\Breeze\WarmupSitemap;
 use Parisek\TimberKit\Health\Check\AuthorSitemapDisabled;
 use Parisek\TimberKit\Health\Check\FileEditingDisabled;
@@ -1225,7 +1226,7 @@ class StarterBase extends Site {
 	 * @return list<HealthCheck>
 	 */
 	protected function default_health_checks(): array {
-		return array(
+		$checks = array(
 			new XmlrpcDisabled(),
 			new WpVersionHidden(),
 			new AuthorSitemapDisabled(),
@@ -1235,6 +1236,16 @@ class StarterBase extends Site {
 			new GtmContainerNotDuplicated( array() !== $this->gtm_containers && GtmContainer::enabled() ),
 			new PreloadChainHealthy(),
 		);
+
+		// Registered only when the feature is on. A site that never asked for
+		// sitemap warmup would otherwise carry a permanent "not built yet"
+		// row, and a board with rows nobody can act on is a board nobody
+		// reads.
+		if ( $this->breeze_warmup_sitemap ) {
+			$checks[] = new WarmupSitemapResolved();
+		}
+
+		return $checks;
 	}
 
 	/**

--- a/tests/Unit/Breeze/Health/WarmupSitemapResolvedTest.php
+++ b/tests/Unit/Breeze/Health/WarmupSitemapResolvedTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Breeze\Health;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use Parisek\TimberKit\Breeze\Health\WarmupSitemapResolved;
+use Parisek\TimberKit\Breeze\PriorityStore;
+use Parisek\TimberKit\Health\HealthCheck;
+use Parisek\TimberKit\Health\Result;
+
+/**
+ * Covers the empty-warmup-list check.
+ *
+ * `WarmupSitemap` degrades silently by design: an empty sitemap result is a
+ * normal return value and the refresh job swallows throwables by contract. The
+ * administrator is the one left without a signal, and this check is that
+ * signal.
+ */
+class WarmupSitemapResolvedTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+		Functions\when( '__' )->returnArg();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * @param array<int, string>|null $urls Stored URLs, or null for "never refreshed".
+	 */
+	private function storeHolds( ?array $urls ): void {
+		$record = null === $urls
+			? null
+			: array(
+				'urls'         => $urls,
+				'signals'      => array(),
+				'fetched_at'   => 1000,
+				'weights_hash' => 'h',
+				'revision'     => 1,
+			);
+
+		Functions\when( 'get_option' )->alias(
+			static fn( string $key, $default = false ) => PriorityStore::OPTION_KEY === $key ? $record : $default
+		);
+	}
+
+	public function test_identity(): void {
+		$check = new WarmupSitemapResolved();
+
+		$this->assertSame( 'warmup_sitemap_resolved', $check->id() );
+		$this->assertSame( 'caching', $check->category() );
+		$this->assertSame( HealthCheck::METHOD_EFFECT, $check->method() );
+	}
+
+	public function test_a_never_refreshed_store_is_not_a_failure(): void {
+		// The first purge after activation schedules the refresh, so a fresh
+		// install sits here through no fault of its own. Calling that a
+		// failure trains an administrator to ignore the check.
+		$this->storeHolds( null );
+
+		$this->assertSame( Result::GOOD, ( new WarmupSitemapResolved() )->run()->status() );
+	}
+
+	public function test_a_refreshed_but_empty_list_is_critical(): void {
+		$this->storeHolds( array() );
+
+		$result = ( new WarmupSitemapResolved() )->run();
+
+		$this->assertSame( Result::CRITICAL, $result->status() );
+	}
+
+	public function test_a_populated_list_passes_and_reports_the_count(): void {
+		$this->storeHolds( array( 'https://example.test/a/', 'https://example.test/b/' ) );
+
+		$result = ( new WarmupSitemapResolved() )->run();
+
+		$this->assertSame( Result::GOOD, $result->status() );
+		$this->assertStringContainsString( '2', $result->summary() );
+	}
+}

--- a/tests/Unit/Breeze/WarmupSitemap/FetchSitemapUrlsTest.php
+++ b/tests/Unit/Breeze/WarmupSitemap/FetchSitemapUrlsTest.php
@@ -199,6 +199,130 @@ class FetchSitemapUrlsTest extends TestCase {
 		$this->assertSame( array( 'https://example.test/wp-sitemap.xml' ), $requested );
 	}
 
+	public function test_rejects_a_filter_url_on_the_same_host_but_another_port(): void {
+		// Host alone is not the same origin. A service bound to :9200 on the
+		// site's own hostname is a different service, and fetching it is the
+		// SSRF this guard exists to stop.
+		Functions\when( 'home_url' )->alias( fn( $path = '' ) => 'https://example.test' . $path );
+		Functions\when( 'apply_filters' )->alias(
+			fn( $hook, $value, ...$args ) => 'timberkit_warmup_sitemap_url' === $hook
+				? 'https://example.test:9200/sitemap.xml'
+				: $value
+		);
+
+		$requested = array();
+		Functions\when( 'wp_remote_get' )->alias(
+			function ( $url ) use ( &$requested ) {
+				$requested[] = $url;
+				return Fixtures::response( Fixtures::urlset( array( 'https://example.test/page/' ) ) );
+			}
+		);
+
+		WarmupSitemap::fetchSitemapUrls();
+
+		$this->assertSame( array( 'https://example.test/wp-sitemap.xml' ), $requested );
+	}
+
+	public function test_accepts_a_filter_url_whose_port_is_the_scheme_default(): void {
+		// The same origin written two ways must not be read as two origins.
+		Functions\when( 'home_url' )->alias( fn( $path = '' ) => 'https://example.test' . $path );
+		Functions\when( 'apply_filters' )->alias(
+			fn( $hook, $value, ...$args ) => 'timberkit_warmup_sitemap_url' === $hook
+				? 'https://example.test:443/custom.xml'
+				: $value
+		);
+
+		$requested = array();
+		Functions\when( 'wp_remote_get' )->alias(
+			function ( $url ) use ( &$requested ) {
+				$requested[] = $url;
+				return Fixtures::response( Fixtures::urlset( array( 'https://example.test/page/' ) ) );
+			}
+		);
+
+		WarmupSitemap::fetchSitemapUrls();
+
+		$this->assertSame( array( 'https://example.test:443/custom.xml' ), $requested );
+	}
+
+	public function test_skips_a_sitemap_index_entry_on_another_port(): void {
+		// The filter is developer-written; a sitemap index is not. This is the
+		// path an attacker actually controls.
+		Functions\when( 'home_url' )->alias( fn( $path = '' ) => 'https://example.test' . $path );
+
+		$requested = array();
+		Functions\when( 'wp_remote_get' )->alias(
+			function ( $url ) use ( &$requested ) {
+				$requested[] = $url;
+				return 'https://example.test/wp-sitemap.xml' === $url
+					? Fixtures::response(
+						Fixtures::sitemapIndex(
+							array(
+								'https://example.test:9200/internal.xml',
+								'https://example.test/wp-sitemap-posts.xml',
+							)
+						)
+					)
+					: Fixtures::response( Fixtures::urlset( array( 'https://example.test/page/' ) ) );
+			}
+		);
+
+		$result = WarmupSitemap::fetchSitemapUrls();
+
+		$this->assertNotContains( 'https://example.test:9200/internal.xml', $requested );
+		$this->assertSame( array( 'https://example.test/page/' ), $result );
+	}
+
+	public function test_falls_back_to_core_when_yoast_sitemaps_are_switched_off(): void {
+		// Yoast can be loaded with its XML sitemap turned off, and then core
+		// serves /wp-sitemap.xml again. Detecting on the symbol alone would
+		// send those sites to an address that 404s -- a configuration that
+		// worked before Yoast was recognised here.
+		if ( ! defined( 'WPSEO_VERSION' ) ) {
+			define( 'WPSEO_VERSION', '24.0' );
+		}
+		Functions\when( 'home_url' )->alias( fn( $path = '' ) => 'https://example.test' . $path );
+		Functions\when( 'get_option' )->alias(
+			fn( $name, $default = false ) => 'wpseo' === $name
+				? array( 'enable_xml_sitemap' => false )
+				: $default
+		);
+
+		$requested = array();
+		Functions\when( 'wp_remote_get' )->alias(
+			function ( $url ) use ( &$requested ) {
+				$requested[] = $url;
+				return Fixtures::response( Fixtures::urlset( array( 'https://example.test/page/' ) ) );
+			}
+		);
+
+		WarmupSitemap::fetchSitemapUrls();
+
+		$this->assertSame( array( 'https://example.test/wp-sitemap.xml' ), $requested );
+	}
+
+	public function test_yoast_stays_selected_when_the_sitemap_switch_is_absent(): void {
+		// Yoast's own default is on, so an option that never stored the key
+		// must not be read as off.
+		if ( ! defined( 'WPSEO_VERSION' ) ) {
+			define( 'WPSEO_VERSION', '24.0' );
+		}
+		Functions\when( 'home_url' )->alias( fn( $path = '' ) => 'https://example.test' . $path );
+		Functions\when( 'get_option' )->alias( fn( $name, $default = false ) => 'wpseo' === $name ? array() : $default );
+
+		$requested = array();
+		Functions\when( 'wp_remote_get' )->alias(
+			function ( $url ) use ( &$requested ) {
+				$requested[] = $url;
+				return Fixtures::response( Fixtures::urlset( array( 'https://example.test/page/' ) ) );
+			}
+		);
+
+		WarmupSitemap::fetchSitemapUrls();
+
+		$this->assertSame( array( 'https://example.test/sitemap_index.xml' ), $requested );
+	}
+
 	public function test_recurses_into_sitemap_index_entries(): void {
 		Functions\when( 'home_url' )->alias( fn( $path = '' ) => 'https://example.test' . $path );
 

--- a/tests/Unit/Breeze/WarmupSitemap/FetchSitemapUrlsTest.php
+++ b/tests/Unit/Breeze/WarmupSitemap/FetchSitemapUrlsTest.php
@@ -82,6 +82,123 @@ class FetchSitemapUrlsTest extends TestCase {
 		$this->assertSame( array( 'https://example.test/aioseo-page/' ), $result );
 	}
 
+	public function test_prefers_yoast_sitemap_index_when_active(): void {
+		// Yoast redirects /wp-sitemap.xml to its own index with a 301, and
+		// fetchBody() sends redirection => 0 on purpose. Resolving the core
+		// path on a Yoast site therefore yields no records at all, not a
+		// slower answer -- so the provider has to be named, not fallen back to.
+		if ( ! defined( 'WPSEO_VERSION' ) ) {
+			define( 'WPSEO_VERSION', '24.0' );
+		}
+		Functions\when( 'home_url' )->alias( fn( $path = '' ) => 'https://example.test' . $path );
+
+		$requested = array();
+		Functions\when( 'wp_remote_get' )->alias(
+			function ( $url ) use ( &$requested ) {
+				$requested[] = $url;
+				return Fixtures::response( Fixtures::urlset( array( 'https://example.test/yoast-page/' ) ) );
+			}
+		);
+
+		$result = WarmupSitemap::fetchSitemapUrls();
+
+		$this->assertSame( array( 'https://example.test/sitemap_index.xml' ), $requested );
+		$this->assertSame( array( 'https://example.test/yoast-page/' ), $result );
+	}
+
+	public function test_aioseo_wins_over_yoast_when_both_are_present(): void {
+		// Detection order is a contract, not an accident of layout: AIOSEO
+		// stays first so a site that already had both keeps resolving the path
+		// it resolved before the provider map existed.
+		if ( ! function_exists( 'aioseo' ) ) {
+			// See the note in test_prefers_aioseo_sitemap_when_active().
+			eval( 'function aioseo() { return true; }' );
+		}
+		if ( ! defined( 'WPSEO_VERSION' ) ) {
+			define( 'WPSEO_VERSION', '24.0' );
+		}
+		Functions\when( 'home_url' )->alias( fn( $path = '' ) => 'https://example.test' . $path );
+
+		$requested = array();
+		Functions\when( 'wp_remote_get' )->alias(
+			function ( $url ) use ( &$requested ) {
+				$requested[] = $url;
+				return Fixtures::response( Fixtures::urlset( array( 'https://example.test/page/' ) ) );
+			}
+		);
+
+		WarmupSitemap::fetchSitemapUrls();
+
+		$this->assertSame( array( 'https://example.test/sitemap.xml' ), $requested );
+	}
+
+	public function test_filter_overrides_the_resolved_sitemap_url(): void {
+		Functions\when( 'home_url' )->alias( fn( $path = '' ) => 'https://example.test' . $path );
+		Functions\when( 'apply_filters' )->alias(
+			fn( $hook, $value, ...$args ) => 'timberkit_warmup_sitemap_url' === $hook
+				? 'https://example.test/custom/sitemap.xml'
+				: $value
+		);
+
+		$requested = array();
+		Functions\when( 'wp_remote_get' )->alias(
+			function ( $url ) use ( &$requested ) {
+				$requested[] = $url;
+				return Fixtures::response( Fixtures::urlset( array( 'https://example.test/custom-page/' ) ) );
+			}
+		);
+
+		$result = WarmupSitemap::fetchSitemapUrls();
+
+		$this->assertSame( array( 'https://example.test/custom/sitemap.xml' ), $requested );
+		$this->assertSame( array( 'https://example.test/custom-page/' ), $result );
+	}
+
+	public function test_filter_receives_the_detected_provider(): void {
+		Functions\when( 'home_url' )->alias( fn( $path = '' ) => 'https://example.test' . $path );
+
+		$seen = null;
+		Functions\when( 'apply_filters' )->alias(
+			function ( $hook, $value, ...$args ) use ( &$seen ) {
+				if ( 'timberkit_warmup_sitemap_url' === $hook ) {
+					$seen = $args[0] ?? null;
+				}
+				return $value;
+			}
+		);
+		Functions\when( 'wp_remote_get' )->alias(
+			fn( $url ) => Fixtures::response( Fixtures::urlset( array( 'https://example.test/page/' ) ) )
+		);
+
+		WarmupSitemap::fetchSitemapUrls();
+
+		$this->assertSame( 'core', $seen );
+	}
+
+	public function test_filter_returning_an_off_host_url_falls_back_to_the_detected_path(): void {
+		// isFetchableSameHostUrl() would reject it at fetch time anyway. Doing
+		// it here keeps the SSRF guard and still warms the site, instead of
+		// silently warming nothing because one filter callback was wrong.
+		Functions\when( 'home_url' )->alias( fn( $path = '' ) => 'https://example.test' . $path );
+		Functions\when( 'apply_filters' )->alias(
+			fn( $hook, $value, ...$args ) => 'timberkit_warmup_sitemap_url' === $hook
+				? 'https://evil.test/sitemap.xml'
+				: $value
+		);
+
+		$requested = array();
+		Functions\when( 'wp_remote_get' )->alias(
+			function ( $url ) use ( &$requested ) {
+				$requested[] = $url;
+				return Fixtures::response( Fixtures::urlset( array( 'https://example.test/page/' ) ) );
+			}
+		);
+
+		WarmupSitemap::fetchSitemapUrls();
+
+		$this->assertSame( array( 'https://example.test/wp-sitemap.xml' ), $requested );
+	}
+
 	public function test_recurses_into_sitemap_index_entries(): void {
 		Functions\when( 'home_url' )->alias( fn( $path = '' ) => 'https://example.test' . $path );
 


### PR DESCRIPTION
Closes #142.

## What

`Breeze\WarmupSitemap` resolved the sitemap root from two candidates, AIOSEO and WordPress core. A Yoast site got core's and produced an **empty** warmup list without a word of complaint.

Providers are now a list, checked in order:

| Provider | Detected by | Root |
| --- | --- | --- |
| AIOSEO | `aioseo()` / `\AIOSEO\Plugin\AIOSEO` | `/sitemap.xml` |
| Yoast SEO | `WPSEO_VERSION` / `\WPSEO_Sitemaps` | `/sitemap_index.xml` |
| WordPress core | nothing else answered | `/wp-sitemap.xml` |

Plus `timberkit_warmup_sitemap_url`, which receives the resolved URL and the detected provider key.

## Why the core fallback did not already cover it

Yoast redirects `/wp-sitemap.xml` to its own index with a 301, and every fetch here sends `redirection => 0` deliberately — following a redirect is the SSRF surface this module closes. So on a Yoast site the core path does not degrade to a slower answer, it degrades to **no** answer: the code lands outside 200–299 and the body is dropped.

Nothing reports that. An empty `fetchSitemapRecords()` is a normal return value, and `runRefresh()` swallows throwables by contract. A project switches the flag on, sees no warning, and ships a warmup that preloads nothing.

## Measured, not assumed

Against a live Yoast Premium site (WPML, five languages), by reflection:

| | Released v1.39.0 | This branch |
| --- | --- | --- |
| Provider detected | — | `yoast` |
| Root requested | `/wp-sitemap.xml` | `/sitemap_index.xml` |
| Records | **0** | **2873** |
| `breeze_preload_urls` | 0 | 200 (the cap), five language homepages first |

Post types came out of Yoast's filenames unchanged: `blog=1469 lexicon=767 page=368 case_studies=103 ebooks=61`.

The two patched files were copied onto that server for the measurement and restored afterwards; MD5 confirms the vendor tree is byte-identical to v1.39.0 again.

## What was deliberately left alone

**`'redirection' => 0` stays.** Opening redirects would also make Yoast work, and would trade a real protection for a symptom. The defect is a missing branch, not the hardening.

**`SourceNaming` logic is unchanged.** Yoast shares AIOSEO's `<type>-sitemap.xml` shape, and the pattern already tolerates the index Yoast appends when a type spills over one file (`blog-sitemap2.xml`). Only the constant was renamed — `AIOSEO_NON_POST_TYPE_INDEXES` → `NON_POST_TYPE_INDEXES` — because a list that now serves both plugins cannot keep a name claiming one. `author` comes from both; the rest only from AIOSEO.

**Detection does not read the active-plugin list.** A must-use load, a renamed directory or a bundled copy all keep the plugin's symbol and lose the list entry.

## Ordering

AIOSEO stays first, so a site that already ran it resolves exactly the path it resolved before this map existed. A regression test pins that, and it passes both before and after the change on purpose.

## Tests

Five added to `FetchSitemapUrlsTest`. Three fail on `main` (Yoast root, filter override, filter arguments); two are guards that pass on both sides by design — the AIOSEO-wins-over-Yoast ordering, and the off-host filter rejection, which `main` passes only because it has no filter at all. Saying so rather than counting it as proof.

`composer check` green: 1632 tests / 2714 assertions, 18 property tests, PHPStan clean, ADR index OK.
