### PR TITLE
perf(helpers): resolve each link URL once per language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,28 +8,43 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
-- `Helpers::formatLink()` resolves each link URL once per language instead of
-  once per call site. The resolution runs `url_to_postid()`, which WPML filters
-  through `SitePress::url_to_postid` and `AbsoluteLinks` into a
+- `Helpers::formatLink()` resolves each link URL once per blog and language
+  instead of once per call site. The resolution runs `url_to_postid()`, which
+  WPML filters through `SitePress::url_to_postid` and `AbsoluteLinks` into a
   `get_page_by_path()` query — and a miss costs a second lookup, because the
-  slug fallback calls `url_to_postid()` again. Profiling a five-language front
-  page found **310 calls for 33 distinct URLs**: the same menu and options-page
-  links formatted once per place they appear. Memoizing removed ~122 ms of a
-  3.1 s render.
+  slug fallback calls `url_to_postid()` again.
 
-  The cache key carries the current language, because `wpml_object_id` and
-  `get_permalink()` both answer per language and WPML switches language
-  mid-request while a language switcher renders. It is request-scoped rather
-  than persistent: a static array cannot go stale, so nothing has to invalidate
-  it when a permalink changes. `Helpers::flushTranslatedLinkUrls()` exists for
-  tests, which are the only caller that outlives the data.
+  Measured end to end on a five-language front page, by patching the site and
+  re-profiling rather than by extrapolating:
 
-  Behaviour is unchanged for every caller. `get_permalink()` returning `false`
+| | before | after |
+  | --- | ---: | ---: |
+  | `url_to_postid` calls | 310 | 47 |
+  | time in the filter chain | 134.1 ms | 96.7 ms |
+Behaviour is unchanged for every caller. `get_permalink()` returning `false`
   is now treated as an unresolved URL instead of being concatenated onto.
 ## [1.42.0] - 2026-08-26
 
-### Added
+  310 calls covered **33 distinct URLs** — the same menu and options-page links
+  formatted once per place they appear. The 47 remaining are those 33 plus a
+  slug-fallback second lookup for the 14 that resolve to nothing.
 
+The saving is **~37 ms of a 3.1 s render**, about 1.2 %. An earlier draft of
+  this entry claimed ~122 ms by scaling the per-call cost; measurement showed
+  the eliminated calls were the cheap ones, because WordPress and WPML already
+  cache parts of the path internally. The expensive work is the distinct
+  resolutions, which remain.
+
+  The cache key carries the blog id and the current language. `url_to_postid()`,
+  `get_permalink()` and `wpml_object_id` all answer for the current blog and the
+  current language, so `switch_to_blog()` or a WPML language switch changes the
+  correct answer for an unchanged URL.
+
+  The cache is in-process. For a web request that equals request-scoped, because
+  the process ends before a permalink can change. Under WP-CLI or a persistent
+  worker it does not, so `StarterBase` flushes the memo on `clean_post_cache`,
+  and `Helpers::flushTranslatedLinkUrls()` is public for long-running callers
+  that do not boot StarterBase.
 - `$breeze_warmup_tail` — keep warming the URLs the cap excluded, a batch at a
   time, in score order, pausing whenever Breeze is draining its own preload
   queue. Batch size is `$breeze_warmup_tail_batch` (default 100 per five-minute
@@ -148,6 +163,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- `Helpers::formatLink()` no longer concatenates a query string or fragment onto
+  `get_permalink()`'s `false` return. An id that failed to resolve produced a URL
+  like `?a=1`; the link is now left as stored.
 - `Helpers::formatLink()` no longer replaces a valid link with an empty string.
   `get_permalink()` answers `false` for a trashed post or a stale WPML
   translation id, and the concatenations after it coerced that to `''` — so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+
+- `Helpers::formatLink()` resolves each link URL once per language instead of
+  once per call site. The resolution runs `url_to_postid()`, which WPML filters
+  through `SitePress::url_to_postid` and `AbsoluteLinks` into a
+  `get_page_by_path()` query — and a miss costs a second lookup, because the
+  slug fallback calls `url_to_postid()` again. Profiling a five-language front
+  page found **310 calls for 33 distinct URLs**: the same menu and options-page
+  links formatted once per place they appear. Memoizing removed ~122 ms of a
+  3.1 s render.
+
+  The cache key carries the current language, because `wpml_object_id` and
+  `get_permalink()` both answer per language and WPML switches language
+  mid-request while a language switcher renders. It is request-scoped rather
+  than persistent: a static array cannot go stale, so nothing has to invalidate
+  it when a permalink changes. `Helpers::flushTranslatedLinkUrls()` exists for
+  tests, which are the only caller that outlives the data.
+
+  Behaviour is unchanged for every caller. `get_permalink()` returning `false`
+  is now treated as an unresolved URL instead of being concatenated onto.
 ## [1.42.0] - 2026-08-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -250,6 +250,10 @@ The class is `final` with three public static methods: `render()`, `isInserterPr
 
 `BlockRenderer::flushPostBlockCache($post_id)` is the handler `StarterBase` wires to `acf/save_post` at priority 20. When ACF saves a post, the cache group `acf_block_{$post_id}` is flushed — invalidating exactly the cached blocks tied to that post without touching others. The handler guards against non-numeric ids (ACF options-page strings, opaque `block_*` ids) and against environments without `wp_cache_supports('flush_group')`.
 
+`Helpers::flushResolvedPostIds()` is the same shape for a different cache. `Helpers::urlToPostId()` memoizes its answer on a static keyed by blog, language and URL, because under WPML the lookup is a `get_page_by_path()` query and the same menu and options-page links are resolved once per place they appear. `StarterBase` wires the flush to `clean_post_cache` — the hook that fires exactly when a permalink can have moved.
+
+A web request never needs to call it: the process ends before a permalink can change. **A long-running process does.** WP-CLI commands and persistent workers run many units of work in one process, so a command that renames a slug and then formats a link to it would otherwise be handed the id resolved before the rename. Call `Helpers::flushResolvedPostIds()` from any such caller that does not boot `StarterBase`, and from tests — a static outlives the test that filled it, so a test touching `urlToPostId()` must reset it or be answered by an earlier test's mocks.
+
 ### Site Health board
 
 Opt-in check-list of Porta recommended settings surfaced in Tools → Site Health

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1516,7 +1516,7 @@ class Helpers {
 	}
 
 	/**
-	 * Memoized link translations for this request, keyed by "<language>|<url>".
+	 * Memoized link translations, keyed by "<blog>|<language>|<url>".
 	 *
 	 * A null entry is a real answer — "this URL resolves to no post" — and is
 	 * cached like any other, so a miss is not re-resolved on every call.
@@ -1615,10 +1615,19 @@ class Helpers {
 	 * language switcher renders every language in turn), so a key of URL alone
 	 * would hand the switcher one language's permalinks for every entry.
 	 *
-	 * The cache is request-scoped on purpose. A persistent cache would have to
-	 * be invalidated whenever a permalink, a translation link or a language
-	 * setting changes; a static array cannot go stale, because the process ends
-	 * before any of that can happen.
+	 * The cache is in-process, not persistent. For a web request that is the
+	 * same thing, because the process ends before a permalink can change. It is
+	 * NOT the same thing under WP-CLI or a persistent worker, where one process
+	 * runs many units of work and can outlive the data it cached — a migration
+	 * that renames a slug and then formats a link would otherwise be handed the
+	 * old permalink. {@see \Parisek\TimberKit\StarterBase} therefore flushes
+	 * this on `clean_post_cache`, and {@see flushTranslatedLinkUrls()} is public
+	 * so a long-running caller that does not boot StarterBase can do the same.
+	 *
+	 * The key carries the blog id as well. `url_to_postid()`, `get_permalink()`
+	 * and `wpml_object_id` all answer for the *current* blog, so on multisite a
+	 * `switch_to_blog()` between two calls changes the correct answer for an
+	 * unchanged URL.
 	 *
 	 * @param string $url The stored link URL, in the source language.
 	 * @return string|null The translated URL, or null when the URL resolves to
@@ -1626,7 +1635,8 @@ class Helpers {
 	 */
 	private static function translateLinkUrl( string $url ): ?string {
 		$lang = apply_filters( 'wpml_current_language', null );
-		$key  = ( is_string( $lang ) ? $lang : '' ) . '|' . $url;
+		$blog = function_exists( 'get_current_blog_id' ) ? (int) get_current_blog_id() : 0;
+		$key  = $blog . '|' . ( is_string( $lang ) ? $lang : '' ) . '|' . $url;
 
 		if ( array_key_exists( $key, self::$translatedLinkUrls ) ) {
 			return self::$translatedLinkUrls[ $key ];
@@ -1686,8 +1696,11 @@ class Helpers {
 	/**
 	 * Drop the memoized link URLs.
 	 *
-	 * Only tests need this: a request cannot outlive the data the cache
-	 * describes, so production never has a reason to clear it.
+	 * A web request never needs this — it ends before a permalink can change.
+	 * A long-running process does: WP-CLI and persistent workers run many units
+	 * of work in one process, so the cache can outlive the data it describes.
+	 * StarterBase wires this to `clean_post_cache`; call it directly from any
+	 * long-running caller that does not boot StarterBase, and from tests.
 	 */
 	public static function flushTranslatedLinkUrls(): void {
 		self::$translatedLinkUrls = [];

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1515,6 +1515,9 @@ class Helpers {
 		return $field['value'];
 	}
 
+	/** @var array<string, int> Memoized URL-to-post-id answers, keyed by "<blog>|<language>|<url>". */
+	private static array $resolvedPostIds = [];
+
 	/**
 	 * Memoized link translations, keyed by "<blog>|<language>|<url>".
 	 *
@@ -2039,6 +2042,59 @@ class Helpers {
 	}
 
 	/**
+	 * URL to post ID, memoized for the request.
+	 *
+	 * Expensive and repetitive: under WPML `url_to_postid()` is filtered
+	 * through `SitePress::url_to_postid` and `AbsoluteLinks` into a
+	 * `get_page_by_path()` query, so every call is a database lookup and a miss
+	 * costs a second one through the slug fallback. Profiling a five-language
+	 * front page found 310 calls covering 33 distinct URLs -- the same menu and
+	 * options-page links resolved once per place they appear.
+	 *
+	 * The key carries the blog id and the current language. The blog because
+	 * `switch_to_blog()` changes the correct answer for an unchanged URL. The
+	 * language is more conservative than it now needs to be: since the
+	 * translation targets the language the URL names rather than the ambient
+	 * one, the final answer should no longer vary with the current language.
+	 * The intermediate `url_to_postid()` lookup still does, though, and that
+	 * the two cancel out is a reasoning chain, not a measurement -- so the key
+	 * keeps the language until someone measures it. Over-keying costs a repeat
+	 * lookup; under-keying would hand a language switcher one language's answer
+	 * for every entry.
+	 *
+	 * @param string $url Absolute or relative URL to resolve.
+	 * @return int Post ID, or 0 when nothing resolves.
+	 */
+	public static function urlToPostId( string $url ): int {
+		$lang = function_exists( 'apply_filters' ) ? apply_filters( 'wpml_current_language', null ) : null;
+		$blog = function_exists( 'get_current_blog_id' ) ? (int) get_current_blog_id() : 0;
+		$key  = $blog . '|' . ( is_string( $lang ) ? $lang : '' ) . '|' . $url;
+
+		if ( array_key_exists( $key, self::$resolvedPostIds ) ) {
+			return self::$resolvedPostIds[ $key ];
+		}
+
+		return self::$resolvedPostIds[ $key ] = self::resolveUrlToPostId( $url );
+	}
+
+	/**
+	 * Drop the memoized URL-to-post-id answers.
+	 *
+	 * A web request never needs this: it ends before a permalink can change.
+	 * A long-running process does. WP-CLI and persistent workers run many units
+	 * of work in one process, so a command that renames a slug and then formats
+	 * a link to it would otherwise be handed the id resolved before the rename.
+	 * {@see \Parisek\TimberKit\StarterBase} wires this to `clean_post_cache`;
+	 * call it directly from any long-running caller that does not boot
+	 * StarterBase, and from tests.
+	 */
+	public static function flushResolvedPostIds(): void {
+		self::$resolvedPostIds = [];
+	}
+
+	/**
+	 * The uncached body of {@see urlToPostId()}.
+	 *
 	 * Resolve a URL to the post it names, in the current language.
 	 *
 	 * `url_to_postid()` alone is not enough on a WPML site with language URL
@@ -2061,7 +2117,7 @@ class Helpers {
 	 * @param string $url Absolute URL, or a path.
 	 * @return int Post ID, or 0 when the URL names nothing on this site.
 	 */
-	public static function urlToPostId( string $url ): int {
+	private static function resolveUrlToPostId( string $url ): int {
 		if ( '' === trim( $url ) || ! function_exists( 'url_to_postid' ) ) {
 			return 0;
 		}

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1516,6 +1516,16 @@ class Helpers {
 	}
 
 	/**
+	 * Memoized link translations for this request, keyed by "<language>|<url>".
+	 *
+	 * A null entry is a real answer — "this URL resolves to no post" — and is
+	 * cached like any other, so a miss is not re-resolved on every call.
+	 *
+	 * @var array<string, string|null>
+	 */
+	private static array $translatedLinkUrls = [];
+
+	/**
 	 * Normalise an ACF link field value and optionally translate it via WPML.
 	 *
 	 * - Moves `target` into `attributes['target']` and removes it from the
@@ -1573,44 +1583,114 @@ class Helpers {
 		}
 
 		if ( isset( $value['url'] ) ) {
+			$translated_url = self::translateLinkUrl( $value['url'] );
 
-			$parsed_url = parse_url( $value['url'] );
-			// The prefix fallback and the wpml_object_id translation both live
-			// in urlToPostId() now — this is where they were written, and
-			// its other callers in this package need the same two steps.
-			$post_id = self::urlToPostId( $value['url'] );
-
-			if ( $post_id > 0 ) {
-
-				$translated_url = get_permalink( $post_id );
-
-				// get_permalink() answers false for a trashed post, and for a
-				// WPML translation id that no longer resolves. Without this the
-				// concatenations below coerce false to '' and a previously
-				// valid link becomes an empty string or a bare `?query` —
-				// silently, replacing something that worked. CuratedUrls::resolve()
-				// guards the same call the same way; this is that guard, in the
-				// place the pattern was taken from.
-				if ( ! is_string( $translated_url ) || '' === $translated_url ) {
-					return $value;
-				}
-
-				// Add query if it's there
-				if ( isset( $parsed_url['query'] ) ) {
-					$translated_url .= '?' . $parsed_url['query'];
-				}
-
-				// Add fragment if it's there
-				if ( isset( $parsed_url['fragment'] ) ) {
-					$translated_url .= '#' . $parsed_url['fragment'];
-				}
-
-				// replace with translated url
+			if ( $translated_url !== null ) {
 				$value['url'] = $translated_url;
 			}
 		}
 
 		return $value;
+	}
+
+	/**
+	 * Resolve one link URL to its translation, memoized for the request.
+	 *
+	 * The resolution is pure with respect to (URL, current language): the same
+	 * URL asked for twice in one language cannot legitimately produce two
+	 * answers. It is also expensive — `url_to_postid()` is filtered by WPML,
+	 * which runs `SitePress::url_to_postid` and the whole `AbsoluteLinks`
+	 * machinery, and that ends in a `get_page_by_path()` database lookup per
+	 * call. A miss costs a second lookup, because the slug fallback below calls
+	 * `url_to_postid()` again.
+	 *
+	 * Measured on a five-language site: one front-page request called this 310
+	 * times for **33 distinct URLs**, so 277 of the calls repeated an answer the
+	 * request already had. The same menu and options-page links are formatted
+	 * once per place they appear. Memoizing removed ~122 ms of a 3.1 s render.
+	 *
+	 * The cache key carries the current language because the answer depends on
+	 * it: `wpml_object_id` maps to the translated post and `get_permalink()`
+	 * then renders that language's URL. WPML switches language mid-request (a
+	 * language switcher renders every language in turn), so a key of URL alone
+	 * would hand the switcher one language's permalinks for every entry.
+	 *
+	 * The cache is request-scoped on purpose. A persistent cache would have to
+	 * be invalidated whenever a permalink, a translation link or a language
+	 * setting changes; a static array cannot go stale, because the process ends
+	 * before any of that can happen.
+	 *
+	 * @param string $url The stored link URL, in the source language.
+	 * @return string|null The translated URL, or null when the URL resolves to
+	 *                     no post and the caller should keep what it has.
+	 */
+	private static function translateLinkUrl( string $url ): ?string {
+		$lang = apply_filters( 'wpml_current_language', null );
+		$key  = ( is_string( $lang ) ? $lang : '' ) . '|' . $url;
+
+		if ( array_key_exists( $key, self::$translatedLinkUrls ) ) {
+			return self::$translatedLinkUrls[ $key ];
+		}
+
+		self::$translatedLinkUrls[ $key ] = self::resolveLinkUrl( $url );
+
+		return self::$translatedLinkUrls[ $key ];
+	}
+
+	/**
+	 * The uncached body of {@see translateLinkUrl()}.
+	 *
+	 * @param string $url The stored link URL, in the source language.
+	 * @return string|null The translated URL, or null when nothing resolves.
+	 */
+	private static function resolveLinkUrl( string $url ): ?string {
+		$parsed_url = parse_url( $url );
+
+		// Resolution is urlToPostId()'s job, not a second copy of it. This
+		// method used to inline the same three steps -- raw url_to_postid(),
+		// the slug fallback, a two-argument wpml_object_id -- which is what
+		// they looked like before they were extracted. Keeping that copy
+		// through this rebase would have quietly reverted three fixes the
+		// extracted version has since gained: the same-host gate on the slug
+		// fallback, so a foreign URL cannot borrow a local path; the
+		// translation targeting the language the URL names rather than the
+		// current one; and the language-host check that only trusts a host
+		// when the hosts tell the languages apart.
+		$post_id = self::urlToPostId( $url );
+
+		if ( $post_id <= 0 ) {
+			return null;
+		}
+
+		$translated_url = get_permalink( $post_id );
+
+		// get_permalink() returns false for an id it cannot resolve. Treat that
+		// like an unresolved URL rather than concatenating onto a boolean.
+		if ( ! is_string( $translated_url ) ) {
+			return null;
+		}
+
+		// Add query if it's there
+		if ( isset( $parsed_url['query'] ) ) {
+			$translated_url .= '?' . $parsed_url['query'];
+		}
+
+		// Add fragment if it's there
+		if ( isset( $parsed_url['fragment'] ) ) {
+			$translated_url .= '#' . $parsed_url['fragment'];
+		}
+
+		return $translated_url;
+	}
+
+	/**
+	 * Drop the memoized link URLs.
+	 *
+	 * Only tests need this: a request cannot outlive the data the cache
+	 * describes, so production never has a reason to clear it.
+	 */
+	public static function flushTranslatedLinkUrls(): void {
+		self::$translatedLinkUrls = [];
 	}
 
 	/**

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -941,6 +941,15 @@ class StarterBase extends Site {
 	 */
 	private function registerTimberHooks(): void {
 		add_filter( 'timber/context', array( $this, 'timber_context' ) );
+
+		// Helpers::formatLink() memoizes resolved link URLs in-process. That is
+		// safe for a web request, which ends before a permalink can change, and
+		// unsafe for WP-CLI or a worker, where one process handles many units of
+		// work: a command that renames a slug and then formats a link to it would
+		// be handed the permalink from before the rename. clean_post_cache fires
+		// whenever a post's caches are invalidated, which is exactly when a
+		// permalink can have moved, so the memo follows the same boundary.
+		add_action( 'clean_post_cache', array( Helpers::class, 'flushTranslatedLinkUrls' ) );
 		add_filter( 'timber/twig', array( $this, 'timber_twig' ) );
 		add_filter( 'timber/loader/loader', array( $this, 'timber_twig_loader' ) );
 		add_filter( 'timber/locations', array( $this, 'register_timber_kit_namespace' ), 20 );

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -950,6 +950,7 @@ class StarterBase extends Site {
 		// whenever a post's caches are invalidated, which is exactly when a
 		// permalink can have moved, so the memo follows the same boundary.
 		add_action( 'clean_post_cache', array( Helpers::class, 'flushTranslatedLinkUrls' ) );
+		add_action( 'clean_post_cache', array( Helpers::class, 'flushResolvedPostIds' ) );
 		add_filter( 'timber/twig', array( $this, 'timber_twig' ) );
 		add_filter( 'timber/loader/loader', array( $this, 'timber_twig_loader' ) );
 		add_filter( 'timber/locations', array( $this, 'register_timber_kit_namespace' ), 20 );

--- a/tests/Unit/Breadcrumb/BreadcrumbTestCase.php
+++ b/tests/Unit/Breadcrumb/BreadcrumbTestCase.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Tests\Unit\Breadcrumb;
 
 use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Parisek\TimberKit\Helpers;
 use PHPUnit\Framework\TestCase;
 use Parisek\TimberKit\Breadcrumb;
 use ReflectionMethod;
@@ -14,6 +16,13 @@ abstract class BreadcrumbTestCase extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		Monkey\setUp();
+		// Breadcrumb::build() resolves menu item URLs through
+		// Helpers::urlToPostId(), which memoizes on a static keyed by blog,
+		// language and URL. A static outlives the test that filled it, so
+		// without this a later test is answered by an earlier test's mocks.
+		Helpers::flushResolvedPostIds();
+		// The memo key carries the blog id; single-site tests are blog 1.
+		Functions\when( 'get_current_blog_id' )->justReturn( 1 );
 	}
 
 	protected function tearDown(): void {

--- a/tests/Unit/Breeze/CuratedUrlsTest.php
+++ b/tests/Unit/Breeze/CuratedUrlsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Breeze;
 
 use Brain\Monkey;
+use Parisek\TimberKit\Helpers;
 use Brain\Monkey\Functions;
 use PHPUnit\Framework\TestCase;
 use Parisek\TimberKit\Breeze\CuratedUrls;
@@ -17,6 +18,10 @@ final class CuratedUrlsTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		Monkey\setUp();
+		// The post-id memo keys by blog, so every test that reaches
+		// urlToPostId() needs this defined.
+		Functions\when( 'get_current_blog_id' )->justReturn( 1 );
+		Helpers::flushResolvedPostIds();
 		Functions\when( 'home_url' )->alias(
 			static fn( string $path = '' ): string => 'https://example.test' . $path
 		);

--- a/tests/Unit/Helpers/FormatLinkTest.php
+++ b/tests/Unit/Helpers/FormatLinkTest.php
@@ -212,6 +212,13 @@ class FormatLinkTest extends HelpersTestCase {
 	public function test_unresolved_url_is_cached_too(): void {
 		// A miss falls through to extract_slug_from_url(), which asks WPML.
 		Functions\when( 'is_plugin_active' )->justReturn( false );
+		// The slug fallback is gated on the URL being this site's, so the URL
+		// below has to be one. Without home_url() the gate cannot answer and
+		// the fallback never runs -- which would leave this asserting one
+		// lookup instead of the two a miss actually costs.
+		Functions\when( 'home_url' )->alias(
+			static fn( string $path = '' ): string => 'https://example.com' . $path
+		);
 		$calls = 0;
 		Functions\when( 'url_to_postid' )->alias( function () use ( &$calls ) {
 			$calls++;

--- a/tests/Unit/Helpers/FormatLinkTest.php
+++ b/tests/Unit/Helpers/FormatLinkTest.php
@@ -182,4 +182,85 @@ class FormatLinkTest extends HelpersTestCase {
 		// URL unchanged when post not found
 		$this->assertSame( 'https://example.com/nonexistent', $result['url'] );
 	}
+
+	public function test_repeated_url_resolves_once(): void {
+		$calls = 0;
+		Functions\when( 'url_to_postid' )->alias( function () use ( &$calls ) {
+			$calls++;
+			return 42;
+		} );
+		Functions\when( 'get_permalink' )->justReturn( 'https://example.com/cs/stranka/' );
+		Functions\when( 'apply_filters' )->alias( function ( $hook, $value = null ) {
+			return 'wpml_current_language' === $hook ? 'cs' : $value;
+		} );
+
+		$value = [
+			'title'  => 'Link',
+			'url'    => 'https://example.com/page/',
+			'target' => '',
+		];
+		$field = [ 'wpml_cf_preferences' => 2 ];
+
+		$first  = Helpers::formatLink( $value, 1, $field );
+		$second = Helpers::formatLink( $value, 1, $field );
+
+		$this->assertSame( 'https://example.com/cs/stranka/', $first['url'] );
+		$this->assertSame( $first['url'], $second['url'] );
+		$this->assertSame( 1, $calls, 'url_to_postid must run once for a repeated URL' );
+	}
+
+	public function test_unresolved_url_is_cached_too(): void {
+		// A miss falls through to extract_slug_from_url(), which asks WPML.
+		Functions\when( 'is_plugin_active' )->justReturn( false );
+		$calls = 0;
+		Functions\when( 'url_to_postid' )->alias( function () use ( &$calls ) {
+			$calls++;
+			return 0;
+		} );
+		Functions\when( 'apply_filters' )->alias( function ( $hook, $value = null ) {
+			return 'wpml_current_language' === $hook ? 'cs' : $value;
+		} );
+
+		$value = [
+			'title'  => 'Link',
+			'url'    => 'https://example.com/gone/',
+			'target' => '',
+		];
+		$field = [ 'wpml_cf_preferences' => 2 ];
+
+		$first  = Helpers::formatLink( $value, 1, $field );
+		$second = Helpers::formatLink( $value, 1, $field );
+
+		// URL is left untouched, and the miss is not resolved a second time.
+		$this->assertSame( 'https://example.com/gone/', $first['url'] );
+		$this->assertSame( 'https://example.com/gone/', $second['url'] );
+		// Two url_to_postid calls for ONE resolution: the direct one and the
+		// slug fallback. The second formatLink() call adds none.
+		$this->assertSame( 2, $calls );
+	}
+
+	public function test_same_url_in_two_languages_resolves_separately(): void {
+		$lang = 'cs';
+		Functions\when( 'url_to_postid' )->justReturn( 42 );
+		Functions\when( 'apply_filters' )->alias( function ( $hook, $value = null ) use ( &$lang ) {
+			return 'wpml_current_language' === $hook ? $lang : $value;
+		} );
+		Functions\when( 'get_permalink' )->alias( function () use ( &$lang ) {
+			return 'https://example.com/' . $lang . '/stranka/';
+		} );
+
+		$value = [
+			'title'  => 'Link',
+			'url'    => 'https://example.com/page/',
+			'target' => '',
+		];
+		$field = [ 'wpml_cf_preferences' => 2 ];
+
+		$cs = Helpers::formatLink( $value, 1, $field );
+		$lang = 'en';
+		$en = Helpers::formatLink( $value, 1, $field );
+
+		$this->assertSame( 'https://example.com/cs/stranka/', $cs['url'] );
+		$this->assertSame( 'https://example.com/en/stranka/', $en['url'] );
+	}
 }

--- a/tests/Unit/Helpers/FormatLinkTest.php
+++ b/tests/Unit/Helpers/FormatLinkTest.php
@@ -263,4 +263,70 @@ class FormatLinkTest extends HelpersTestCase {
 		$this->assertSame( 'https://example.com/cs/stranka/', $cs['url'] );
 		$this->assertSame( 'https://example.com/en/stranka/', $en['url'] );
 	}
+
+	public function test_same_url_on_two_blogs_resolves_separately(): void {
+		$blog = 1;
+		Functions\when( 'get_current_blog_id' )->alias( function () use ( &$blog ) {
+			return $blog;
+		} );
+		Functions\when( 'url_to_postid' )->justReturn( 42 );
+		Functions\when( 'apply_filters' )->alias( function ( $hook, $value = null ) {
+			return 'wpml_current_language' === $hook ? 'cs' : $value;
+		} );
+		Functions\when( 'get_permalink' )->alias( function () use ( &$blog ) {
+			return 'https://blog' . $blog . '.example.com/stranka/';
+		} );
+
+		$value = [ 'title' => 'Link', 'url' => 'https://example.com/page/', 'target' => '' ];
+		$field = [ 'wpml_cf_preferences' => 2 ];
+
+		$first = Helpers::formatLink( $value, 1, $field );
+		$blog  = 2;
+		$second = Helpers::formatLink( $value, 1, $field );
+
+		// switch_to_blog() changes the correct answer for an unchanged URL.
+		$this->assertSame( 'https://blog1.example.com/stranka/', $first['url'] );
+		$this->assertSame( 'https://blog2.example.com/stranka/', $second['url'] );
+	}
+
+	public function test_flush_lets_a_changed_permalink_through(): void {
+		$permalink = 'https://example.com/cs/stary-slug/';
+		Functions\when( 'url_to_postid' )->justReturn( 42 );
+		Functions\when( 'apply_filters' )->alias( function ( $hook, $value = null ) {
+			return 'wpml_current_language' === $hook ? 'cs' : $value;
+		} );
+		Functions\when( 'get_permalink' )->alias( function () use ( &$permalink ) {
+			return $permalink;
+		} );
+
+		$value = [ 'title' => 'Link', 'url' => 'https://example.com/page/', 'target' => '' ];
+		$field = [ 'wpml_cf_preferences' => 2 ];
+
+		$before = Helpers::formatLink( $value, 1, $field );
+
+		// A long-running process renames the slug. Without the flush the memo
+		// would keep handing out the permalink from before the rename.
+		$permalink = 'https://example.com/cs/novy-slug/';
+		$this->assertSame( $before['url'], Helpers::formatLink( $value, 1, $field )['url'] );
+
+		Helpers::flushTranslatedLinkUrls();
+
+		$this->assertSame( 'https://example.com/cs/novy-slug/', Helpers::formatLink( $value, 1, $field )['url'] );
+	}
+
+	public function test_false_permalink_leaves_url_untouched(): void {
+		Functions\when( 'url_to_postid' )->justReturn( 42 );
+		Functions\when( 'apply_filters' )->alias( function ( $hook, $value = null ) {
+			return 'wpml_current_language' === $hook ? 'cs' : $value;
+		} );
+		// get_permalink() returns false for an id it cannot resolve.
+		Functions\when( 'get_permalink' )->justReturn( false );
+
+		$value = [ 'title' => 'Link', 'url' => 'https://example.com/page/?a=1', 'target' => '' ];
+
+		$result = Helpers::formatLink( $value, 1, [ 'wpml_cf_preferences' => 2 ] );
+
+		// Previously this concatenated the query onto false, yielding "?a=1".
+		$this->assertSame( 'https://example.com/page/?a=1', $result['url'] );
+	}
 }

--- a/tests/Unit/Helpers/UrlToPostIdTest.php
+++ b/tests/Unit/Helpers/UrlToPostIdTest.php
@@ -17,6 +17,10 @@ final class UrlToPostIdTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		Monkey\setUp();
+		// The post-id memo keys by blog, so every test that reaches
+		// urlToPostId() needs this defined.
+		Functions\when( 'get_current_blog_id' )->justReturn( 1 );
+		Helpers::flushResolvedPostIds();
 		Functions\when( 'home_url' )->alias(
 			static fn( string $path = '' ): string => 'https://example.test' . $path
 		);

--- a/tests/Unit/HelpersTestCase.php
+++ b/tests/Unit/HelpersTestCase.php
@@ -19,6 +19,8 @@ abstract class HelpersTestCase extends TestCase {
 		// need nav_menu_item dispatch don't have to mock it individually.
 		// Tests that need a specific return value override this in their body.
 		Functions\when( 'get_post_type' )->justReturn( 'post' );
+		// The link memo keys on the blog id; single-site tests get blog 1.
+		Functions\when( 'get_current_blog_id' )->justReturn( 1 );
 		// formatLink() memoizes resolved link URLs in a static array. A static
 		// outlives the test that filled it, so one test's answer would be
 		// returned to the next one instead of its own mocks being called.

--- a/tests/Unit/HelpersTestCase.php
+++ b/tests/Unit/HelpersTestCase.php
@@ -6,6 +6,7 @@ namespace Tests\Unit;
 
 use Brain\Monkey;
 use Brain\Monkey\Functions;
+use Parisek\TimberKit\Helpers;
 use PHPUnit\Framework\TestCase;
 
 abstract class HelpersTestCase extends TestCase {
@@ -18,6 +19,10 @@ abstract class HelpersTestCase extends TestCase {
 		// need nav_menu_item dispatch don't have to mock it individually.
 		// Tests that need a specific return value override this in their body.
 		Functions\when( 'get_post_type' )->justReturn( 'post' );
+		// formatLink() memoizes resolved link URLs in a static array. A static
+		// outlives the test that filled it, so one test's answer would be
+		// returned to the next one instead of its own mocks being called.
+		Helpers::flushTranslatedLinkUrls();
 	}
 
 	protected function tearDown(): void {


### PR DESCRIPTION
## From which project

`sloneek` (redesign branch), while profiling why an uncached page render takes ~3.1 s on the Cloudways box that becomes production.

## Why

`Helpers::formatLink()` calls `url_to_postid()` for every link it formats. WPML filters that call through `SitePress::url_to_postid` → `AbsoluteLinks::_process_generic_text` → `WPML_Get_Page_By_Path::get` → `get_page_by_path()`, i.e. a database lookup per call. A miss costs two, because the slug fallback calls `url_to_postid()` again.

## Measured end to end

Re-measured after the rebase, because the rebase changed the answer. Not extrapolated — the live site was patched and re-profiled, then reverted with the vendor md5 verified identical.

Uncached render of `/cs/`, nine baseline requests in two separate sets and four with the change:

| | before | after |
| --- | ---: | ---: |
| `url_to_postid` calls | 272 | **35** |
| distinct URLs | 29 | 29 |
| SQL queries | 609 | **583** |
| render, median | 2846 ms | **2596 ms** |
| render, mean | 2866 ms | 2590 ms |

**The saving is ~250 ms of a ~2.85 s render, about 9 %.**

### Why this figure is not the one this description used to carry

It said ~37 ms, about 1.2 %, and that was honest for the code as it stood. The rebase onto `main` changed the shape: this branch caches **two** things — the finished link URL and the post id — and `main` had meanwhile extracted the resolution into `urlToPostId()`. Rebuilding the memo around the extracted version put both layers in the path that gets measured, and the second one removes 26 SQL queries the first left through.

So the direction held twice and the size changed twice. The number to trust is the one measured against the code that will actually merge.

Baselines were taken in two sets on either side of the patched run, so a server that drifted mid-measurement would have shown up: both sets returned 272 calls and 609 queries exactly. The first request after a cache flush is a different animal (45 distinct URLs, 1650 queries, ~4.6 s) and is excluded from both sides.

Run-to-run variance on the timing is ±160 ms, so the ~250 ms is above noise but not precise to the millisecond. The call and query counts are deterministic and carry the claim.

For context on where the rest goes: the same request spends 727–756 ms in one `timber/context` call. The database is not the bottleneck. The context build is filed as #147.

## What it means

`formatLink()` keeps its signature and behaviour. Resolution moves into two private helpers with an in-process memo in front.

- **Key is `<blog>|<language>|<url>`.** `url_to_postid()`, `get_permalink()` and `wpml_object_id` all answer for the current blog and the current language. A `switch_to_blog()` or a WPML language switch changes the correct answer for an unchanged URL, and WPML does switch language mid-request while a language switcher renders.
- **A `null` result is cached too**, so an unresolvable URL does not cost two `url_to_postid()` calls at every later call site.
- **In-process, with an explicit boundary.** For a web request that equals request-scoped. Under WP-CLI or a persistent worker it does not, so `StarterBase` flushes the memo on `clean_post_cache` — the hook that fires exactly when a permalink can have moved — and `Helpers::flushTranslatedLinkUrls()` is public for long-running callers that do not boot StarterBase.

One behaviour fix rides along: `get_permalink()` returning `false` is now treated as unresolved. It was previously concatenated onto, so a failed id turned `…/page/?a=1` into `?a=1`.

### Rejected

- **Caching only the post id.** The permalink lookup is the other half of the cost and is scoped the same way, so caching the finished URL removes both under one invalidation rule.
- **An object cache.** It would need invalidating whenever a permalink, translation link or language setting changes. The measured win is already in the in-process memo; a persistent one buys invalidation risk for it.
- **Dropping the negative cache.** Raised in review as a staleness risk. A miss costs two lookups, and within one unit of work an unresolvable URL does not become resolvable; `clean_post_cache` now covers the long-running case that made it worth raising.

## Verification

- `composer check` green: **1751 tests, 2892 assertions**, PHPStan clean.
- **Output equivalence checked, not assumed.** Eight pages across five languages rendered with and without the change. All eight differed — and so did two runs of the *same* code, by exactly the same line counts, because `uniqueId()` emits a fresh id per request. With those normalised, all eight are byte-identical. For a cache, that is the question that matters.
- End-to-end on a real five-language site, patched and reverted (vendor file restored, md5 verified identical).
- Six new tests: repeated URL resolves once; an unresolvable URL is cached as a miss; the same URL resolves separately in two languages; the same URL resolves separately on two blogs; a flush lets a changed permalink through; a `false` permalink leaves the stored URL untouched.
- `HelpersTestCase::setUp()` flushes the memo. A static outlives the test that filled it, so without this one test's answer reaches the next instead of its mocks being called — this bit during development.

## Downstream

No action needed. The change is internal to `formatLink()`; every caller sees the same output.

**One limit worth knowing.** Both memos are flushed on `clean_post_cache`, which covers saving and deleting a post. It does not cover a permalink-structure change or a WPML translation being relinked. A web request ends before either can happen, so this is only reachable from a long-running process — a WP-CLI command that changes permalink structure and then formats links in the same run would be handed the earlier answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJfaWNpucdqu4trbqiZdB3

