### PR TITLE
fix(wpml): resolve a URL in the language the URL names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- `Helpers::languageFromUrl()` — the language a URL names, read from the URL
+  itself rather than from the request. Covers both WPML negotiation shapes, a
+  path prefix and a per-language host.
+- `Helpers::withLanguage()` — run one callback with WPML switched to a given
+  language and switch back in a `finally`, so a throw cannot leave the rest of
+  the request in another language.
 - `$acf_json_keep_on_delete` (opt-in, default off) stops ACF from deleting a
   Local JSON file when its field group, post type or taxonomy is deleted in
   wp-admin. The database record is still removed, so the group reverts to the
@@ -18,6 +24,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   file and the loss is silent: `get_field_objects()` skips the now-unresolvable
   `_<field>` references, `Helpers::formatFields()` omits the keys, and consumer
   code reads them as "off" while the page still returns 200.
+
+### Fixed
+
+- **A curated warmup entry naming a translated page warmed its default-language
+  sibling instead.** Two things had to be wrong at once and both were.
+  `urlToPostId()` passed `wpml_object_id` two arguments, which translates
+  towards the *current* language — and the refresh runs from cron, which has no
+  language, so that is always the site default. Measured on a live
+  five-language site: `url_to_postid()` resolved `/it/glossario-di-termini/` to
+  the Italian page correctly and the translation then replaced it with the
+  English one, so the step meant to repair a mismatch was discarding a correct
+  answer. `get_permalink()` then compounded it: asked for an Italian page's
+  permalink under an English context it answers with the English URL, so fixing
+  the ID alone was not enough.
+
+  The failure was invisible. On a 25-entry curated list covering five
+  languages, all 20 non-default entries collapsed onto their 5 default siblings
+  and were deduplicated away. 22 of the 25 URLs still appeared in the warmup
+  queue — supplied by the sitemap, not by the curated list — so the list looked
+  honoured while contributing nothing.
 
 ## [1.40.0] - 2026-08-26
 

--- a/src/Breeze/CuratedUrls.php
+++ b/src/Breeze/CuratedUrls.php
@@ -135,7 +135,19 @@ final class CuratedUrls {
 		// language, whatever was written.
 		$post_id = \Parisek\TimberKit\Helpers::urlToPostId( $absolute );
 		if ( $post_id > 0 ) {
-			$permalink = function_exists( 'get_permalink' ) ? get_permalink( $post_id ) : false;
+			// The permalink is taken inside the entry's own language. WPML
+			// renders get_permalink() in the CURRENT language rather than in
+			// the post's, so an Italian page asked for from a cron request --
+			// which has no language and therefore uses the site default --
+			// comes back as its English sibling. Measured: every non-default
+			// entry of a five-language curated list collapsed onto its default
+			// sibling and was then deduplicated away, leaving a list that
+			// looked honoured and contributed nothing.
+			$language  = \Parisek\TimberKit\Helpers::languageFromUrl( $absolute );
+			$permalink = \Parisek\TimberKit\Helpers::withLanguage(
+				$language,
+				static fn() => function_exists( 'get_permalink' ) ? get_permalink( $post_id ) : false
+			);
 			if ( is_string( $permalink ) && '' !== $permalink ) {
 				// A post ID settles existence. Probing anyway would spend a
 				// request per entry per refresh and, worse, drop a page that

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1995,14 +1995,120 @@ class Helpers {
 		}
 
 		if ( function_exists( 'apply_filters' ) ) {
-			$post_type  = function_exists( 'get_post_type' ) ? get_post_type( $post_id ) : 'page';
-			$translated = (int) apply_filters( 'wpml_object_id', $post_id, $post_type ?: 'page' );
+			$post_type = function_exists( 'get_post_type' ) ? get_post_type( $post_id ) : 'page';
+
+			// Translate towards the language the URL names, never towards the
+			// ambient one. Two arguments means "the current language", and on a
+			// request without a language of its own -- cron, WP-CLI -- that is
+			// the site default. Measured on a five-language site:
+			// url_to_postid('/it/glossario-di-termini/') resolved the Italian
+			// page correctly, and the two-argument translation then replaced it
+			// with the English one. The step meant to repair a mismatch was
+			// discarding a correct answer.
+			$language   = self::languageFromUrl( $url );
+			$translated = '' !== $language
+				? (int) apply_filters( 'wpml_object_id', $post_id, $post_type ?: 'page', false, $language )
+				: (int) apply_filters( 'wpml_object_id', $post_id, $post_type ?: 'page' );
+
 			if ( $translated > 0 ) {
 				$post_id = $translated;
 			}
 		}
 
 		return $post_id;
+	}
+
+	/**
+	 * The language a URL names, read from the URL itself.
+	 *
+	 * Read from the URL rather than from the ambient context on purpose. The
+	 * refresh jobs that need this run from cron and from WP-CLI, neither of
+	 * which has a language of its own, so the ambient answer is always the
+	 * site's default — and using it silently turns every translated URL into
+	 * its default-language sibling.
+	 *
+	 * Covers both WPML negotiation shapes: a path prefix (`/it/…`) and a
+	 * per-language host. A URL with neither is the default language, which is
+	 * what an unprefixed URL means under directory negotiation.
+	 *
+	 * @param string $url Absolute or root-relative URL.
+	 * @return string Language code, or '' when WPML is absent or cannot answer.
+	 */
+	public static function languageFromUrl( string $url ): string {
+		if ( ! function_exists( 'apply_filters' ) ) {
+			return '';
+		}
+
+		$languages = apply_filters( 'wpml_active_languages', null );
+		if ( ! is_array( $languages ) || array() === $languages ) {
+			return '';
+		}
+
+		$parts = parse_url( $url );
+		$host  = isset( $parts['host'] ) ? strtolower( (string) $parts['host'] ) : '';
+
+		// Domain negotiation first: a per-language host settles the question
+		// without looking at the path, and under that shape no prefix exists.
+		if ( '' !== $host ) {
+			foreach ( $languages as $code => $language ) {
+				$lang_host = isset( $language['url'] )
+					? strtolower( (string) ( parse_url( (string) $language['url'], PHP_URL_HOST ) ?: '' ) )
+					: '';
+				if ( '' !== $lang_host && $lang_host === $host ) {
+					return (string) $code;
+				}
+			}
+		}
+
+		$path = isset( $parts['path'] ) ? rtrim( (string) $parts['path'], '/' ) : '';
+		foreach ( array_keys( $languages ) as $code ) {
+			$prefix = '/' . $code;
+			if ( $path === $prefix || 0 === strpos( $path, $prefix . '/' ) ) {
+				return (string) $code;
+			}
+		}
+
+		$default = apply_filters( 'wpml_default_language', null );
+
+		return is_string( $default ) ? $default : '';
+	}
+
+	/**
+	 * Run a callback with WPML switched to one language, then switch back.
+	 *
+	 * `get_permalink()` renders in the **current** language, not in the
+	 * language of the post it is handed: asked for an Italian page's permalink
+	 * while the request is English, WPML answers with the English URL. So the
+	 * ID being right is not enough — measured on a five-language site,
+	 * `get_permalink( $italian_id )` under an English context returns the
+	 * English permalink.
+	 *
+	 * The restore is in `finally` because this runs alongside other work on the
+	 * same request. A throw that left the language switched would not fail
+	 * here; it would surface later, as the wrong language somewhere unrelated.
+	 *
+	 * @template T
+	 * @param string          $language Language code; '' runs the callback unchanged.
+	 * @param callable():T    $callback
+	 * @return T
+	 */
+	public static function withLanguage( string $language, callable $callback ) {
+		if ( '' === $language || ! function_exists( 'apply_filters' ) || ! function_exists( 'do_action' ) ) {
+			return $callback();
+		}
+
+		$previous = apply_filters( 'wpml_current_language', null );
+		if ( ! is_string( $previous ) || $previous === $language ) {
+			return $callback();
+		}
+
+		do_action( 'wpml_switch_language', $language );
+
+		try {
+			return $callback();
+		} finally {
+			do_action( 'wpml_switch_language', $previous );
+		}
 	}
 
 	/**

--- a/tests/Unit/Helpers/LanguageFromUrlTest.php
+++ b/tests/Unit/Helpers/LanguageFromUrlTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Helpers;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use Parisek\TimberKit\Helpers;
+
+/**
+ * The language a URL names, read from the URL rather than from the request.
+ *
+ * The jobs that need this run from cron and WP-CLI, which have no language of
+ * their own. Asking the ambient context there always answers "the site
+ * default", which is how a translated URL silently becomes its default-language
+ * sibling.
+ */
+final class LanguageFromUrlTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * @param array<string, array<string, string>> $languages
+	 */
+	private function wpml( array $languages, string $default = 'en' ): void {
+		Functions\when( 'apply_filters' )->alias(
+			static function ( string $hook, $value = null, ...$rest ) use ( $languages, $default ) {
+				return match ( $hook ) {
+					'wpml_active_languages' => $languages,
+					'wpml_default_language' => $default,
+					default                 => $value,
+				};
+			}
+		);
+	}
+
+	/** @var array<string, array<string, string>> Directory negotiation: no per-language host. */
+	private const DIRECTORY = array( 'en' => array(), 'cs' => array(), 'it' => array() );
+
+	public function test_reads_the_path_prefix(): void {
+		$this->wpml( self::DIRECTORY );
+
+		$this->assertSame( 'it', Helpers::languageFromUrl( 'https://example.test/it/glossario-di-termini/' ) );
+		$this->assertSame( 'cs', Helpers::languageFromUrl( 'https://example.test/cs/cenik/' ) );
+	}
+
+	public function test_a_bare_language_prefix_still_reads(): void {
+		// `/it` and `/it/` are the Italian home page, not an unprefixed URL.
+		$this->wpml( self::DIRECTORY );
+
+		$this->assertSame( 'it', Helpers::languageFromUrl( 'https://example.test/it/' ) );
+		$this->assertSame( 'it', Helpers::languageFromUrl( 'https://example.test/it' ) );
+	}
+
+	public function test_an_unprefixed_url_is_the_default_language(): void {
+		// Under directory negotiation that is what no prefix means — not
+		// "unknown", which would leave the caller to guess.
+		$this->wpml( self::DIRECTORY );
+
+		$this->assertSame( 'en', Helpers::languageFromUrl( 'https://example.test/pricing/' ) );
+	}
+
+	public function test_a_path_that_merely_starts_with_a_code_is_not_a_prefix(): void {
+		// `/italy-guide/` begins with "it" and is not Italian.
+		$this->wpml( self::DIRECTORY );
+
+		$this->assertSame( 'en', Helpers::languageFromUrl( 'https://example.test/italy-guide/' ) );
+	}
+
+	public function test_a_relative_path_reads_the_same_as_an_absolute_one(): void {
+		$this->wpml( self::DIRECTORY );
+
+		$this->assertSame( 'cs', Helpers::languageFromUrl( '/cs/cenik/' ) );
+	}
+
+	public function test_domain_negotiation_reads_the_host(): void {
+		// Under per-language domains there is no prefix to read, and the path
+		// would otherwise fall through to the default for every language.
+		$this->wpml(
+			array(
+				'en' => array( 'url' => 'https://example.com/' ),
+				'de' => array( 'url' => 'https://example.de/' ),
+			)
+		);
+
+		$this->assertSame( 'de', Helpers::languageFromUrl( 'https://example.de/preise/' ) );
+		$this->assertSame( 'en', Helpers::languageFromUrl( 'https://example.com/pricing/' ) );
+	}
+
+	public function test_the_host_wins_over_a_path_that_looks_like_a_prefix(): void {
+		$this->wpml(
+			array(
+				'en' => array( 'url' => 'https://example.com/' ),
+				'de' => array( 'url' => 'https://example.de/' ),
+			)
+		);
+
+		$this->assertSame( 'de', Helpers::languageFromUrl( 'https://example.de/en/whatever/' ) );
+	}
+
+	public function test_no_wpml_answers_empty(): void {
+		// Empty means "no opinion", and every caller treats it as "change
+		// nothing" rather than as a language.
+		Functions\when( 'apply_filters' )->alias(
+			static fn( string $hook, $value = null, ...$rest ) => 'wpml_active_languages' === $hook ? null : $value
+		);
+
+		$this->assertSame( '', Helpers::languageFromUrl( 'https://example.test/it/x/' ) );
+	}
+}

--- a/tests/Unit/Helpers/UrlToPostIdTest.php
+++ b/tests/Unit/Helpers/UrlToPostIdTest.php
@@ -73,6 +73,61 @@ final class UrlToPostIdTest extends TestCase {
 		$this->assertSame( 0, Helpers::urlToPostId( '   ' ) );
 	}
 
+	public function test_the_translation_targets_the_language_the_url_names(): void {
+		// The defect this pins: with two arguments, wpml_object_id translates
+		// towards the CURRENT language. On a request that has none of its own
+		// -- cron, WP-CLI -- that is the site default, so an Italian URL whose
+		// lookup already succeeded came back as its English sibling. Measured
+		// on a live five-language site: url_to_postid() resolved the Italian
+		// page correctly and the translation then replaced it.
+		Functions\when( 'url_to_postid' )->justReturn( 5 );
+
+		$asked = null;
+		Functions\when( 'apply_filters' )->alias(
+			static function ( string $hook, $value = null, ...$rest ) use ( &$asked ) {
+				if ( 'wpml_active_languages' === $hook ) {
+					return array( 'en' => array(), 'it' => array() );
+				}
+				if ( 'wpml_default_language' === $hook ) {
+					return 'en';
+				}
+				if ( 'wpml_object_id' === $hook ) {
+					$asked = $rest[2] ?? null;
+					return 62;
+				}
+				return $value;
+			}
+		);
+
+		$this->assertSame( 62, Helpers::urlToPostId( 'https://example.test/it/glossario/' ) );
+		$this->assertSame( 'it', $asked, 'the target language must come from the URL, not the request' );
+	}
+
+	public function test_an_unprefixed_url_targets_the_default_language(): void {
+		Functions\when( 'url_to_postid' )->justReturn( 5 );
+
+		$asked = null;
+		Functions\when( 'apply_filters' )->alias(
+			static function ( string $hook, $value = null, ...$rest ) use ( &$asked ) {
+				if ( 'wpml_active_languages' === $hook ) {
+					return array( 'en' => array(), 'it' => array() );
+				}
+				if ( 'wpml_default_language' === $hook ) {
+					return 'en';
+				}
+				if ( 'wpml_object_id' === $hook ) {
+					$asked = $rest[2] ?? null;
+					return 5;
+				}
+				return $value;
+			}
+		);
+
+		Helpers::urlToPostId( 'https://example.test/about/' );
+
+		$this->assertSame( 'en', $asked );
+	}
+
 	public function test_the_id_is_translated_for_the_rendered_language(): void {
 		Functions\when( 'url_to_postid' )->justReturn( 5 );
 		Functions\when( 'apply_filters' )->alias(

--- a/tests/Unit/Helpers/WithLanguageTest.php
+++ b/tests/Unit/Helpers/WithLanguageTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Helpers;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use Parisek\TimberKit\Helpers;
+
+/**
+ * Switching WPML's language around one call, and putting it back.
+ *
+ * `get_permalink()` renders in the current language, not in the language of
+ * the post it is handed, so the ID being right is not enough.
+ */
+final class WithLanguageTest extends TestCase {
+
+	/** @var array<int, string> */
+	private array $switches = array();
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+		$this->switches = array();
+
+		Functions\when( 'apply_filters' )->alias(
+			static fn( string $hook, $value = null, ...$rest ) => 'wpml_current_language' === $hook ? 'en' : $value
+		);
+		Functions\when( 'do_action' )->alias(
+			function ( string $hook, ...$args ): void {
+				if ( 'wpml_switch_language' === $hook ) {
+					$this->switches[] = (string) ( $args[0] ?? '' );
+				}
+			}
+		);
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	public function test_switches_there_and_back(): void {
+		$seen = Helpers::withLanguage( 'it', static fn() => 'ran' );
+
+		$this->assertSame( 'ran', $seen );
+		$this->assertSame( array( 'it', 'en' ), $this->switches );
+	}
+
+	public function test_restores_the_language_when_the_callback_throws(): void {
+		// The restore is in a finally because this runs alongside other work on
+		// the same request. A throw that left the language switched would not
+		// fail here — it would surface later, somewhere unrelated.
+		$this->expectException( \RuntimeException::class );
+
+		try {
+			Helpers::withLanguage( 'it', static function (): void {
+				throw new \RuntimeException( 'boom' );
+			} );
+		} finally {
+			$this->assertSame( array( 'it', 'en' ), $this->switches );
+		}
+	}
+
+	public function test_an_empty_language_does_not_switch(): void {
+		$seen = Helpers::withLanguage( '', static fn() => 'ran' );
+
+		$this->assertSame( 'ran', $seen );
+		$this->assertSame( array(), $this->switches );
+	}
+
+	public function test_the_language_already_active_does_not_switch(): void {
+		// Switching to the language already in force is two hooks that change
+		// nothing, and each one costs WPML a cache rebuild.
+		$seen = Helpers::withLanguage( 'en', static fn() => 'ran' );
+
+		$this->assertSame( 'ran', $seen );
+		$this->assertSame( array(), $this->switches );
+	}
+}


### PR DESCRIPTION
Closes #149.

## What was wrong

A curated warmup entry naming a translated page warmed its **default-language sibling**. Two independent things were wrong, and either alone would have been enough.

**1. The ID.** `urlToPostId()` called `wpml_object_id` with two arguments, which translates towards the *current* language. The refresh runs from cron, which has no language of its own, so "current" is always the site default.

```
url_to_postid('https://<site>/it/glossario-di-termini/')   ->  59262   (language: it)  ✓
apply_filters('wpml_object_id', 59262, 'page')             ->  59239   (language: en)  ✗
```

The raw lookup was already right. The step that exists to repair a mismatch was discarding a correct answer.

**2. The permalink.** Fixing the ID is not enough, which is worth stating because it looks like it should be. WPML renders `get_permalink()` in the current language, not in the language of the post it is handed:

```
get_permalink(59262)                              ->  https://<site>/lexicon/            ✗
do_action('wpml_switch_language', 'it');
get_permalink(59262)                              ->  https://<site>/it/glossario-di-termini/   ✓
```

## Why it was worth chasing

It was invisible. On a 25-entry curated list covering five languages, the 20 non-default entries resolved to their 5 default siblings and were deduplicated away. **22 of the 25 URLs still appeared in the warmup queue** — supplied by the sitemap, not by the curated list. Deleting the curated list entirely would have changed almost nothing, and no log line said so.

Checking that the list was non-empty would have passed. Checking each entry's position in the resulting queue is what found it.

## The change

- `Helpers::languageFromUrl()` — the language a URL names, read from the URL. Covers both WPML negotiation shapes: a path prefix and a per-language host, host first. An unprefixed URL is the default language, which is what no prefix means under directory negotiation, rather than "unknown".
- `Helpers::withLanguage()` — run one callback in a language and switch back in a `finally`. The restore is not decoration: this runs alongside other work on the same request, and a throw that left the language switched would not fail here, it would surface later somewhere unrelated.
- `urlToPostId()` targets the URL's language when it can name one, and keeps today's two-argument call when it cannot.
- `CuratedUrls::resolve()` takes the permalink inside the entry's own language.

## Blast radius

Only contexts with no language of their own — cron, WP-CLI, a REST route without a language parameter. `formatLink()` and `Breadcrumb` call the same helper from web requests, where the current language already matches the URL. That is why loading a page never reproduced this, and why it survived three reviews on #141.

## Tests

14 added. The one that matters is `test_the_translation_targets_the_language_the_url_names`, which fails on `main` with *"Failed asserting that null is identical to 'it'"* — the target-language argument was never passed. `test_restores_the_language_when_the_callback_throws` pins the `finally`.

`composer check` green: 1691 tests / 2794 assertions, 18 property tests, PHPStan clean.

## One thing PHPStan caught that no test could

The first draft inserted the two helpers between `extract_slug_from_url()`'s docblock and the method itself, orphaning it. Behaviour was byte-identical and every test passed; PHPStan reported the method's types as undeclared. Fixed before this commit — recorded because it is a good example of what the two analysers each see.
