### PR TITLE
fix(wpml): trust a language host only when hosts tell languages apart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `Helpers::languageFromUrl()` (new in 1.41.0) read a per-language host before
+  the path prefix, and under **directory** negotiation that host is the same
+  for every language — so the match succeeded for whichever language came first
+  in WPML's array and every URL resolved to it. Measured on a five-language
+  site whose array starts with `cs`: an Italian URL came back Czech, and the
+  curated warmup list it was written for warmed five copies of the Czech pages.
+  A language host now counts only where the hosts actually tell the languages
+  apart; where they do not, the path is the only evidence and is used alone.
+
+  The 1.41.0 tests missed it because neither fixture had the real shape: the
+  directory one omitted `url` entirely, so the host branch never ran, and the
+  domain one gave each language a distinct host. Both fixtures made the defect
+  unreachable.
+
 ## [1.41.0] - 2026-08-26
 
 ### Added

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -2047,17 +2047,16 @@ class Helpers {
 		$parts = parse_url( $url );
 		$host  = isset( $parts['host'] ) ? strtolower( (string) $parts['host'] ) : '';
 
-		// Domain negotiation first: a per-language host settles the question
-		// without looking at the path, and under that shape no prefix exists.
-		if ( '' !== $host ) {
-			foreach ( $languages as $code => $language ) {
-				$lang_host = isset( $language['url'] )
-					? strtolower( (string) ( parse_url( (string) $language['url'], PHP_URL_HOST ) ?: '' ) )
-					: '';
-				if ( '' !== $lang_host && $lang_host === $host ) {
-					return (string) $code;
-				}
-			}
+		// A per-language host answers first, but ONLY when the hosts actually
+		// tell the languages apart. Under directory negotiation WPML still
+		// reports a `url` for every language and they all share one host, so a
+		// plain host match succeeds for whichever language happens to come
+		// first in the array and every URL resolves to that one. Measured on a
+		// five-language site whose array starts with `cs`: an Italian URL came
+		// back Czech.
+		$by_host = self::discriminatingLanguageHosts( $languages );
+		if ( '' !== $host && isset( $by_host[ $host ] ) ) {
+			return $by_host[ $host ];
 		}
 
 		$path = isset( $parts['path'] ) ? rtrim( (string) $parts['path'], '/' ) : '';
@@ -2071,6 +2070,38 @@ class Helpers {
 		$default = apply_filters( 'wpml_default_language', null );
 
 		return is_string( $default ) ? $default : '';
+	}
+
+	/**
+	 * Host-to-language map, kept only where the hosts discriminate.
+	 *
+	 * A host shared by two languages proves nothing about which one a URL is
+	 * in, so it is dropped rather than resolved arbitrarily. Under directory
+	 * negotiation that drops every entry, which is correct: there the path is
+	 * the only evidence.
+	 *
+	 * @param array<string, mixed> $languages `wpml_active_languages` output.
+	 * @return array<string, string> Host => language code.
+	 */
+	private static function discriminatingLanguageHosts( array $languages ): array {
+		$hosts = array();
+
+		foreach ( $languages as $code => $language ) {
+			if ( ! is_array( $language ) || ! isset( $language['url'] ) ) {
+				continue;
+			}
+
+			$host = strtolower( (string) ( parse_url( (string) $language['url'], PHP_URL_HOST ) ?: '' ) );
+			if ( '' === $host ) {
+				continue;
+			}
+
+			// Second sighting means the host is shared; mark it useless rather
+			// than letting the first language keep it.
+			$hosts[ $host ] = array_key_exists( $host, $hosts ) ? null : (string) $code;
+		}
+
+		return array_filter( $hosts, 'is_string' );
 	}
 
 	/**

--- a/tests/Unit/Helpers/LanguageFromUrlTest.php
+++ b/tests/Unit/Helpers/LanguageFromUrlTest.php
@@ -44,8 +44,21 @@ final class LanguageFromUrlTest extends TestCase {
 		);
 	}
 
-	/** @var array<string, array<string, string>> Directory negotiation: no per-language host. */
+	/** @var array<string, array<string, string>> Directory negotiation, minimal shape. */
 	private const DIRECTORY = array( 'en' => array(), 'cs' => array(), 'it' => array() );
+
+	/**
+	 * Directory negotiation as WPML actually reports it: every language carries
+	 * a `url`, and they all share one host. The earlier fixture omitted `url`
+	 * entirely, which is why it could not catch the defect below.
+	 *
+	 * @var array<string, array<string, string>>
+	 */
+	private const DIRECTORY_REAL = array(
+		'cs' => array( 'url' => 'https://example.test/cs/' ),
+		'en' => array( 'url' => 'https://example.test/' ),
+		'it' => array( 'url' => 'https://example.test/it/' ),
+	);
 
 	public function test_reads_the_path_prefix(): void {
 		$this->wpml( self::DIRECTORY );
@@ -81,6 +94,19 @@ final class LanguageFromUrlTest extends TestCase {
 		$this->wpml( self::DIRECTORY );
 
 		$this->assertSame( 'cs', Helpers::languageFromUrl( '/cs/cenik/' ) );
+	}
+
+	public function test_a_host_shared_by_every_language_decides_nothing(): void {
+		// The defect this pins. Under directory negotiation WPML still reports
+		// a `url` per language and they all share one host, so a plain host
+		// match succeeds for whichever language comes first in the array --
+		// here `cs` -- and every URL resolves to it. Measured on a live
+		// five-language site: an Italian URL came back Czech.
+		$this->wpml( self::DIRECTORY_REAL );
+
+		$this->assertSame( 'it', Helpers::languageFromUrl( 'https://example.test/it/glossario/' ) );
+		$this->assertSame( 'cs', Helpers::languageFromUrl( 'https://example.test/cs/cenik/' ) );
+		$this->assertSame( 'en', Helpers::languageFromUrl( 'https://example.test/pricing/' ) );
 	}
 
 	public function test_domain_negotiation_reads_the_host(): void {


### PR DESCRIPTION
Fixes a defect I shipped in 1.41.0.

## What broke

`Helpers::languageFromUrl()` checked a per-language host before the path prefix. Under **directory** negotiation WPML still reports a `url` for every language and they all share one host, so the match succeeded for whichever language came first in the array.

Measured on a live five-language site whose array starts with `cs`:

| Entry | 1.41.0 | This branch |
| --- | --- | --- |
| `/it/glossario-di-termini/` | `/cs/slovnik-pojmu/` | `/it/glossario-di-termini/` |
| `/sk/cennik/` | `/cs/cenik/` | `/sk/cennik/` |
| `/pl/cennik/` | `/cs/cenik/` | `/pl/cennik/` |

The curated warmup list that #150 existed to fix therefore warmed five copies of the Czech pages. Before #150 it warmed five copies of the English ones. Different wrong answer, same shape.

## The change

The host is consulted through a map that **drops any host claimed by more than one language**. Under directory negotiation that empties the map — correct, because there the path is the only evidence. Under domain negotiation it keeps every entry and still beats a path that merely looks like a prefix.

## Why the 1.41.0 tests could not have caught it

Neither fixture had the shape WPML actually reports.

- The directory fixture omitted `url` entirely, so the host branch never ran.
- The domain fixture gave each language a distinct host.

Both made the defect **unreachable**, not absent. That is the lesson worth keeping: the fixtures were chosen to exercise each branch, and the bug lived in the combination neither one modelled. The new test uses `url` present and identical across languages, and fails on `main`.

`composer check` green: 1692 tests / 2797 assertions, PHPStan clean.