### PR TITLE
feat(kit): run the backend and field-group probes once per request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,53 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+
+- Two capability probes that ran once per object now run once per request.
+  Both had a memo already; both stored it on the instance the caller throws
+  away, so it never answered anything.
+
+  `Resizer::probeBackendFormats()` built a `new Imagick()` and asked it for the
+  format list. One `|resizer` call builds one Resizer, so a page that resizes
+  320 images probed 320 times — for a list that is a property of the
+  ImageMagick build and cannot change while the process runs. The memo moves to
+  a static; `Resizer::flushBackendFormats()` drops it.
+
+  `Helpers::getFieldObjectsByScreen()` called `acf_get_field_groups($screen)`
+  per nav menu item. ACF caches nothing here: every call walks each registered
+  field group and evaluates its location rules, measured at 8-10 ms against 96
+  groups whether or not the screen repeats. Answers are now memoized per
+  screen, and `Helpers::flushFieldGroups()` drops them.
+
+  The key normalizes `nav_menu_item` to a presence marker, which is what makes
+  the memo hit at all. `ACF_Location_Nav_Menu_Item::match()` reads that key only
+  to confirm it is set and then hands the decision to the `nav_menu` location
+  type, so the item id cannot change which groups match — every item of one menu
+  shares an answer. The key also carries the blog id and the language, because
+  field groups are registered per site and ACFML translates a group's own
+  strings.
+
+  Measured on the sloneek front page by patching the site and re-measuring, not
+  by scaling the profile. Median of eight requests, warm:
+
+| | before | after |
+  | --- | ---: | ---: |
+  | `Imagick::queryFormats()` calls | 320 | 1 |
+  | `acf_get_field_groups()` calls | 109 | 24 |
+  | page | 644 ms | 548 ms |
+
+  That is **96 ms, about 15 %**. The rendered HTML is byte-identical once the
+  random `uniqueId()` values are normalized — checked against a control pair of
+  runs of the unchanged code, because the page is not deterministic without one.
+
+  The saving scales with images and menu items, not with the page: the same
+  measurement on an archive with fewer images gave 6 %.
+
+  A static memo is request-scoped for a web request and **not** for WP-CLI or a
+  persistent worker, where one process can register field groups and then read
+  them back. Both flush methods are public for those callers; `StarterBase`
+  wires `flushFieldGroups()` to `acf/update_field_group`.
+
 ### Fixed
 
 - `StarterBase::cleanup_cached_images()` deleted resizer derivatives that other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   two in-process memos below. A web request never needs either; WP-CLI
   commands, persistent workers and tests do, because a static outlives the unit
   of work that filled it.
+- `timber_kit_share_nav_menu_item_field_groups` — opt in to letting every item
+  of one menu share a field-group answer. **Off by default, and the default is
+  the safe one.** See below for the contract it asks you to accept.
 
 ### Changed
 
@@ -23,72 +26,72 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   format list. One `|resizer` call builds one Resizer, so a page that resizes
   320 images probed 320 times — for a list that is a property of the
   ImageMagick build and cannot change while the process runs. The memo moves to
-  a static; `Resizer::flushBackendFormats()` drops it.
+  a static, keyed by concrete class so a subclass that stubs the probe cannot
+  answer for the base class.
 
   `Helpers::getFieldObjectsByScreen()` called `acf_get_field_groups($screen)`
-  per nav menu item. ACF caches nothing here: every call walks each registered
+  once per screen. ACF caches nothing here: every call walks each registered
   field group and evaluates its location rules, measured at 8-10 ms against 96
   groups whether or not the screen repeats. Answers are now memoized per
-  screen, and `Helpers::flushFieldGroups()` drops them.
-
-  The key normalizes `nav_menu_item` to a presence marker, which is what makes
-  the memo hit at all. `ACF_Location_Nav_Menu_Item::match()` reads that key only
-  to confirm it is set and then hands the decision to the `nav_menu` location
-  type, so the item id cannot change which groups match — every item of one menu
-  shares an answer. The key also carries the blog id and the language, because
-  field groups are registered per site and ACFML translates a group's own
-  strings.
+  screen.
 
   Measured on the sloneek front page by patching the site and re-measuring, not
-  by scaling the profile. Median of eight requests, warm:
+  by scaling the profile. Fastest of twelve warm requests, two independent
+  rounds:
 
-| | before | after |
-  | --- | ---: | ---: |
-  | `Imagick::queryFormats()` calls | 320 | 1 |
-  | `acf_get_field_groups()` calls | 109 | 24 |
-  | page | 644 ms | 548 ms |
+| | probes | `acf_get_field_groups()` | page |
+  | --- | ---: | ---: | ---: |
+  | before | 320 | 109 | 652-668 ms |
+  | default | 1 | 96 | 603-609 ms |
+  | with the opt-in filter | 1 | 11 | 551-556 ms |
 
-  That is **96 ms, about 15 %**. The rendered HTML is byte-identical once the
-  random `uniqueId()` values are normalized — checked against a control pair of
-  runs of the unchanged code, because the page is not deterministic without one.
+  So **43-65 ms by default**, and **101-112 ms with the filter on** — roughly
+  7-10 % and 15-17 %. The saving scales with images and menu items, not with
+  the page. Rendered HTML is byte-identical once the random `uniqueId()` values
+  are normalized, checked against a control pair of runs of the unchanged code
+  because the page is not deterministic without one.
 
-  The saving scales with images and menu items, not with the page: the same
-  measurement on an archive with fewer images gave 6 %.
+### The nav-menu opt-in, and why it is not the default
 
-  A static memo is request-scoped for a web request and **not** for WP-CLI or a
-  persistent worker, where one process can register field groups and then read
-  them back. Both flush methods are public for those callers; `StarterBase`
-  wires `flushFieldGroups()` to `acf/update_field_group`.
+`formatFields()` asks ACF for field groups once per nav menu item, and on a
+90-item menu the answers are identical — ACF's own
+`ACF_Location_Nav_Menu_Item::match()` reads the item id only to confirm the key
+is set, then matches on `nav_menu`.
 
-### Fixed
+That is true of ACF's own matcher and **not guaranteed of anyone else's**.
+`acf_register_location_type()` is public API, ACF hands the whole screen to
+every registered location type and to the `acf/location/rule_match` filter, and
+a matcher that answers per item is a legitimate thing to write. Sharing one
+answer would then serve the first item's groups to all of them, with no error
+and no log. A screen whose `nav_menu_item` is literally `'*'` collides for the
+same reason.
 
-- `StarterBase::cleanup_cached_images()` deleted resizer derivatives that other
-  attachments were still using. The cache under `wp-content/cache/image` is
-  keyed by file, but one file routinely carries several attachment rows: WPML
-  writes one per language, and a duplicate upload can be pointed at a path that
-  already exists. Deleting any one of those rows wiped the shared derivatives,
-  and the site then regenerated them — or, where the encoder was broken, served
-  a damaged image.
+So the sharing is opt-in, and only for sites that know their own location
+rules:
 
-  Measured on a five-language site: 5542 files were shared by 25981 attachment
-  rows, so roughly four fifths of the media library could take a live image
-  down with it. The homepage hero lost its derivatives while five attachment
-  rows and the rendered page still referenced them.
+```php
+add_filter( 'timber_kit_share_nav_menu_item_field_groups', '__return_true' );
+```
 
-  The delete now runs only when no other attachment points at the same
-  `_wp_attached_file`. It fails closed: where that question cannot be answered
-  the files are kept, because a stale derivative is overwritten by the next
-  resize while one deleted in error vanishes from a page still serving it.
-  "Cannot be answered" covers a missing `$wpdb`, an empty `_wp_attached_file`
-  (a filter supplied the path, so siblings have no key to match on), and a
-  failed query — `get_var()` reports an error by returning null, which casts to
-  the same zero a genuine "no siblings" answer gives, so the null and
-  `last_error` are both checked rather than read as a count.
+Turn it on only if no custom location type and no location-match filter on the
+site reads the item id. The installed ACFML integration hooks
+`acf/location/rule_match` but reads `post_id`, `lang` and `page_parent`, so it
+does not block the opt-in.
 
-  Not fixed here, and tracked separately: two different files that share a
-  basename across upload-year folders still collide in the flat cache
-  namespace, so deleting one can remove the other's derivative. That needs a
-  cache-naming change, not a guard.
+### What the memo does not cover
+
+The memo freezes the first answer for a screen until something flushes it.
+`acf_get_field_groups()` is not a pure function of the screen: a group
+registered late through `acf_add_local_field_group()`, an `acf/load_field_groups`
+callback, or a location-match filter reading mutable state can all change the
+answer within one process. `StarterBase` flushes on `acf/update_field_group`,
+`acf/delete_field_group`, `acf/trash_field_group` and `acf/untrash_field_group`
+— ACF fires all four dynamically as `acf/{$verb}_{$hook_name}`, which is why a
+literal search for them finds nothing. Anything else that changes groups
+mid-process must call `Helpers::flushFieldGroups()` itself.
+
+A screen `wp_json_encode()` cannot encode is never memoized, because casting
+`false` to a string would collapse every such screen onto one key.
 
 ## [1.42.0] - 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- `Resizer::flushBackendFormats()` and `Helpers::flushFieldGroups()` drop the
+  two in-process memos below. A web request never needs either; WP-CLI
+  commands, persistent workers and tests do, because a static outlives the unit
+  of work that filled it.
+
 ### Changed
 
 - Two capability probes that ran once per object now run once per request.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   two in-process memos below. A web request never needs either; WP-CLI
   commands, persistent workers and tests do, because a static outlives the unit
   of work that filled it.
-- `timber_kit_share_nav_menu_item_field_groups` — opt in to letting every item
-  of one menu share a field-group answer. **Off by default, and the default is
-  the safe one.** See below for the contract it asks you to accept.
+- `timber_kit_share_nav_menu_item_field_groups` — override the automatic
+  verdict described below, in either direction. Nothing to set for it to work.
 
 ### Changed
 
@@ -32,51 +31,51 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   `Helpers::getFieldObjectsByScreen()` called `acf_get_field_groups($screen)`
   once per screen. ACF caches nothing here: every call walks each registered
   field group and evaluates its location rules, measured at 8-10 ms against 96
-  groups whether or not the screen repeats. Answers are now memoized per
-  screen.
+  groups whether or not the screen repeats. `formatFields()` asks once per nav
+  menu item, so a 90-item menu paid for 90 answers. Answers are now memoized
+  per screen.
 
   Measured on the sloneek front page by patching the site and re-measuring, not
-  by scaling the profile. Fastest of twelve warm requests, two independent
-  rounds:
+  by scaling the profile. Fastest of twelve warm requests, **with no
+  configuration of any kind**:
 
-| | probes | `acf_get_field_groups()` | page |
+| | Imagick probes | `acf_get_field_groups()` | page |
   | --- | ---: | ---: | ---: |
-  | before | 320 | 109 | 652-668 ms |
-  | default | 1 | 96 | 603-609 ms |
-  | with the opt-in filter | 1 | 11 | 551-556 ms |
+  | before | 320 | 109 | 671 ms |
+  | after | 1 | 11 | 561 ms |
 
-  So **43-65 ms by default**, and **101-112 ms with the filter on** — roughly
-  7-10 % and 15-17 %. The saving scales with images and menu items, not with
-  the page. Rendered HTML is byte-identical once the random `uniqueId()` values
-  are normalized, checked against a control pair of runs of the unchanged code
-  because the page is not deterministic without one.
+  **110 ms, 16 %**, reproduced across three rounds at 101-112 ms. The saving
+  scales with images and menu items, not with the page. Rendered HTML is
+  byte-identical once the random `uniqueId()` values are normalized, checked
+  against a control pair of runs of the unchanged code because the page is not
+  deterministic without one.
 
-### The nav-menu opt-in, and why it is not the default
+### How the nav-menu sharing stays correct
 
-`formatFields()` asks ACF for field groups once per nav menu item, and on a
-90-item menu the answers are identical — ACF's own
-`ACF_Location_Nav_Menu_Item::match()` reads the item id only to confirm the key
-is set, then matches on `nav_menu`.
+Every item of one menu shares a field-group answer, which is where most of the
+saving comes from. That is safe while ACF's own location types are the only
+things that see the screen: `ACF_Location_Nav_Menu_Item::match()` reads
+`nav_menu_item` only to confirm the key is set, then matches on `nav_menu`.
 
-That is true of ACF's own matcher and **not guaranteed of anyone else's**.
-`acf_register_location_type()` is public API, ACF hands the whole screen to
-every registered location type and to the `acf/location/rule_match` filter, and
-a matcher that answers per item is a legitimate thing to write. Sharing one
-answer would then serve the first item's groups to all of them, with no error
-and no log. A screen whose `nav_menu_item` is literally `'*'` collides for the
-same reason.
+It is not safe in general. `acf_register_location_type()` is public API, ACF
+hands the whole screen to every registered type, and a matcher that answers per
+item is a legitimate thing to write — a "show this group on this one menu item"
+rule for a mega-menu is the obvious case. Sharing would then serve the first
+item's groups to every item, with no error and no log.
 
-So the sharing is opt-in, and only for sites that know their own location
-rules:
+So the kit does not guess and does not ask. Before sharing, it checks that
+**every registered location type is one ACF ships**, by resolving each class to
+its file and requiring it inside `ACF_PATH`. A site that registers its own gets
+the per-item lookups back automatically, with nothing to configure and no
+notice to read. Anything unverifiable — a missing `ACF_PATH`, an empty
+registry, a class with no file — counts as unsafe.
 
-```php
-add_filter( 'timber_kit_share_nav_menu_item_field_groups', '__return_true' );
-```
-
-Turn it on only if no custom location type and no location-match filter on the
-site reads the item id. The installed ACFML integration hooks
-`acf/location/rule_match` but reads `post_id`, `lang` and `page_parent`, so it
-does not block the opt-in.
+The one thing the check cannot see is a callback on `acf/location/rule_match`
+or `acf/location/match_rule`, which also receives the screen. Writing
+menu-item-specific logic there instead of registering a location type is
+contrived, and the one common callback — ACFML's — reads `post_id`, `lang` and
+`page_parent`. A site that does it anyway sets
+`timber_kit_share_nav_menu_item_field_groups` to `false`.
 
 ### What the memo does not cover
 

--- a/README.md
+++ b/README.md
@@ -258,13 +258,13 @@ Two capability probes are memoized on statics, because both answer a question th
 
 `Helpers::getFieldObjectsByScreen()` asks ACF which field groups match a screen. ACF caches nothing here — every call walks each registered field group and evaluates its location rules, 8-10 ms against 96 groups whether or not the screen repeats. Answers are memoized per screen; `Helpers::flushFieldGroups()` drops them, and `StarterBase` wires it to `acf/update_field_group`, `acf/delete_field_group`, `acf/trash_field_group` and `acf/untrash_field_group`. ACF fires all four dynamically as `acf/{$verb}_{$hook_name}`, which is why a literal search for them finds nothing.
 
-**`formatFields()` asks once per nav menu item, and sharing those answers is opt-in:**
+**`formatFields()` asks once per nav menu item, and those answers are shared — automatically, with nothing to configure.** On a 90-item menu it takes 96 lookups down to 11, most of the saving.
 
-```php
-add_filter( 'timber_kit_share_nav_menu_item_field_groups', '__return_true' );
-```
+Sharing is safe while ACF's own location types are the only things that see the screen: `ACF_Location_Nav_Menu_Item::match()` reads the item id only to confirm the key is set, then matches on `nav_menu`. It is not safe in general — `acf_register_location_type()` is public API, ACF hands the whole screen to every registered type, and a "show this group on this one menu item" rule for a mega-menu is a legitimate thing to write. Sharing would then serve the first item's groups to every item, with no error and no log.
 
-On a 90-item menu it takes 96 lookups down to 11, worth about 9 % of the render. It is off by default because ACF's own `ACF_Location_Nav_Menu_Item::match()` reads the item id only to confirm the key is set — and nobody else's matcher has to. `acf_register_location_type()` is public API, ACF hands the whole screen to every registered location type and to the `acf/location/rule_match` filter, and a matcher that answers per item is a legitimate thing to write. Sharing would then serve the first item's groups to every item, with no error and no log. **Turn it on only if no custom location type and no location-match filter on the site reads the item id.**
+So the kit checks rather than guesses: before sharing, **every registered location type must resolve to a class file inside `ACF_PATH`**. A site that registers its own gets the per-item lookups back automatically. Anything unverifiable — no `ACF_PATH`, an empty registry, a class with no file — counts as unsafe.
+
+The check cannot see a callback on `acf/location/rule_match` or `acf/location/match_rule`, which also receives the screen. ACFML's reads `post_id`, `lang` and `page_parent`, so it is fine; a site whose own callback reads the item id sets `timber_kit_share_nav_menu_item_field_groups` to `false`. The same filter forces sharing on for a custom location type known not to read the id.
 
 **A web request never needs either flush.** A long-running process does: WP-CLI commands and persistent workers run many units of work in one process, so a command that saves a field group and then formats fields would otherwise be handed the list read before the save. Call the flush from any such caller that does not boot `StarterBase`, and from tests — a static outlives the test that filled it.
 

--- a/README.md
+++ b/README.md
@@ -250,6 +250,19 @@ The class is `final` with three public static methods: `render()`, `isInserterPr
 
 `BlockRenderer::flushPostBlockCache($post_id)` is the handler `StarterBase` wires to `acf/save_post` at priority 20. When ACF saves a post, the cache group `acf_block_{$post_id}` is flushed — invalidating exactly the cached blocks tied to that post without touching others. The handler guards against non-numeric ids (ACF options-page strings, opaque `block_*` ids) and against environments without `wp_cache_supports('flush_group')`.
 
+### In-process memos
+
+Two capability probes are memoized on statics, because both answer a question that cannot change while the process runs.
+
+`Resizer::probeBackendFormats()` asks the active ImageMagick or GD build which formats it can decode. The answer is a property of the build. It used to be probed once per Resizer instance and one `|resizer` call builds one instance, so a page resizing 320 images built 320 `Imagick` objects to ask the same question. `Resizer::flushBackendFormats()` drops the memo.
+
+`Helpers::getFieldObjectsByScreen()` asks ACF which field groups match a screen. ACF caches nothing here — every call walks each registered field group and evaluates its location rules, 8-10 ms against 96 groups whether or not the screen repeats — and `formatFields()` asks once per nav menu item. Answers are memoized per screen; `Helpers::flushFieldGroups()` drops them, and `StarterBase` wires it to `acf/update_field_group`.
+
+**A web request never needs either flush.** A long-running process does: WP-CLI commands and persistent workers run many units of work in one process, so a command that saves a field group and then formats fields would otherwise be handed the list read before the save. Call the flush from any such caller that does not boot `StarterBase`, and from tests — a static outlives the test that filled it.
+
+These are in-process memos, not a persistent cache. They remove repeated work inside one render; they do not remove the first call of each request. Moving either into the object cache is a separate decision, and its cost is invalidation rather than implementation: ACF field groups load from theme JSON files, and no hook fires when a deploy changes one.
+
+
 ### Site Health board
 
 Opt-in check-list of Porta recommended settings surfaced in Tools → Site Health

--- a/README.md
+++ b/README.md
@@ -252,16 +252,25 @@ The class is `final` with three public static methods: `render()`, `isInserterPr
 
 ### In-process memos
 
-Two capability probes are memoized on statics, because both answer a question that cannot change while the process runs.
+Two capability probes are memoized on statics, because both answer a question that is expensive to compute and cheap to store.
 
-`Resizer::probeBackendFormats()` asks the active ImageMagick or GD build which formats it can decode. The answer is a property of the build. It used to be probed once per Resizer instance and one `|resizer` call builds one instance, so a page resizing 320 images built 320 `Imagick` objects to ask the same question. `Resizer::flushBackendFormats()` drops the memo.
+`Resizer::probeBackendFormats()` asks the active ImageMagick or GD build which formats it can decode. The answer is a property of the build. It used to be probed once per Resizer instance and one `|resizer` call builds one instance, so a page resizing 320 images built 320 `Imagick` objects to ask the same question. The memo is keyed by concrete class, so a subclass that stubs the probe cannot answer for the base class. `Resizer::flushBackendFormats()` drops it.
 
-`Helpers::getFieldObjectsByScreen()` asks ACF which field groups match a screen. ACF caches nothing here — every call walks each registered field group and evaluates its location rules, 8-10 ms against 96 groups whether or not the screen repeats — and `formatFields()` asks once per nav menu item. Answers are memoized per screen; `Helpers::flushFieldGroups()` drops them, and `StarterBase` wires it to `acf/update_field_group`.
+`Helpers::getFieldObjectsByScreen()` asks ACF which field groups match a screen. ACF caches nothing here — every call walks each registered field group and evaluates its location rules, 8-10 ms against 96 groups whether or not the screen repeats. Answers are memoized per screen; `Helpers::flushFieldGroups()` drops them, and `StarterBase` wires it to `acf/update_field_group`, `acf/delete_field_group`, `acf/trash_field_group` and `acf/untrash_field_group`. ACF fires all four dynamically as `acf/{$verb}_{$hook_name}`, which is why a literal search for them finds nothing.
+
+**`formatFields()` asks once per nav menu item, and sharing those answers is opt-in:**
+
+```php
+add_filter( 'timber_kit_share_nav_menu_item_field_groups', '__return_true' );
+```
+
+On a 90-item menu it takes 96 lookups down to 11, worth about 9 % of the render. It is off by default because ACF's own `ACF_Location_Nav_Menu_Item::match()` reads the item id only to confirm the key is set — and nobody else's matcher has to. `acf_register_location_type()` is public API, ACF hands the whole screen to every registered location type and to the `acf/location/rule_match` filter, and a matcher that answers per item is a legitimate thing to write. Sharing would then serve the first item's groups to every item, with no error and no log. **Turn it on only if no custom location type and no location-match filter on the site reads the item id.**
 
 **A web request never needs either flush.** A long-running process does: WP-CLI commands and persistent workers run many units of work in one process, so a command that saves a field group and then formats fields would otherwise be handed the list read before the save. Call the flush from any such caller that does not boot `StarterBase`, and from tests — a static outlives the test that filled it.
 
-These are in-process memos, not a persistent cache. They remove repeated work inside one render; they do not remove the first call of each request. Moving either into the object cache is a separate decision, and its cost is invalidation rather than implementation: ACF field groups load from theme JSON files, and no hook fires when a deploy changes one.
+The memo freezes the first answer until something flushes it, and `acf_get_field_groups()` is not a pure function of the screen: a late `acf_add_local_field_group()`, an `acf/load_field_groups` callback, or a location-match filter reading mutable state can all change the answer mid-process. The four hooks above cover the admin edit; anything else must flush for itself. A screen `wp_json_encode()` cannot encode is never memoized, because casting `false` to a string would collapse every such screen onto one key.
 
+These are in-process memos, not a persistent cache. They remove repeated work inside one render; they do not remove the first call of each request. Moving either into the object cache is a separate decision, and its cost is invalidation rather than implementation: ACF field groups load from theme JSON files and no hook fires when a deploy changes one. A persistent cache would also still want a static in front of it, because `wp_cache_get()` is not free.
 
 ### Site Health board
 

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1238,6 +1238,13 @@ class Helpers {
 	private static array $field_groups_memo = [];
 
 	/**
+	 * Memoized answer of the `timber_kit_share_nav_menu_item_field_groups` filter.
+	 *
+	 * @var bool|null
+	 */
+	private static ?bool $share_nav_menu_item_groups = null;
+
+	/**
 	 * Drop the memoized field-group answers.
 	 *
 	 * A web request never needs this: the process ends before a field group can
@@ -1249,6 +1256,7 @@ class Helpers {
 	 */
 	public static function flushFieldGroups(): void {
 		self::$field_groups_memo = [];
+		self::$share_nav_menu_item_groups = null;
 	}
 
 	/**
@@ -1259,6 +1267,11 @@ class Helpers {
 	 */
 	private static function fieldGroupsForScreen( array $screen ): array {
 		$key = self::fieldGroupsMemoKey( $screen );
+		if ( null === $key ) {
+			$groups = acf_get_field_groups( $screen );
+			return is_array( $groups ) ? $groups : [];
+		}
+
 		if ( ! array_key_exists( $key, self::$field_groups_memo ) ) {
 			$groups = acf_get_field_groups( $screen );
 			self::$field_groups_memo[ $key ] = is_array( $groups ) ? $groups : [];
@@ -1284,15 +1297,60 @@ class Helpers {
 	 * @param array<string, mixed> $screen Screen array.
 	 * @return string
 	 */
-	private static function fieldGroupsMemoKey( array $screen ): string {
-		if ( isset( $screen['nav_menu_item'] ) ) {
+	private static function fieldGroupsMemoKey( array $screen ): ?string {
+		if ( isset( $screen['nav_menu_item'] ) && self::sharesNavMenuItemFieldGroups() ) {
 			$screen['nav_menu_item'] = '*';
 		}
 		ksort( $screen );
 
+		$encoded = wp_json_encode( $screen );
+		if ( ! is_string( $encoded ) ) {
+			// An unencodable screen has no usable identity. Casting `false` to a
+			// string would collapse every such screen onto one key and hand the
+			// first one's groups to all the others.
+			return null;
+		}
+
 		$blog_id = function_exists( 'get_current_blog_id' ) ? (int) get_current_blog_id() : 0;
 
-		return $blog_id . '|' . self::getLanguage() . '|' . (string) wp_json_encode( $screen );
+		return $blog_id . '|' . self::getLanguage() . '|' . $encoded;
+	}
+
+	/**
+	 * Whether every item of one menu may share one field-group answer.
+	 *
+	 * **Off by default, and the default is the safe one.** ACF hands the whole
+	 * screen to every registered location type and to the
+	 * `acf/location/rule_match` filter, and `acf_register_location_type()` is
+	 * public API — so a project or plugin can register a matcher that reads
+	 * `nav_menu_item` and answers differently per item. Sharing would then serve
+	 * the first item's groups to all of them, silently. A screen whose
+	 * `nav_menu_item` is literally `'*'` collides for the same reason.
+	 *
+	 * ACF's own `ACF_Location_Nav_Menu_Item::match()` reads the key only to
+	 * confirm it is set and then matches on `nav_menu`, so on a site with no
+	 * such custom matcher the answers are identical and asking per item is
+	 * wasted work. Opt in there:
+	 *
+	 * ```php
+	 * add_filter( 'timber_kit_share_nav_menu_item_field_groups', '__return_true' );
+	 * ```
+	 *
+	 * Measured on a 90-item menu against 96 field groups: 96 lookups fall to 11,
+	 * worth about 9 % of the render. Turn it on only if no custom location type
+	 * and no location-match filter on the site reads the item id.
+	 *
+	 * @return bool
+	 */
+	private static function sharesNavMenuItemFieldGroups(): bool {
+		if ( null === self::$share_nav_menu_item_groups ) {
+			self::$share_nav_menu_item_groups = (bool) apply_filters(
+				'timber_kit_share_nav_menu_item_field_groups',
+				false
+			);
+		}
+
+		return self::$share_nav_menu_item_groups;
 	}
 
 	/**

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1226,6 +1226,76 @@ class Helpers {
 	}
 
 	/**
+	 * Memoized `acf_get_field_groups()` answers, keyed by screen.
+	 *
+	 * ACF does not cache this call. Every invocation walks each registered field
+	 * group and evaluates its location rules, so the cost is
+	 * `groups x screens` — measured at 8-10 ms per call against 96 groups,
+	 * whether or not the screen repeats.
+	 *
+	 * @var array<string, array<int, mixed>>
+	 */
+	private static array $field_groups_memo = [];
+
+	/**
+	 * Drop the memoized field-group answers.
+	 *
+	 * A web request never needs this: the process ends before a field group can
+	 * change. `StarterBase` wires it to `acf/update_field_group` for the admin
+	 * save, and it is public for WP-CLI commands, persistent workers and tests,
+	 * where one process registers groups and then reads them back.
+	 *
+	 * @return void
+	 */
+	public static function flushFieldGroups(): void {
+		self::$field_groups_memo = [];
+	}
+
+	/**
+	 * `acf_get_field_groups()` behind a per-screen memo.
+	 *
+	 * @param array<string, mixed> $screen Screen array passed to `acf_get_field_groups()`.
+	 * @return array<int, mixed> Matching field groups; empty when none match.
+	 */
+	private static function fieldGroupsForScreen( array $screen ): array {
+		$key = self::fieldGroupsMemoKey( $screen );
+		if ( ! array_key_exists( $key, self::$field_groups_memo ) ) {
+			$groups = acf_get_field_groups( $screen );
+			self::$field_groups_memo[ $key ] = is_array( $groups ) ? $groups : [];
+		}
+
+		return self::$field_groups_memo[ $key ];
+	}
+
+	/**
+	 * Cache key for one screen.
+	 *
+	 * Carries the blog id and the language because field groups are registered
+	 * per site and ACFML translates a group's own strings, so both change the
+	 * correct answer for an unchanged screen.
+	 *
+	 * `nav_menu_item` is normalized to a presence marker.
+	 * `ACF_Location_Nav_Menu_Item::match()` reads that key only to confirm it is
+	 * set and then hands the whole decision to the `nav_menu` location type, so
+	 * the item id cannot change which groups match — every item of one menu
+	 * shares an answer. Without the normalization the memo would key on an id
+	 * that never affects the result and never hit.
+	 *
+	 * @param array<string, mixed> $screen Screen array.
+	 * @return string
+	 */
+	private static function fieldGroupsMemoKey( array $screen ): string {
+		if ( isset( $screen['nav_menu_item'] ) ) {
+			$screen['nav_menu_item'] = '*';
+		}
+		ksort( $screen );
+
+		$blog_id = function_exists( 'get_current_blog_id' ) ? (int) get_current_blog_id() : 0;
+
+		return $blog_id . '|' . self::getLanguage() . '|' . (string) wp_json_encode( $screen );
+	}
+
+	/**
 	 * Resolve ACF field objects for an explicit location-rule screen.
 	 *
 	 * Walks `acf_get_field_groups($screen)` → `acf_get_fields($group)` and
@@ -1253,8 +1323,8 @@ class Helpers {
 			return false;
 		}
 
-		$groups = acf_get_field_groups( $screen );
-		if ( ! is_array( $groups ) || empty( $groups ) ) {
+		$groups = self::fieldGroupsForScreen( $screen );
+		if ( empty( $groups ) ) {
 			return false;
 		}
 

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1319,26 +1319,24 @@ class Helpers {
 	/**
 	 * Whether every item of one menu may share one field-group answer.
 	 *
-	 * **Off by default, and the default is the safe one.** ACF hands the whole
-	 * screen to every registered location type and to the
-	 * `acf/location/rule_match` filter, and `acf_register_location_type()` is
-	 * public API — so a project or plugin can register a matcher that reads
-	 * `nav_menu_item` and answers differently per item. Sharing would then serve
-	 * the first item's groups to all of them, silently. A screen whose
-	 * `nav_menu_item` is literally `'*'` collides for the same reason.
+	 * **On by default, and it switches itself off where it would be wrong.**
 	 *
-	 * ACF's own `ACF_Location_Nav_Menu_Item::match()` reads the key only to
-	 * confirm it is set and then matches on `nav_menu`, so on a site with no
-	 * such custom matcher the answers are identical and asking per item is
-	 * wasted work. Opt in there:
+	 * ACF's own `ACF_Location_Nav_Menu_Item::match()` reads `nav_menu_item` only
+	 * to confirm the key is set and then matches on `nav_menu`, so the item id
+	 * cannot change which groups match and asking once per item is wasted work.
+	 * That holds for every location type ACF ships and for nobody else's by
+	 * guarantee: `acf_register_location_type()` is public API, ACF hands the
+	 * whole screen to every registered type, and a matcher that answers per item
+	 * is a legitimate thing to write.
 	 *
-	 * ```php
-	 * add_filter( 'timber_kit_share_nav_menu_item_field_groups', '__return_true' );
-	 * ```
+	 * So the default is not a bet — it is
+	 * {@see navMenuItemSharingIsSafe()}, which checks that every registered
+	 * location type is one ACF ships. A site that registers its own gets the
+	 * per-item lookups back automatically, with nothing to configure.
 	 *
-	 * Measured on a 90-item menu against 96 field groups: 96 lookups fall to 11,
-	 * worth about 9 % of the render. Turn it on only if no custom location type
-	 * and no location-match filter on the site reads the item id.
+	 * `timber_kit_share_nav_menu_item_field_groups` overrides the verdict in
+	 * either direction — force it off while auditing, or force it on for a
+	 * custom type that is known not to read the item id.
 	 *
 	 * @return bool
 	 */
@@ -1346,11 +1344,66 @@ class Helpers {
 		if ( null === self::$share_nav_menu_item_groups ) {
 			self::$share_nav_menu_item_groups = (bool) apply_filters(
 				'timber_kit_share_nav_menu_item_field_groups',
-				false
+				self::navMenuItemSharingIsSafe()
 			);
 		}
 
 		return self::$share_nav_menu_item_groups;
+	}
+
+	/**
+	 * Whether only ACF's own location types can see the screen.
+	 *
+	 * The one thing that makes sharing unsafe is a matcher that reads the item
+	 * id, and the only way to add one is `acf_register_location_type()`. Every
+	 * registered type whose class file sits inside `ACF_PATH` is ACF's own, and
+	 * ACF's own were read: `nav_menu_item` is the only type that touches the
+	 * key, and only through `isset()`.
+	 *
+	 * Anything it cannot verify counts as unsafe — a missing `ACF_PATH`, a class
+	 * with no file (eval'd or from an extension), a type from anywhere else.
+	 *
+	 * Known limit: a callback on `acf/location/rule_match` or
+	 * `acf/location/match_rule` also receives the screen and is not detectable
+	 * this way. Writing menu-item-specific logic there instead of registering a
+	 * location type is contrived, and the one common callback — ACFML's — reads
+	 * `post_id`, `lang` and `page_parent`. A site that does it anyway turns the
+	 * filter above off.
+	 *
+	 * @return bool
+	 */
+	private static function navMenuItemSharingIsSafe(): bool {
+		if ( ! defined( 'ACF_PATH' ) || ! function_exists( 'acf_get_location_types' ) ) {
+			return false;
+		}
+
+		$acf_path = (string) constant( 'ACF_PATH' );
+		if ( '' === $acf_path ) {
+			return false;
+		}
+
+		$types = acf_get_location_types();
+		if ( ! is_array( $types ) || empty( $types ) ) {
+			return false;
+		}
+
+		foreach ( $types as $type ) {
+			if ( ! is_object( $type ) ) {
+				return false;
+			}
+
+			try {
+				$file = ( new \ReflectionClass( $type ) )->getFileName();
+			} catch ( \ReflectionException $e ) {
+				return false;
+			}
+
+			if ( ! is_string( $file ) || ! str_starts_with( $file, $acf_path ) ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/src/Resizer.php
+++ b/src/Resizer.php
@@ -160,9 +160,14 @@ class Resizer {
 	 * once per resized image: 320 `new Imagick()` + `queryFormats()` pairs on the
 	 * sloneek front page, 52 ms of a 990 ms render.
 	 *
-	 * @var array<int, string>|null
+	 * Keyed by concrete class: a subclass that overrides
+	 * {@see probeBackendFormatsUncached()} must not fill the base class's
+	 * entry, or ordinary Resizer instances downstream of it would be answered
+	 * with its stubbed list. The test fixture does exactly that.
+	 *
+	 * @var array<string, array<int, string>>
 	 */
-	private static ?array $backend_formats_memo = null;
+	private static array $backend_formats_memo = [];
 
 	/**
 	 * Initialize resizer settings, each of which can be overridden via a WordPress filter.
@@ -505,7 +510,8 @@ class Resizer {
 	 * @return array<int, string>
 	 */
 	protected function probeBackendFormats(): array {
-		return self::$backend_formats_memo ??= $this->probeBackendFormatsUncached();
+		return self::$backend_formats_memo[ static::class ]
+			??= $this->probeBackendFormatsUncached();
 	}
 
 	/**
@@ -518,7 +524,7 @@ class Resizer {
 	 * @return void
 	 */
 	public static function flushBackendFormats(): void {
-		self::$backend_formats_memo = null;
+		self::$backend_formats_memo = [];
 	}
 
 	/**

--- a/src/Resizer.php
+++ b/src/Resizer.php
@@ -140,11 +140,29 @@ class Resizer {
 	private bool $quality_in_cache_key;
 
 	/**
-	 * Memoized allow-list of decodable input MIME types (per request).
+	 * Memoized allow-list of decodable input MIME types, per instance.
+	 *
+	 * Per instance, not per request: the theme builds one Resizer per `|resizer`
+	 * call, so this only ever answers the second question asked of one image.
+	 * The backend probe behind it is memoized per process instead — see
+	 * {@see $backend_formats_memo}.
 	 *
 	 * @var array<int, string>|null
 	 */
 	private ?array $decodable_cache = null;
+
+	/**
+	 * Memoized format list reported by the active image backend.
+	 *
+	 * Static, because the list is a property of the ImageMagick or GD build and
+	 * cannot change while the process runs, while `$decodable_cache` above dies
+	 * with its instance. One `|resizer` call builds one Resizer, so the probe ran
+	 * once per resized image: 320 `new Imagick()` + `queryFormats()` pairs on the
+	 * sloneek front page, 52 ms of a 990 ms render.
+	 *
+	 * @var array<int, string>|null
+	 */
+	private static ?array $backend_formats_memo = null;
 
 	/**
 	 * Initialize resizer settings, each of which can be overridden via a WordPress filter.
@@ -197,7 +215,9 @@ class Resizer {
 
 	/**
 	 * The allow-list of input MIME types: the desired superset intersected with what
-	 * the active backend can decode. Memoized per request.
+	 * the active backend can decode. Memoized per instance, and one `|resizer`
+	 * call builds one instance — the backend probe behind it carries the
+	 * process-wide memo.
 	 *
 	 * Filterable via `timber_kit_resizer_allowed_types` ( `array<int,string> $mimes,
 	 * array<int,string> $backend_formats` ) for projects that need to force a format
@@ -485,6 +505,33 @@ class Resizer {
 	 * @return array<int, string>
 	 */
 	protected function probeBackendFormats(): array {
+		return self::$backend_formats_memo ??= $this->probeBackendFormatsUncached();
+	}
+
+	/**
+	 * Drop the memoized backend format list.
+	 *
+	 * A web request never needs this: an ImageMagick build cannot change while
+	 * the process runs. Tests do, because a static outlives the test that filled
+	 * it, and so does any process that reloads the image backend.
+	 *
+	 * @return void
+	 */
+	public static function flushBackendFormats(): void {
+		self::$backend_formats_memo = null;
+	}
+
+	/**
+	 * Ask the active backend which formats it can decode.
+	 *
+	 * Split from {@see probeBackendFormats()} so the memo above wraps it. Both
+	 * stay `protected`: a test that stubs `probeBackendFormats()` replaces the
+	 * memo too and never fills it, and a test that stubs this one gets memoized,
+	 * so it must reset the memo afterwards.
+	 *
+	 * @return array<int, string>
+	 */
+	protected function probeBackendFormatsUncached(): array {
 		if ( extension_loaded( 'imagick' ) && class_exists( '\Imagick' ) ) {
 			try {
 				$formats = ( new \Imagick() )->queryFormats();

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -1024,6 +1024,9 @@ class StarterBase extends Site {
 		add_filter( 'acf/json/save_file_name', array( $this, 'acf_json_save_file_name' ), 10, 3 );
 		add_filter( 'acf/update_value/type=wysiwyg', array( $this, 'sanitize_acf_editor_value' ), 10, 1 );
 		add_filter( 'acf/format_value/type=post_object', array( $this, 'fix_wrong_acf_orders_with_ids' ), 10, 3 );
+		// Field groups are memoized per screen for the render; a save in the same
+		// request must not be answered from the list read before it.
+		add_action( 'acf/update_field_group', array( Helpers::class, 'flushFieldGroups' ) );
 		if ( $this->acf_json_keep_on_delete ) {
 			// acf/init runs after ACF constructs ACF_Local_JSON, so the
 			// listeners exist by the time the guard tries to remove them.

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -1024,9 +1024,13 @@ class StarterBase extends Site {
 		add_filter( 'acf/json/save_file_name', array( $this, 'acf_json_save_file_name' ), 10, 3 );
 		add_filter( 'acf/update_value/type=wysiwyg', array( $this, 'sanitize_acf_editor_value' ), 10, 1 );
 		add_filter( 'acf/format_value/type=post_object', array( $this, 'fix_wrong_acf_orders_with_ids' ), 10, 3 );
-		// Field groups are memoized per screen for the render; a save in the same
-		// request must not be answered from the list read before it.
-		add_action( 'acf/update_field_group', array( Helpers::class, 'flushFieldGroups' ) );
+		// Field groups are memoized per screen for the render; a change in the same
+		// request must not be answered from the list read before it. ACF fires
+		// these four dynamically as "acf/{$verb}_{$hook_name}", which is why a
+		// literal grep for them finds nothing.
+		foreach ( array( 'update', 'delete', 'trash', 'untrash' ) as $verb ) {
+			add_action( 'acf/' . $verb . '_field_group', array( Helpers::class, 'flushFieldGroups' ) );
+		}
 		if ( $this->acf_json_keep_on_delete ) {
 			// acf/init runs after ACF constructs ACF_Local_JSON, so the
 			// listeners exist by the time the guard tries to remove them.

--- a/tests/Fixtures/Acf/StubCoreLocationType.php
+++ b/tests/Fixtures/Acf/StubCoreLocationType.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Acf;
+
+/**
+ * Stands in for a location type ACF ships.
+ *
+ * The detection under test asks only one question of a location type: does its
+ * class file sit inside `ACF_PATH`. The tests point `ACF_PATH` at this
+ * directory, so this class is "ACF's own" and anything in the parent directory
+ * is not — the same mechanism the production check uses, not a parallel one.
+ */
+class StubCoreLocationType {
+
+	public string $name = 'stub_core';
+}

--- a/tests/Fixtures/CountingResizer.php
+++ b/tests/Fixtures/CountingResizer.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Parisek\TimberKit\Resizer;
+
+/**
+ * Resizer whose backend probe is stubbed and counted.
+ *
+ * It overrides `probeBackendFormatsUncached()`, not `probeBackendFormats()`, so
+ * the memo under test still wraps it.
+ *
+ * It lives in `tests/Fixtures/` rather than beside its test on purpose. A
+ * `class X extends Resizer` at the top level of a `*Test.php` file loads
+ * `Resizer` while PHPUnit is still collecting test files — before Patchwork
+ * instruments it — and `Patchwork\redefine( 'file_exists', … )` then silently
+ * stops reaching the copy of `Resizer` that the other resizer tests exercise.
+ * Ten of them failed that way. Autoloaded from here, the class is built when a
+ * test asks for it, like every other Resizer in the suite.
+ */
+class CountingResizer extends Resizer {
+
+	public static int $probes = 0;
+
+	protected function probeBackendFormatsUncached(): array {
+		++self::$probes;
+		return [ 'JPEG', 'PNG', 'GIF' ];
+	}
+}

--- a/tests/Fixtures/JpegOnlyResizer.php
+++ b/tests/Fixtures/JpegOnlyResizer.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Parisek\TimberKit\Resizer;
+
+/**
+ * Second stubbed Resizer, reporting a different backend than
+ * {@see CountingResizer}.
+ *
+ * Its whole job is to prove the memo is keyed per concrete class. Two
+ * subclasses that stub the probe differently must not answer each other.
+ */
+class JpegOnlyResizer extends Resizer {
+
+	public static int $probes = 0;
+
+	protected function probeBackendFormatsUncached(): array {
+		++self::$probes;
+		return [ 'JPEG' ];
+	}
+}

--- a/tests/Fixtures/StubCustomLocationType.php
+++ b/tests/Fixtures/StubCustomLocationType.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+/**
+ * Stands in for a location type a project registered itself.
+ *
+ * It lives one directory above `tests/Fixtures/Acf/`, which the tests use as
+ * `ACF_PATH`, so the detection must classify it as foreign.
+ */
+class StubCustomLocationType {
+
+	public string $name = 'stub_custom';
+}

--- a/tests/Unit/Helpers/FieldGroupsMemoTest.php
+++ b/tests/Unit/Helpers/FieldGroupsMemoTest.php
@@ -13,22 +13,30 @@ use Tests\Unit\HelpersTestCase;
  *
  * ACF caches nothing here: every call walks each registered field group and
  * evaluates its location rules, measured at 8-10 ms against 96 groups whether
- * or not the screen repeats. `formatFields()` asks once per nav menu item, so a
- * 90-item menu paid for 90 identical answers.
+ * or not the screen repeats.
+ *
+ * The nav-menu-item half of it is opt-in, and these tests pin that the default
+ * is the safe one — ACF hands the whole screen to every registered location
+ * type, so a custom matcher may legitimately answer per item.
  */
 class FieldGroupsMemoTest extends HelpersTestCase {
 
 	/** @var array<int, array<string, mixed>> */
 	private array $seen = [];
 
+	private bool $shareMenuItems = false;
+
 	protected function setUp(): void {
 		parent::setUp();
-		$this->seen = [];
+		$this->seen           = [];
+		$this->shareMenuItems = false;
 
 		Functions\when( 'apply_filters' )->alias(
 			function ( $filter, $default = null, ...$args ) {
-				unset( $filter, $args );
-				return $default;
+				unset( $args );
+				return 'timber_kit_share_nav_menu_item_field_groups' === $filter
+					? $this->shareMenuItems
+					: $default;
 			}
 		);
 		Functions\when( 'get_locale' )->justReturn( 'cs_CZ' );
@@ -53,26 +61,42 @@ class FieldGroupsMemoTest extends HelpersTestCase {
 		return $method->invoke( null, $screen );
 	}
 
-	public function test_items_of_one_menu_share_an_answer(): void {
-		// ACF_Location_Nav_Menu_Item::match() reads `nav_menu_item` only to
-		// confirm it is set, then matches on `nav_menu` — so the item id cannot
-		// change which groups match.
+	private function optIn(): void {
+		$this->shareMenuItems = true;
+		Helpers::flushFieldGroups();
+	}
+
+	public function test_menu_items_are_asked_separately_by_default(): void {
+		// The default must stay safe: a custom location type may read the item id.
+		$this->lookup( [ 'nav_menu_item' => 101, 'nav_menu' => 75 ] );
+		$this->lookup( [ 'nav_menu_item' => 102, 'nav_menu' => 75 ] );
+
+		$this->assertCount( 2, $this->seen );
+	}
+
+	public function test_items_of_one_menu_share_an_answer_when_opted_in(): void {
+		$this->optIn();
+
 		$this->lookup( [ 'nav_menu_item' => 101, 'nav_menu' => 75 ] );
 		$this->lookup( [ 'nav_menu_item' => 102, 'nav_menu' => 75 ] );
 		$this->lookup( [ 'nav_menu_item' => 103, 'nav_menu' => 75 ] );
 
-		$this->assertCount( 1, $this->seen, 'Three items of one menu must ask ACF once.' );
+		$this->assertCount( 1, $this->seen );
 	}
 
-	public function test_the_first_item_id_still_reaches_acf(): void {
-		// The normalization is in the cache key only. ACF must still be asked
-		// with a real id, because its location type checks that the key is set.
+	public function test_the_real_item_id_still_reaches_acf_when_opted_in(): void {
+		// The normalization is in the cache key only. ACF's own location type
+		// checks that the key is set, so a placeholder would change the answer.
+		$this->optIn();
+
 		$this->lookup( [ 'nav_menu_item' => 101, 'nav_menu' => 75 ] );
 
 		$this->assertSame( 101, $this->seen[0]['nav_menu_item'] );
 	}
 
-	public function test_a_different_menu_is_asked_separately(): void {
+	public function test_a_different_menu_is_asked_separately_when_opted_in(): void {
+		$this->optIn();
+
 		$this->lookup( [ 'nav_menu_item' => 101, 'nav_menu' => 75 ] );
 		$this->lookup( [ 'nav_menu_item' => 102, 'nav_menu' => 76 ] );
 
@@ -80,6 +104,7 @@ class FieldGroupsMemoTest extends HelpersTestCase {
 	}
 
 	public function test_one_options_page_is_asked_once(): void {
+		// Not gated: the options-page screen carries no per-caller id.
 		$this->lookup( [ 'options_page' => 'site-settings' ] );
 		$this->lookup( [ 'options_page' => 'site-settings' ] );
 
@@ -87,10 +112,39 @@ class FieldGroupsMemoTest extends HelpersTestCase {
 	}
 
 	public function test_key_order_does_not_split_the_memo(): void {
-		$this->lookup( [ 'nav_menu' => 75, 'nav_menu_item' => 101 ] );
-		$this->lookup( [ 'nav_menu_item' => 102, 'nav_menu' => 75 ] );
+		$this->lookup( [ 'nav_menu' => 75, 'post_type' => 'page' ] );
+		$this->lookup( [ 'post_type' => 'page', 'nav_menu' => 75 ] );
 
 		$this->assertCount( 1, $this->seen );
+	}
+
+	public function test_another_blog_is_asked_separately(): void {
+		$this->lookup( [ 'options_page' => 'site-settings' ] );
+		Functions\when( 'get_current_blog_id' )->justReturn( 2 );
+		$this->lookup( [ 'options_page' => 'site-settings' ] );
+
+		$this->assertCount( 2, $this->seen );
+	}
+
+	public function test_another_language_is_asked_separately(): void {
+		$this->lookup( [ 'options_page' => 'site-settings' ] );
+		Functions\when( 'get_locale' )->justReturn( 'it_IT' );
+		$this->lookup( [ 'options_page' => 'site-settings' ] );
+
+		$this->assertCount( 2, $this->seen );
+	}
+
+	public function test_an_unencodable_screen_is_never_memoized(): void {
+		// `wp_json_encode()` answers false for invalid UTF-8. Casting that to a
+		// string would collapse every such screen onto one key, so the memo is
+		// skipped instead — twice the work, never the wrong answer.
+		Functions\when( 'wp_json_encode' )->justReturn( false );
+
+		$this->lookup( [ 'options_page' => "bad\xB1utf8" ] );
+		$this->lookup( [ 'options_page' => "bad\xB1utf8" ] );
+		$this->lookup( [ 'options_page' => 'another' ] );
+
+		$this->assertCount( 3, $this->seen );
 	}
 
 	public function test_flush_forces_a_fresh_read(): void {

--- a/tests/Unit/Helpers/FieldGroupsMemoTest.php
+++ b/tests/Unit/Helpers/FieldGroupsMemoTest.php
@@ -15,9 +15,9 @@ use Tests\Unit\HelpersTestCase;
  * evaluates its location rules, measured at 8-10 ms against 96 groups whether
  * or not the screen repeats.
  *
- * The nav-menu-item half of it is opt-in, and these tests pin that the default
- * is the safe one — ACF hands the whole screen to every registered location
- * type, so a custom matcher may legitimately answer per item.
+ * These tests drive the nav-menu-item sharing explicitly through its filter,
+ * both ways. Whether it is on by default on a given site is decided by
+ * {@see NavMenuItemSharingSafetyTest}, which covers the detection itself.
  */
 class FieldGroupsMemoTest extends HelpersTestCase {
 
@@ -61,21 +61,20 @@ class FieldGroupsMemoTest extends HelpersTestCase {
 		return $method->invoke( null, $screen );
 	}
 
-	private function optIn(): void {
+	private function shareMenuItems(): void {
 		$this->shareMenuItems = true;
 		Helpers::flushFieldGroups();
 	}
 
-	public function test_menu_items_are_asked_separately_by_default(): void {
-		// The default must stay safe: a custom location type may read the item id.
+	public function test_menu_items_are_asked_separately_when_sharing_is_off(): void {
 		$this->lookup( [ 'nav_menu_item' => 101, 'nav_menu' => 75 ] );
 		$this->lookup( [ 'nav_menu_item' => 102, 'nav_menu' => 75 ] );
 
 		$this->assertCount( 2, $this->seen );
 	}
 
-	public function test_items_of_one_menu_share_an_answer_when_opted_in(): void {
-		$this->optIn();
+	public function test_items_of_one_menu_share_an_answer_when_sharing_is_on(): void {
+		$this->shareMenuItems();
 
 		$this->lookup( [ 'nav_menu_item' => 101, 'nav_menu' => 75 ] );
 		$this->lookup( [ 'nav_menu_item' => 102, 'nav_menu' => 75 ] );
@@ -84,18 +83,18 @@ class FieldGroupsMemoTest extends HelpersTestCase {
 		$this->assertCount( 1, $this->seen );
 	}
 
-	public function test_the_real_item_id_still_reaches_acf_when_opted_in(): void {
+	public function test_the_real_item_id_still_reaches_acf_when_sharing_is_on(): void {
 		// The normalization is in the cache key only. ACF's own location type
 		// checks that the key is set, so a placeholder would change the answer.
-		$this->optIn();
+		$this->shareMenuItems();
 
 		$this->lookup( [ 'nav_menu_item' => 101, 'nav_menu' => 75 ] );
 
 		$this->assertSame( 101, $this->seen[0]['nav_menu_item'] );
 	}
 
-	public function test_a_different_menu_is_asked_separately_when_opted_in(): void {
-		$this->optIn();
+	public function test_a_different_menu_is_asked_separately_when_sharing_is_on(): void {
+		$this->shareMenuItems();
 
 		$this->lookup( [ 'nav_menu_item' => 101, 'nav_menu' => 75 ] );
 		$this->lookup( [ 'nav_menu_item' => 102, 'nav_menu' => 76 ] );
@@ -104,7 +103,7 @@ class FieldGroupsMemoTest extends HelpersTestCase {
 	}
 
 	public function test_one_options_page_is_asked_once(): void {
-		// Not gated: the options-page screen carries no per-caller id.
+		// Never gated: the options-page screen carries no per-caller id.
 		$this->lookup( [ 'options_page' => 'site-settings' ] );
 		$this->lookup( [ 'options_page' => 'site-settings' ] );
 

--- a/tests/Unit/Helpers/FieldGroupsMemoTest.php
+++ b/tests/Unit/Helpers/FieldGroupsMemoTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Helpers;
+
+use Brain\Monkey\Functions;
+use Parisek\TimberKit\Helpers;
+use Tests\Unit\HelpersTestCase;
+
+/**
+ * Covers the per-screen memo in front of `acf_get_field_groups()`.
+ *
+ * ACF caches nothing here: every call walks each registered field group and
+ * evaluates its location rules, measured at 8-10 ms against 96 groups whether
+ * or not the screen repeats. `formatFields()` asks once per nav menu item, so a
+ * 90-item menu paid for 90 identical answers.
+ */
+class FieldGroupsMemoTest extends HelpersTestCase {
+
+	/** @var array<int, array<string, mixed>> */
+	private array $seen = [];
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->seen = [];
+
+		Functions\when( 'apply_filters' )->alias(
+			function ( $filter, $default = null, ...$args ) {
+				unset( $filter, $args );
+				return $default;
+			}
+		);
+		Functions\when( 'get_locale' )->justReturn( 'cs_CZ' );
+		Functions\when( 'get_current_blog_id' )->justReturn( 1 );
+		Functions\when( 'wp_json_encode' )->alias(
+			static fn ( $value ) => json_encode( $value )
+		);
+		Functions\when( 'acf_get_field_groups' )->alias(
+			function ( $screen ) {
+				$this->seen[] = $screen;
+				return [ [ 'key' => 'group_1' ] ];
+			}
+		);
+	}
+
+	/**
+	 * @param array<string, mixed> $screen
+	 * @return array<int, mixed>
+	 */
+	private function lookup( array $screen ): array {
+		$method = new \ReflectionMethod( Helpers::class, 'fieldGroupsForScreen' );
+		return $method->invoke( null, $screen );
+	}
+
+	public function test_items_of_one_menu_share_an_answer(): void {
+		// ACF_Location_Nav_Menu_Item::match() reads `nav_menu_item` only to
+		// confirm it is set, then matches on `nav_menu` — so the item id cannot
+		// change which groups match.
+		$this->lookup( [ 'nav_menu_item' => 101, 'nav_menu' => 75 ] );
+		$this->lookup( [ 'nav_menu_item' => 102, 'nav_menu' => 75 ] );
+		$this->lookup( [ 'nav_menu_item' => 103, 'nav_menu' => 75 ] );
+
+		$this->assertCount( 1, $this->seen, 'Three items of one menu must ask ACF once.' );
+	}
+
+	public function test_the_first_item_id_still_reaches_acf(): void {
+		// The normalization is in the cache key only. ACF must still be asked
+		// with a real id, because its location type checks that the key is set.
+		$this->lookup( [ 'nav_menu_item' => 101, 'nav_menu' => 75 ] );
+
+		$this->assertSame( 101, $this->seen[0]['nav_menu_item'] );
+	}
+
+	public function test_a_different_menu_is_asked_separately(): void {
+		$this->lookup( [ 'nav_menu_item' => 101, 'nav_menu' => 75 ] );
+		$this->lookup( [ 'nav_menu_item' => 102, 'nav_menu' => 76 ] );
+
+		$this->assertCount( 2, $this->seen );
+	}
+
+	public function test_one_options_page_is_asked_once(): void {
+		$this->lookup( [ 'options_page' => 'site-settings' ] );
+		$this->lookup( [ 'options_page' => 'site-settings' ] );
+
+		$this->assertCount( 1, $this->seen );
+	}
+
+	public function test_key_order_does_not_split_the_memo(): void {
+		$this->lookup( [ 'nav_menu' => 75, 'nav_menu_item' => 101 ] );
+		$this->lookup( [ 'nav_menu_item' => 102, 'nav_menu' => 75 ] );
+
+		$this->assertCount( 1, $this->seen );
+	}
+
+	public function test_flush_forces_a_fresh_read(): void {
+		$this->lookup( [ 'options_page' => 'site-settings' ] );
+		$this->lookup( [ 'options_page' => 'site-settings' ] );
+		Helpers::flushFieldGroups();
+		$this->lookup( [ 'options_page' => 'site-settings' ] );
+		$this->lookup( [ 'options_page' => 'site-settings' ] );
+
+		$this->assertCount( 2, $this->seen );
+	}
+
+	public function test_a_non_array_answer_is_normalized_to_empty(): void {
+		Functions\when( 'acf_get_field_groups' )->justReturn( false );
+
+		$this->assertSame( [], $this->lookup( [ 'options_page' => 'x' ] ) );
+	}
+}

--- a/tests/Unit/Helpers/NavMenuItemSharingSafetyTest.php
+++ b/tests/Unit/Helpers/NavMenuItemSharingSafetyTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Helpers;
+
+use Brain\Monkey\Functions;
+use Parisek\TimberKit\Helpers;
+use Tests\Fixtures\Acf\StubCoreLocationType;
+use Tests\Fixtures\StubCustomLocationType;
+use Tests\Unit\HelpersTestCase;
+
+/**
+ * Covers the check that decides, without configuration, whether every item of
+ * one menu may share a field-group answer.
+ *
+ * Sharing is safe exactly while ACF's own location types are the only things
+ * that see the screen: theirs read `nav_menu_item` only through `isset()`.
+ * `acf_register_location_type()` is public API, so anyone can add a matcher
+ * that reads the id — and the check is what notices.
+ */
+class NavMenuItemSharingSafetyTest extends HelpersTestCase {
+
+	/** @var array<int, array<string, mixed>> */
+	private array $seen = [];
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->seen = [];
+
+		if ( ! defined( 'ACF_PATH' ) ) {
+			define( 'ACF_PATH', realpath( __DIR__ . '/../../Fixtures/Acf' ) . '/' );
+		}
+
+		Functions\when( 'apply_filters' )->alias(
+			static function ( $filter, $default = null, ...$args ) {
+				unset( $filter, $args );
+				return $default;
+			}
+		);
+		Functions\when( 'get_locale' )->justReturn( 'cs_CZ' );
+		Functions\when( 'get_current_blog_id' )->justReturn( 1 );
+		Functions\when( 'wp_json_encode' )->alias(
+			static fn ( $value ) => json_encode( $value )
+		);
+		Functions\when( 'acf_get_field_groups' )->alias(
+			function ( $screen ) {
+				$this->seen[] = $screen;
+				return [ [ 'key' => 'group_1' ] ];
+			}
+		);
+	}
+
+	/**
+	 * @param array<int, object> $types
+	 */
+	private function withLocationTypes( array $types ): void {
+		Functions\when( 'acf_get_location_types' )->justReturn( $types );
+		Helpers::flushFieldGroups();
+	}
+
+	/**
+	 * @param array<string, mixed> $screen
+	 */
+	private function lookup( array $screen ): void {
+		( new \ReflectionMethod( Helpers::class, 'fieldGroupsForScreen' ) )->invoke( null, $screen );
+	}
+
+	public function test_vanilla_acf_shares_by_default(): void {
+		$this->withLocationTypes( [ new StubCoreLocationType(), new StubCoreLocationType() ] );
+
+		$this->lookup( [ 'nav_menu_item' => 101, 'nav_menu' => 75 ] );
+		$this->lookup( [ 'nav_menu_item' => 102, 'nav_menu' => 75 ] );
+		$this->lookup( [ 'nav_menu_item' => 103, 'nav_menu' => 75 ] );
+
+		$this->assertCount( 1, $this->seen, 'Nothing to configure on a site with only ACF location types.' );
+	}
+
+	public function test_one_custom_location_type_stops_sharing(): void {
+		// It only takes one: that matcher receives the screen for every rule.
+		$this->withLocationTypes( [ new StubCoreLocationType(), new StubCustomLocationType() ] );
+
+		$this->lookup( [ 'nav_menu_item' => 101, 'nav_menu' => 75 ] );
+		$this->lookup( [ 'nav_menu_item' => 102, 'nav_menu' => 75 ] );
+
+		$this->assertCount( 2, $this->seen );
+	}
+
+	public function test_an_empty_registry_stops_sharing(): void {
+		// Nothing to verify is not the same as verified.
+		$this->withLocationTypes( [] );
+
+		$this->lookup( [ 'nav_menu_item' => 101, 'nav_menu' => 75 ] );
+		$this->lookup( [ 'nav_menu_item' => 102, 'nav_menu' => 75 ] );
+
+		$this->assertCount( 2, $this->seen );
+	}
+
+	public function test_the_filter_can_force_sharing_off(): void {
+		$this->withLocationTypes( [ new StubCoreLocationType() ] );
+		Functions\when( 'apply_filters' )->alias(
+			static function ( $filter, $default = null, ...$args ) {
+				unset( $args );
+				return 'timber_kit_share_nav_menu_item_field_groups' === $filter ? false : $default;
+			}
+		);
+		Helpers::flushFieldGroups();
+
+		$this->lookup( [ 'nav_menu_item' => 101, 'nav_menu' => 75 ] );
+		$this->lookup( [ 'nav_menu_item' => 102, 'nav_menu' => 75 ] );
+
+		$this->assertCount( 2, $this->seen );
+	}
+
+	public function test_the_filter_can_force_sharing_on(): void {
+		$this->withLocationTypes( [ new StubCustomLocationType() ] );
+		Functions\when( 'apply_filters' )->alias(
+			static function ( $filter, $default = null, ...$args ) {
+				unset( $args );
+				return 'timber_kit_share_nav_menu_item_field_groups' === $filter ? true : $default;
+			}
+		);
+		Helpers::flushFieldGroups();
+
+		$this->lookup( [ 'nav_menu_item' => 101, 'nav_menu' => 75 ] );
+		$this->lookup( [ 'nav_menu_item' => 102, 'nav_menu' => 75 ] );
+
+		$this->assertCount( 1, $this->seen );
+	}
+}

--- a/tests/Unit/HelpersTestCase.php
+++ b/tests/Unit/HelpersTestCase.php
@@ -6,6 +6,7 @@ namespace Tests\Unit;
 
 use Brain\Monkey;
 use Brain\Monkey\Functions;
+use Parisek\TimberKit\Helpers;
 use PHPUnit\Framework\TestCase;
 
 abstract class HelpersTestCase extends TestCase {
@@ -13,11 +14,23 @@ abstract class HelpersTestCase extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		Monkey\setUp();
+		// Field-group answers are memoized on a static, which outlives the
+		// test that filled it.
+		Helpers::flushFieldGroups();
 		// get_post_type is called by Helpers::isNavMenuItemPostId() on the
 		// function_exists() branch.  Default to 'post' so tests that don't
 		// need nav_menu_item dispatch don't have to mock it individually.
 		// Tests that need a specific return value override this in their body.
 		Functions\when( 'get_post_type' )->justReturn( 'post' );
+
+		// The field-group memo keys on blog + language, so any test that reaches
+		// formatFields() calls these. Defaults here rather than in each test,
+		// matching get_post_type above; tests that care override them.
+		Functions\when( 'get_current_blog_id' )->justReturn( 1 );
+		Functions\when( 'get_locale' )->justReturn( 'en_US' );
+		Functions\when( 'wp_json_encode' )->alias(
+			static fn ( $value ) => json_encode( $value )
+		);
 	}
 
 	protected function tearDown(): void {

--- a/tests/Unit/Resizer/BackendFormatsMemoTest.php
+++ b/tests/Unit/Resizer/BackendFormatsMemoTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\Resizer;
 use Brain\Monkey\Functions;
 use Parisek\TimberKit\Resizer;
 use Tests\Fixtures\CountingResizer;
+use Tests\Fixtures\JpegOnlyResizer;
 use Tests\Unit\ResizerTestCase;
 
 /**
@@ -69,5 +70,22 @@ class BackendFormatsMemoTest extends ResizerTestCase {
 		( new CountingResizer() )->canDecode( 'image/jpeg' );
 
 		$this->assertSame( 2, CountingResizer::$probes );
+	}
+
+	public function test_subclasses_do_not_answer_each_other(): void {
+		// The memo is keyed by concrete class. A subclass that stubs the probe
+		// must not fill the entry an ordinary Resizer or a sibling reads, or the
+		// first stub on a page would decide what every later one can decode.
+		$this->passThroughFilters();
+		CountingResizer::$probes = 0;
+		JpegOnlyResizer::$probes = 0;
+
+		$counting = new CountingResizer();
+		$jpegOnly = new JpegOnlyResizer();
+
+		$this->assertTrue( $counting->canDecode( 'image/png' ) );
+		$this->assertFalse( $jpegOnly->canDecode( 'image/png' ), 'PNG is not in the second stub.' );
+		$this->assertSame( 1, CountingResizer::$probes );
+		$this->assertSame( 1, JpegOnlyResizer::$probes );
 	}
 }

--- a/tests/Unit/Resizer/BackendFormatsMemoTest.php
+++ b/tests/Unit/Resizer/BackendFormatsMemoTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Resizer;
+
+use Brain\Monkey\Functions;
+use Parisek\TimberKit\Resizer;
+use Tests\Fixtures\CountingResizer;
+use Tests\Unit\ResizerTestCase;
+
+/**
+ * Covers the process-wide memo on the image backend's format list.
+ *
+ * The list is a property of the ImageMagick or GD build, so it cannot change
+ * while the process runs. It used to be probed once per Resizer instance, and
+ * one `|resizer` call builds one instance — 320 probes on a front page that
+ * resizes 320 images.
+ */
+class BackendFormatsMemoTest extends ResizerTestCase {
+
+	private function passThroughFilters(): void {
+		Functions\when( 'apply_filters' )->alias(
+			function ( $filter, $default, ...$args ) {
+				unset( $filter, $args );
+				return $default;
+			}
+		);
+	}
+
+	public function test_probe_runs_once_across_instances(): void {
+		$this->passThroughFilters();
+		CountingResizer::$probes = 0;
+
+		( new CountingResizer() )->canDecode( 'image/jpeg' );
+		( new CountingResizer() )->canDecode( 'image/jpeg' );
+		( new CountingResizer() )->canDecode( 'image/png' );
+
+		$this->assertSame(
+			1,
+			CountingResizer::$probes,
+			'Three instances must share one backend probe.'
+		);
+	}
+
+	public function test_memo_does_not_change_the_answer(): void {
+		$this->passThroughFilters();
+		CountingResizer::$probes = 0;
+
+		$first  = new CountingResizer();
+		$second = new CountingResizer();
+
+		$this->assertTrue( $first->canDecode( 'image/jpeg' ) );
+		$this->assertTrue( $second->canDecode( 'image/jpeg' ) );
+		$this->assertFalse( $second->canDecode( 'image/heic' ) );
+	}
+
+	public function test_flush_forces_a_fresh_probe(): void {
+		$this->passThroughFilters();
+		CountingResizer::$probes = 0;
+
+		// Two probes either side of the flush, so the count separates a working
+		// memo (2) from no memo at all (4) — one call each side would be 2 in
+		// both worlds and prove nothing.
+		( new CountingResizer() )->canDecode( 'image/jpeg' );
+		( new CountingResizer() )->canDecode( 'image/jpeg' );
+		Resizer::flushBackendFormats();
+		( new CountingResizer() )->canDecode( 'image/jpeg' );
+		( new CountingResizer() )->canDecode( 'image/jpeg' );
+
+		$this->assertSame( 2, CountingResizer::$probes );
+	}
+}

--- a/tests/Unit/ResizerTestCase.php
+++ b/tests/Unit/ResizerTestCase.php
@@ -14,6 +14,9 @@ abstract class ResizerTestCase extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		Monkey\setUp();
+		// The backend format list is memoized on a static, which outlives the
+		// test that filled it.
+		Resizer::flushBackendFormats();
 	}
 
 	protected function tearDown(): void {

--- a/tests/Unit/StarterBase/AcfHookRegistrationTest.php
+++ b/tests/Unit/StarterBase/AcfHookRegistrationTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\StarterBase;
+
+use Brain\Monkey\Functions;
+use Parisek\TimberKit\Helpers;
+use Tests\Unit\StarterBaseTestCase;
+
+/**
+ * Covers the ACF hook wiring that keeps the field-group memo honest.
+ *
+ * `Helpers::fieldGroupsForScreen()` memoizes per screen for the whole process.
+ * This hook is the only thing that invalidates it automatically, so an admin
+ * save is not answered from the list read before it. Deleting the line, or
+ * pointing it at a different hook, otherwise changes no test.
+ */
+class AcfHookRegistrationTest extends StarterBaseTestCase {
+
+	public function test_field_group_flush_is_wired_to_acf_update_field_group(): void {
+		$base = $this->createStarterBase();
+
+		$actions = [];
+		Functions\when( 'add_action' )->alias(
+			function ( string $tag, $callback = null ) use ( &$actions ) {
+				$actions[ $tag ] = $callback;
+				return true;
+			}
+		);
+		Functions\when( 'add_filter' )->justReturn( true );
+
+		( new \ReflectionMethod( $base, 'registerAcfHooks' ) )->invoke( $base );
+
+		$this->assertArrayHasKey(
+			'acf/update_field_group',
+			$actions,
+			'The field-group memo has no other automatic invalidation.'
+		);
+		$this->assertSame(
+			[ Helpers::class, 'flushFieldGroups' ],
+			$actions['acf/update_field_group']
+		);
+	}
+}

--- a/tests/Unit/StarterBase/AcfHookRegistrationTest.php
+++ b/tests/Unit/StarterBase/AcfHookRegistrationTest.php
@@ -32,14 +32,17 @@ class AcfHookRegistrationTest extends StarterBaseTestCase {
 
 		( new \ReflectionMethod( $base, 'registerAcfHooks' ) )->invoke( $base );
 
-		$this->assertArrayHasKey(
-			'acf/update_field_group',
-			$actions,
-			'The field-group memo has no other automatic invalidation.'
-		);
-		$this->assertSame(
-			[ Helpers::class, 'flushFieldGroups' ],
-			$actions['acf/update_field_group']
-		);
+		// ACF fires all four dynamically as "acf/{$verb}_{$hook_name}". Missing
+		// any one of them leaves the memo holding a list the admin has already
+		// changed.
+		foreach ( [ 'update', 'delete', 'trash', 'untrash' ] as $verb ) {
+			$hook = 'acf/' . $verb . '_field_group';
+			$this->assertArrayHasKey(
+				$hook,
+				$actions,
+				'The field-group memo has no other automatic invalidation.'
+			);
+			$this->assertSame( [ Helpers::class, 'flushFieldGroups' ], $actions[ $hook ] );
+		}
 	}
 }


### PR DESCRIPTION
## From which project

`sloneek` (redesign branch), profiling an uncached front-page render locally with xhprof. Companion to #147 and #131, which own the two larger items in the same profile; this is the self-contained part.

## The finding

Two capability probes ran once per object instead of once per request. **Both already had a memo** — stored on the instance the caller throws away, so neither ever answered anything. `Resizer`'s docblock said `Memoized per request`, which is the sentence that kept anyone from checking.

`acf_get_field_groups()` is the more interesting one: **ACF caches nothing there.** Repeating the *identical* screen costs the same 8-10 ms as a new one, because every call walks each registered field group and evaluates its location rules. `formatFields()` asks once per nav menu item, so a 90-item menu paid for 90 answers.

## Measured

By patching the site and re-measuring, not by scaling the profile. Fastest of twelve warm requests, **with no configuration of any kind**:

| | Imagick probes | `acf_get_field_groups()` | page |
|---|---:|---:|---:|
| before | 320 | 109 | 671 ms |
| after | 1 | 11 | **561 ms** |

**110 ms, 16 %**, reproduced across three rounds at 101-112 ms. The saving scales with images and menu items rather than with the page.

Output is byte-identical once the random `uniqueId()` values are normalized. That check needed a control pair of runs of the *unchanged* code first, because the page is not deterministic without one — the first comparison showed differences that had nothing to do with this change.

## How the nav-menu sharing stays correct

Sharing one field-group answer across every item of a menu is where most of the saving is. It is safe while ACF's own location types are the only things that see the screen: `ACF_Location_Nav_Menu_Item::match()` reads the item id only to confirm the key is set, then matches on `nav_menu`.

It is **not** safe in general. `acf_register_location_type()` is public API, ACF hands the whole screen to every registered type, and a *"show this group on this one menu item"* rule — a mega-menu wanting extra fields on one item — is a legitimate thing to write. Sharing would then serve the first item's groups to every item, with no error and no log.

So the kit checks rather than guesses. Before sharing, **every registered location type must resolve to a class file inside `ACF_PATH`**. A site that registers its own gets per-item lookups back automatically, with nothing to configure and no notice to read. Anything unverifiable — no `ACF_PATH`, an empty registry, a class with no file — counts as unsafe. The check costs 0.003 ms and is memoized per request.

It reads the location-type registry rather than scanning field-group rules, because `acf_get_field_groups()` with no arguments costs 27 ms on a cold store — a fifth of the saving, spent protecting it.

`timber_kit_share_nav_menu_item_field_groups` overrides the verdict either way: force it off for an `acf/location/rule_match` callback that reads the item id (the one path the check cannot see; ACFML's reads `post_id`, `lang`, `page_parent` and is fine), or force it on for a custom type known not to read it.

**This whole mechanism exists because of the Codex review below.** The first version normalized unconditionally.

## Not done here, deliberately

- **Neither memo moved into the object cache.** They remove repeated work inside one render, not the first call of each request. Persisting them is a separate decision whose cost is invalidation, not implementation: ACF field groups load from theme JSON files and no hook fires when a deploy changes one. A persistent cache would also still want a static in front of it, because `wp_cache_get()` is not free. The place where that trade pays off is #147, where one filter costs 751 ms.
- **No flush on late `acf_add_local_field_group()`** — ACF exposes no action for it. The README states the limit rather than pretending to cover it.
- **`decodableFormats()` keeps its per-instance memo**, so `timber_kit_resizer_allowed_types` still runs per instance. Only the raw backend capability is shared, and that is the filter's input, not its output.

## Type

`feat`, not `perf`, because public methods and a filter are new and RELEASING.md maps a new public symbol to MINOR. The intent is performance.

## One thing worth reading

Ten unrelated resizer tests failed at first, and the cause was **the new test file existing**, not the memo. A `class X extends Resizer` at the top level of a `*Test.php` file loads `Resizer` while PHPUnit is still collecting files — before Patchwork instruments it — and `Patchwork\redefine( 'file_exists', … )` then stops reaching the copy those tests exercise. The stub subclasses now live in `tests/Fixtures/`, autoloaded lazily. Bisecting was the only way to find it; the failure pointed squarely at the production change.