### PR TITLE
perf(helpers): memoize acf_get_fields() per group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+
+- `acf_get_fields()` is memoized per field group for the request. ACF caches
+  nothing here either, and the answer is the same for every screen a group
+  matches — so `getFieldObjectsByScreen()` asked it **348 times for 21 distinct
+  answers** on the sloneek front page, once per group per screen.
+
+  Measured directly on the work removed: 26-38 ms falls to 5-8 ms. End to end
+  the page moved 16-34 ms across two rounds, which is the same saving seen
+  through a noisier instrument. Rendered HTML is byte-identical, checked
+  against a control pair of runs of the unchanged code.
+
+  Field definitions are configuration, not content: they come from the theme's
+  JSON, they do not depend on the page being rendered, and nothing a visitor
+  does changes them. **So this needs no invalidation beyond the request it
+  lives in** — unlike a value, which does. The key carries the blog id and the
+  language because groups are registered per site and ACFML translates a
+  field's label, instructions and choices; a group with neither a key nor an id
+  has no identity to memoize on and is asked every time rather than sharing an
+  entry with the next anonymous group.
+
+  `Helpers::flushFieldGroups()` drops it alongside the screen memo.
+
 ### Added
 
 - `Resizer::flushBackendFormats()` and `Helpers::flushFieldGroups()` drop the

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1238,6 +1238,23 @@ class Helpers {
 	private static array $field_groups_memo = [];
 
 	/**
+	 * Memoized `acf_get_fields()` answers, keyed by field group.
+	 *
+	 * ACF does not cache this either, and the answer is the same for every
+	 * screen a group matches. `getFieldObjectsByScreen()` asks once per group
+	 * **per screen**, so a 90-item menu asked 348 times for what turned out to
+	 * be 21 distinct answers.
+	 *
+	 * Field definitions are configuration, not content: they come from the
+	 * theme's JSON, they do not depend on the page being rendered, and nothing
+	 * a visitor does changes them. That is why this needs no invalidation
+	 * beyond the request it lives in.
+	 *
+	 * @var array<string, array<int, mixed>>
+	 */
+	private static array $group_fields_memo = [];
+
+	/**
 	 * Memoized answer of the `timber_kit_share_nav_menu_item_field_groups` filter.
 	 *
 	 * @var bool|null
@@ -1255,9 +1272,69 @@ class Helpers {
 	 * @return void
 	 */
 	public static function flushFieldGroups(): void {
-		self::$field_groups_memo = [];
-		self::$share_nav_menu_item_groups = null;
+		self::$field_groups_memo           = [];
+		self::$group_fields_memo           = [];
+		self::$share_nav_menu_item_groups  = null;
 	}
+
+	/**
+	 * `acf_get_fields()` behind a per-group memo.
+	 *
+	 * @param array<string, mixed>|mixed $group Field group, as ACF returned it.
+	 * @return array<int, mixed> The group's fields; empty when it has none.
+	 */
+	private static function fieldsForGroup( $group ): array {
+		$key = self::groupFieldsMemoKey( $group );
+
+		if ( null === $key ) {
+			$fields = acf_get_fields( $group );
+
+			return is_array( $fields ) ? $fields : [];
+		}
+
+		if ( ! array_key_exists( $key, self::$group_fields_memo ) ) {
+			$fields = acf_get_fields( $group );
+			self::$group_fields_memo[ $key ] = is_array( $fields ) ? $fields : [];
+		}
+
+		return self::$group_fields_memo[ $key ];
+	}
+
+	/**
+	 * Cache key for one field group's fields.
+	 *
+	 * A group without a key or an id has no identity to memoize on, and gets
+	 * asked every time rather than sharing an entry with the next such group.
+	 *
+	 * Carries the blog id and the language for the same reasons the screen memo
+	 * does: groups are registered per site, and ACFML translates a field's
+	 * label, instructions and choices.
+	 *
+	 * @param array<string, mixed>|mixed $group Field group.
+	 * @return string|null
+	 */
+	private static function groupFieldsMemoKey( $group ): ?string {
+		if ( ! is_array( $group ) ) {
+			return null;
+		}
+
+		$identity = '';
+		foreach ( [ 'key', 'ID', 'id' ] as $candidate ) {
+			if ( isset( $group[ $candidate ] ) && is_scalar( $group[ $candidate ] ) ) {
+				$identity = (string) $group[ $candidate ];
+				break;
+			}
+		}
+
+		if ( '' === $identity ) {
+			return null;
+		}
+
+		$blog_id = function_exists( 'get_current_blog_id' ) ? (int) get_current_blog_id() : 0;
+
+		return $blog_id . '|' . self::getLanguage() . '|' . $identity;
+	}
+
 
 	/**
 	 * `acf_get_field_groups()` behind a per-screen memo.
@@ -1441,8 +1518,8 @@ class Helpers {
 
 		$fields = [];
 		foreach ( $groups as $group ) {
-			$group_fields = acf_get_fields( $group );
-			if ( ! is_array( $group_fields ) ) {
+			$group_fields = self::fieldsForGroup( $group );
+			if ( [] === $group_fields ) {
 				continue;
 			}
 			foreach ( $group_fields as $field ) {

--- a/tests/Unit/Helpers/GroupFieldsMemoTest.php
+++ b/tests/Unit/Helpers/GroupFieldsMemoTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Helpers;
+
+use Brain\Monkey\Functions;
+use Parisek\TimberKit\Helpers;
+use Tests\Unit\HelpersTestCase;
+
+/**
+ * Covers the per-group memo in front of `acf_get_fields()`.
+ *
+ * ACF caches nothing here, and the answer is the same for every screen a group
+ * matches. `getFieldObjectsByScreen()` asks once per group per screen, so a
+ * 90-item menu asked 348 times for 21 distinct answers.
+ *
+ * Field definitions are configuration rather than content — theme JSON, not
+ * anything a visitor changes — which is why this memo needs no invalidation
+ * beyond the request it lives in.
+ */
+class GroupFieldsMemoTest extends HelpersTestCase {
+
+	/** @var array<int, mixed> */
+	private array $seen = [];
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->seen = [];
+
+		Functions\when( 'apply_filters' )->alias(
+			static function ( $filter, $default = null, ...$args ) {
+				unset( $filter, $args );
+				return $default;
+			}
+		);
+		Functions\when( 'acf_get_fields' )->alias(
+			function ( $group ) {
+				$this->seen[] = $group;
+				return [ [ 'key' => 'field_1', 'name' => 'badge', 'type' => 'text' ] ];
+			}
+		);
+	}
+
+	/**
+	 * @param array<string, mixed>|mixed $group
+	 * @return array<int, mixed>
+	 */
+	private function lookup( $group ): array {
+		$method = new \ReflectionMethod( Helpers::class, 'fieldsForGroup' );
+
+		return $method->invoke( null, $group );
+	}
+
+	public function test_one_group_is_asked_once(): void {
+		$group = [ 'key' => 'group_menu' ];
+
+		$this->lookup( $group );
+		$this->lookup( $group );
+		$this->lookup( $group );
+
+		$this->assertCount( 1, $this->seen, 'Ninety menu items share one set of field definitions.' );
+	}
+
+	public function test_the_answer_is_the_same_one(): void {
+		$first  = $this->lookup( [ 'key' => 'group_menu' ] );
+		$second = $this->lookup( [ 'key' => 'group_menu' ] );
+
+		$this->assertSame( $first, $second );
+		$this->assertSame( 'badge', $second[0]['name'] );
+	}
+
+	public function test_another_group_is_asked_separately(): void {
+		$this->lookup( [ 'key' => 'group_menu' ] );
+		$this->lookup( [ 'key' => 'group_options' ] );
+
+		$this->assertCount( 2, $this->seen );
+	}
+
+	public function test_a_group_identified_by_id_is_memoized_too(): void {
+		$this->lookup( [ 'ID' => 42 ] );
+		$this->lookup( [ 'ID' => 42 ] );
+
+		$this->assertCount( 1, $this->seen );
+	}
+
+	public function test_a_group_with_no_identity_is_asked_every_time(): void {
+		// Sharing one entry between two anonymous groups would hand the second
+		// the first one's fields.
+		$this->lookup( [ 'title' => 'Untitled' ] );
+		$this->lookup( [ 'title' => 'Untitled' ] );
+
+		$this->assertCount( 2, $this->seen );
+	}
+
+	public function test_another_language_is_asked_separately(): void {
+		// ACFML translates a field's label, instructions and choices.
+		$this->lookup( [ 'key' => 'group_menu' ] );
+		Functions\when( 'get_locale' )->justReturn( 'it_IT' );
+		$this->lookup( [ 'key' => 'group_menu' ] );
+
+		$this->assertCount( 2, $this->seen );
+	}
+
+	public function test_another_blog_is_asked_separately(): void {
+		$this->lookup( [ 'key' => 'group_menu' ] );
+		Functions\when( 'get_current_blog_id' )->justReturn( 2 );
+		$this->lookup( [ 'key' => 'group_menu' ] );
+
+		$this->assertCount( 2, $this->seen );
+	}
+
+	public function test_a_non_array_answer_is_normalized_to_empty(): void {
+		Functions\when( 'acf_get_fields' )->justReturn( false );
+
+		$this->assertSame( [], $this->lookup( [ 'key' => 'group_menu' ] ) );
+	}
+
+	public function test_flush_forces_a_fresh_read(): void {
+		$this->lookup( [ 'key' => 'group_menu' ] );
+		$this->lookup( [ 'key' => 'group_menu' ] );
+		Helpers::flushFieldGroups();
+		$this->lookup( [ 'key' => 'group_menu' ] );
+		$this->lookup( [ 'key' => 'group_menu' ] );
+
+		$this->assertCount( 2, $this->seen );
+	}
+}


### PR DESCRIPTION
## From which project

`sloneek`, from the profiling that produced #154. **Stacked on #154** — the base is `perf/memoize-capability-probes`, so this diff shows only the new change; GitHub retargets to `main` when #154 merges.

## The finding

`getFieldObjectsByScreen()` asks ACF for a group's fields once per group **per screen**. A 90-item menu resolves the same group ninety times.

| | calls | time |
|---|---:|---:|
| before | 348 | 26-38 ms |
| after | **21** | **5-8 ms** |

That is measured on the work removed. End to end the page moved 16-34 ms across two rounds — the same saving through a noisier instrument, and the machine drifted between them, so the component figure is the one to trust.

Rendered HTML is byte-identical, checked against a control pair of runs of the unchanged code because the page is not deterministic without one.

## Why this one needs no invalidation

**Field definitions are configuration, not content.** They come from the theme's JSON, they do not depend on the page being rendered, and nothing a visitor does changes them. The memo lives for the request, and there is nothing for a hook to notice.

A field *value* is the opposite, which is exactly why #155 is parked: caching one layer up meant caching formatted output, and formatting runs shortcodes and arbitrary filters that can read the current page. The two look like the same optimisation and are not.

The key carries the blog id and the language for the same reasons the screen memo's does — groups are registered per site, ACFML translates a field's label, instructions and choices. A group carrying neither a key nor an id has no identity to memoize on and is asked every time, rather than sharing an entry with the next anonymous group.

## What was tried and did not work

Recorded so nobody repeats it. All measured on the front page, all rejected:

| Idea | Result |
|---|---|
| Prime the post-meta cache for all menu items | Already warm. 0 ms, query count unchanged. |
| Skip `get_field()` where the item has no stored meta | 206 of 272 calls skipped, time unchanged — ACF already short-circuits. |
| Prime the term-relationship cache | Already warm, and added 5 queries. |
| Cache the formatted field payload | #155, parked: formatting is not a function of the stored value. |

What remains unclaimed on this path is `get_field()` for the 66 menu-item fields that hold a value (37-68 ms) and `wp_get_post_terms()` (9-16 ms, removable only by threading the known menu id through `formatFields()`).

## Tests

Nine, each verified to fail without the memo where it is the mechanism under test: one group asked once, identity by `key` and by `ID`, an anonymous group asked every time, separation by language and by blog, a non-array answer normalized, and the flush.