### PR TITLE
perf(wpml): opt-in guard for ACFML's front-end field-definition translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- `StarterBase::$acfml_skip_frontend_field_translation` — opt-in, default off.
+  Skips ACFML's translation of ACF field **definitions** (labels, instructions,
+  placeholders, prepend/append, choices, message) on plain front-end views.
+
+  `ACFML\Strings\FieldHooks` implements `IWPML_Frontend_Action`, so it registers
+  on the front end with no `is_admin()` guard and hooks `acf/load_field`. Every
+  field then reaches an unmemoized linear scan over a static array, run through
+  WPML's functional library with a closure allocated per element. On a page view
+  none of those strings is rendered.
+
+  Measured on a site with 117 field groups and 972 top-level fields: loading
+  them costs 1.09 s with the translation and 0.29 s without. A PHP-FPM slowlog
+  over 3973 slow requests put 71 % of deepest-frame samples inside `wpml/fp` and
+  `wpml/collect`. Only the field level is expensive — the group level measured
+  1.04 s against 1.11 s.
+
+  **Off by default is a refusal, not timidity.** Switching it on is wrong for a
+  site that renders field definitions to visitors: a theme calling `acf_form()`,
+  or a template printing a `select`/`radio` choice *label* rather than its
+  value. Neither is detectable from the kit, so the consuming site asserts it.
+
+  Four contexts keep the translation, and naming all four is load-bearing:
+  admin, AJAX, REST and WP-CLI. Gutenberg loads field groups over REST and ACF
+  talks to admin-ajax from inside it, so an `is_admin()`-only guard switches the
+  translation off in the editor — where the labels are the entire point.
+
+  Retiring it is a one-line default flip once ACFML memoizes its lookup. Not
+  fixed in acfml 3.0-b.1: every file on the hot path is byte-identical to 2.2.4,
+  and so is the bundled `wpml/fp`.
+
+
+### Added
+
 - `CacheSignature` — the shared part of every cross-request cache key: site,
   language, the current user's roles, and a content version from
   `wp_cache_get_last_changed()` over `posts` and `terms`. WordPress bumps those

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
-- `StarterBase::$acfml_skip_frontend_field_translation` — opt-in, default off.
+- `StarterBase::$acfml_skip_frontend_field_translation` — **on by default**.
   Skips ACFML's translation of ACF field **definitions** (labels, instructions,
   placeholders, prepend/append, choices, message) on plain front-end views.
 
@@ -24,10 +24,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   `wpml/collect`. Only the field level is expensive — the group level measured
   1.04 s against 1.11 s.
 
-  **Off by default is a refusal, not timidity.** Switching it on is wrong for a
-  site that renders field definitions to visitors: a theme calling `acf_form()`,
-  or a template printing a `select`/`radio` choice *label* rather than its
-  value. Neither is detectable from the kit, so the consuming site asserts it.
+  **On by default**, because two shapes make it wrong and only one of them is
+  invisible. A theme calling `acf_form()` puts labels, instructions and
+  placeholders in front of a visitor — and that shape **detects itself**:
+  `acf_form_head()` reaches `ACF_Assets::add_actions()`, which records itself,
+  so the guard steps aside on any front-end request that has set a form up. It
+  is read with `acf_raw_setting()` and never with `acf_has_done()`, which writes
+  the flag it reads and would make ACF skip registering the form's own assets.
+
+  A template printing a `select`/`radio`/`checkbox` choice *label* rather than
+  its value is not detectable from here. That is what the property is for. The
+  failure if a site needs it and does not set it is one label rendered in the
+  source language — quiet, and worth checking rather than assuming when moving
+  a large existing site onto this version.
 
   Four contexts keep the translation, and naming all four is load-bearing:
   admin, AJAX, REST and WP-CLI. Gutenberg loads field groups over REST and ACF

--- a/README.md
+++ b/README.md
@@ -1007,6 +1007,7 @@ For an admin label without a dedicated setup hook (e.g. an options-page `page_ti
 | `$site_icon_tags` | bool | `false` | Emit the favicon set found in `static/images/touch/` instead of WordPress's four legacy site-icon tags. Opt-in — it changes rendered `<head>` output. See [Site icon tags](#site-icon-tags) |
 | `$context_privacy_policy` | bool | `false` | Opt-in: populate the site's privacy-policy URL (`get_privacy_policy_url()`) into the Timber context under `$privacy_policy_context_key`. Off by default — the key typically drives a cookie-consent partial, which must not appear on projects that ship without one |
 | `$privacy_policy_context_key` | string | `'ccnstL'` | Context key for the privacy-policy URL. The default is deliberately non-semantic so cookie-consent markup keyed off it stays invisible to ad-block heuristics |
+| `$acfml_skip_frontend_field_translation` | bool | `true` | Skip ACFML's translation of ACF field **definitions** (labels, instructions, placeholders, choices) on plain front-end views. Admin, REST, AJAX and WP-CLI keep it, and so does any front-end request where `acf_form()` is in play. Set to `false` on a site whose templates print a `select`/`radio` choice **label** rather than its value. See [ACFML field-definition translation](#acfml-field-definition-translation) |
 
 ### Security & Cleanup
 
@@ -1410,6 +1411,28 @@ class Base extends \Parisek\TimberKit\StarterBase {
 `$this->theme_name` in both `_x()` slots is intentional — it doubles as the translation context and the textdomain, so a single project identifier scopes everything. Substitute the source strings with the project's locale (Czech, German, …) and the WPML / Polylang stack picks the right translation at render time.
 
 Projects that don't need translated labels (single-locale English sites) can skip the override entirely — the English defaults declared on `$breadcrumb_labels` apply unchanged.
+
+### ACFML field-definition translation
+
+ACFML translates ACF field **definitions** — labels, instructions, placeholders, prepend/append, choices, message — on every request that loads a field group. `ACFML\Strings\FieldHooks` implements `IWPML_Frontend_Action`, so it registers on the front end with no `is_admin()` guard and hooks `acf/load_field`. Every field then reaches an unmemoized linear scan over a static array, run through WPML's functional library with a closure allocated per element.
+
+On a page view none of those strings is rendered, so the whole walk is discarded.
+
+Measured on a site with 117 field groups and 972 top-level fields: **479 ms with the translation, 370 ms without**, on an otherwise identical stack with a warm Redis object cache. A PHP-FPM slowlog over 3973 slow requests put 71 % of deepest-frame samples inside `wpml/fp` and `wpml/collect`. Only the field level costs anything — the group level measured 1.04 s against 1.11 s.
+
+```php
+// Base.php — a site whose templates print a choice LABEL rather than its value
+protected bool $acfml_skip_frontend_field_translation = false;
+```
+
+**On by default**, because two shapes make it wrong and only one of them is invisible:
+
+- A theme calling `acf_form()` puts labels, instructions and placeholders in front of a visitor. **This detects itself.** `acf_form_head()` reaches `ACF_Assets::add_actions()`, which records itself in ACF's settings, so the guard steps aside on any front-end request that has set a form up — read with `acf_raw_setting()`, never with `acf_has_done()`, which writes the flag it reads.
+- A template printing a `select`/`radio`/`checkbox` choice **label** rather than its value cannot be detected from the kit. That is what the property is for. The failure if a site needs it and does not set it is one label rendered in the source language — quiet, and easy to mistake for an untranslated string, so it is worth checking rather than assuming when moving a large existing site onto this version.
+
+Four contexts keep the translation and naming all four is load-bearing: **admin, AJAX, REST and WP-CLI**. Gutenberg loads field groups over REST and ACF talks to admin-ajax from inside it, so an `is_admin()`-only guard would switch the translation off in the editor, where the labels are the entire point.
+
+Retiring this is a one-line default flip once ACFML memoizes its lookup. Not fixed in acfml 3.0-b.1: every file on the hot path is byte-identical to 2.2.4, and so is the bundled `wpml/fp`.
 
 ### Performance
 

--- a/phpstan-stubs/acf.stub
+++ b/phpstan-stubs/acf.stub
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Corrections to `php-stubs/acf-pro-stubs`, which reproduces ACF's own
+ * docblocks faithfully — including where they are wrong about the code beneath
+ * them.
+ */
+
+/**
+ * `acf_raw_setting()` is documented `@return void` in ACF and in the generated
+ * stubs. Its body is `return acf()->get_setting( $name );`, so it returns the
+ * setting — which is the entire reason to call it.
+ *
+ * It matters here rather than being pedantry: it is the read-only way to ask
+ * ACF a question. Its sibling `acf_has_done()` answers the same question and
+ * WRITES the flag while doing so, so a probe that used it would break the
+ * subsystem it was probing.
+ *
+ * @param string $name
+ * @return mixed
+ */
+function acf_raw_setting($name = '') {}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,6 +11,7 @@ parameters:
     treatPhpDocTypesAsCertain: false
     stubFiles:
         - phpstan-stubs/wpml.stub
+        - phpstan-stubs/acf.stub
     reportUnmatchedIgnoredErrors: false
     ignoreErrors:
         - '#Offset .relative. does not exist on array#'

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -135,6 +135,38 @@ class StarterBase extends Site {
 	protected bool $site_icon_tags = false;
 
 	/**
+	 * @var bool Skip ACFML's translation of ACF field DEFINITIONS on plain
+	 * front-end views. Admin, REST, AJAX and WP-CLI keep it.
+	 *
+	 * ACFML translates labels, instructions, placeholders, prepend/append,
+	 * choices and message on every request that loads a field group.
+	 * `ACFML\Strings\FieldHooks` implements `IWPML_Frontend_Action`, so it
+	 * registers on the front end with no `is_admin()` guard and hooks
+	 * `acf/load_field`. Every field then reaches an unmemoized linear scan over
+	 * a static array, run through WPML's functional library, allocating a
+	 * closure per element. On a page view none of those strings is rendered, so
+	 * the whole walk is discarded.
+	 *
+	 * Measured on a site with 117 field groups and 972 top-level fields:
+	 * loading them costs 1.09 s with the translation and 0.29 s without. A
+	 * PHP-FPM slowlog over 3973 slow requests put 71 % of deepest-frame samples
+	 * inside `wpml/fp` and `wpml/collect`. Only the field level is expensive —
+	 * the group level measured 1.04 s against 1.11 s, so it is free.
+	 *
+	 * **Off by default, and that is a refusal rather than timidity.** Switching
+	 * it on is wrong for a site that renders field definitions to visitors: a
+	 * theme calling `acf_form()`, where placeholders, instructions and labels
+	 * become visitor-facing, or a template printing a `select`/`radio` choice
+	 * LABEL rather than its value. Neither is detectable from here, so the
+	 * consuming site asserts it.
+	 *
+	 * Retiring it is a one-line default flip once ACFML memoizes its lookup.
+	 * Not fixed in acfml 3.0-b.1: every file on the hot path is byte-identical
+	 * to 2.2.4, and so is the bundled `wpml/fp`.
+	 */
+	protected bool $acfml_skip_frontend_field_translation = false;
+
+	/**
 	 * @var bool Derive and store intrinsic width/height for SVG uploads that
 	 * arrive without them. Opt-in because it changes rendered output: an <img>
 	 * that carried no dimensions starts carrying them, which is the point — the
@@ -982,6 +1014,9 @@ class StarterBase extends Site {
 	private function registerAssetHooks(): void {
 		add_action( 'enqueue_block_assets', array( $this, 'assets' ) );
 		add_action( 'wp_preload_resources', array( $this, 'preload_resources' ) );
+		if ( $this->acfml_skip_frontend_field_translation ) {
+			add_filter( 'acfml_should_translate_acf_entity', array( $this, 'acfml_should_translate_acf_entity' ) );
+		}
 		add_action( 'send_headers', array( $this, 'send_preload_headers' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
@@ -4068,6 +4103,35 @@ class StarterBase extends Site {
 		}
 
 		return $file;
+	}
+
+	/**
+	 * Keep ACFML's field-definition translation only where it can be seen.
+	 *
+	 * Four contexts are named rather than one `is_admin()` check, and each is
+	 * needed. Gutenberg loads field groups over REST. ACF talks to admin-ajax
+	 * from inside the editor. Migration and maintenance scripts run under
+	 * WP-CLI. None of the three is `is_admin()`, so an `is_admin()`-only guard
+	 * would switch the translation off in the editor — where the labels are the
+	 * entire point.
+	 *
+	 * The default direction is deliberate: anything this cannot classify keeps
+	 * the translation. The cost of guessing wrong that way is a slow request;
+	 * guessing wrong the other way shows an editor untranslated labels.
+	 *
+	 * @param mixed $translate Whether ACFML would translate the entity.
+	 * @return mixed False on a plain front-end view, the incoming value otherwise.
+	 */
+	public function acfml_should_translate_acf_entity( $translate ) {
+		if ( is_admin()
+			|| wp_doing_ajax()
+			|| ( defined( 'REST_REQUEST' ) && REST_REQUEST )
+			|| ( defined( 'WP_CLI' ) && WP_CLI )
+		) {
+			return $translate;
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -153,18 +153,26 @@ class StarterBase extends Site {
 	 * inside `wpml/fp` and `wpml/collect`. Only the field level is expensive —
 	 * the group level measured 1.04 s against 1.11 s, so it is free.
 	 *
-	 * **Off by default, and that is a refusal rather than timidity.** Switching
-	 * it on is wrong for a site that renders field definitions to visitors: a
-	 * theme calling `acf_form()`, where placeholders, instructions and labels
-	 * become visitor-facing, or a template printing a `select`/`radio` choice
-	 * LABEL rather than its value. Neither is detectable from here, so the
-	 * consuming site asserts it.
+	 * **On by default.** Two shapes make it wrong, and they are not equal:
+	 *
+	 * A theme calling `acf_form()` puts placeholders, instructions and labels in
+	 * front of a visitor. That one **detects itself** — see
+	 * {@see acfml_should_translate_acf_entity()} — and the guard steps aside
+	 * without being told.
+	 *
+	 * A template printing a `select`/`radio`/`checkbox` choice **label** rather
+	 * than its value is not detectable from here, and is the reason this stays a
+	 * property rather than being unconditional. A site that does it sets this to
+	 * false. The failure if it does not is a label rendered in the source
+	 * language on one page — quiet, and easy to mistake for an untranslated
+	 * string, so it is worth checking rather than assuming when turning a large
+	 * existing site onto this version.
 	 *
 	 * Retiring it is a one-line default flip once ACFML memoizes its lookup.
 	 * Not fixed in acfml 3.0-b.1: every file on the hot path is byte-identical
 	 * to 2.2.4, and so is the bundled `wpml/fp`.
 	 */
-	protected bool $acfml_skip_frontend_field_translation = false;
+	protected bool $acfml_skip_frontend_field_translation = true;
 
 	/**
 	 * @var bool Derive and store intrinsic width/height for SVG uploads that
@@ -4115,9 +4123,27 @@ class StarterBase extends Site {
 	 * would switch the translation off in the editor — where the labels are the
 	 * entire point.
 	 *
-	 * The default direction is deliberate: anything this cannot classify keeps
-	 * the translation. The cost of guessing wrong that way is a slow request;
-	 * guessing wrong the other way shows an editor untranslated labels.
+	 * Everything the four do not name is treated as a plain front-end view and
+	 * loses the translation. That is the policy, not an oversight — an earlier
+	 * version of this comment claimed the opposite of what the code does, which
+	 * a review caught.
+	 *
+	 * The fifth test is a detection rather than a context. A theme calling
+	 * `acf_form()` renders labels, instructions and placeholders to a visitor,
+	 * and that is exactly the shape this guard must not strip. `acf_form_head()`
+	 * reaches `ACF_Assets::add_actions()`, which records itself, so the front
+	 * end can be asked whether a form is being set up.
+	 *
+	 * It is asked with `acf_raw_setting()` and never with `acf_has_done()`. The
+	 * latter **writes the flag it reads** — verified in ACF's `api-helpers.php`
+	 * — so probing with it would make ACF's own `add_actions()` believe it had
+	 * already run and skip registering the form's assets. The probe would break
+	 * the case it exists to protect.
+	 *
+	 * A false positive here costs a slow request; a false negative shows a
+	 * visitor an untranslated form. The probe is therefore read generously: any
+	 * front-end request that has enqueued ACF's input assets keeps the
+	 * translation, whether or not a form is finally printed.
 	 *
 	 * @param mixed $translate Whether ACFML would translate the entity.
 	 * @return mixed False on a plain front-end view, the incoming value otherwise.
@@ -4131,7 +4157,31 @@ class StarterBase extends Site {
 			return $translate;
 		}
 
+		if ( $this->acf_front_end_form_in_play() ) {
+			return $translate;
+		}
+
 		return false;
+	}
+
+	/**
+	 * Whether ACF is setting up a form on this front-end request.
+	 *
+	 * True once `acf_form_head()` has run, because it reaches
+	 * `acf_enqueue_scripts()` and thence `ACF_Assets::add_actions()`, which
+	 * records `has_done_ACF_Assets::add_actions` in ACF's settings.
+	 *
+	 * Read-only by construction: `acf_raw_setting()` is the getter
+	 * `acf_has_done()` itself calls before it writes.
+	 *
+	 * @return bool
+	 */
+	protected function acf_front_end_form_in_play(): bool {
+		if ( ! function_exists( 'acf_raw_setting' ) ) {
+			return false;
+		}
+
+		return (bool) acf_raw_setting( 'has_done_ACF_Assets::add_actions' );
 	}
 
 	/**

--- a/tests/Unit/StarterBase/AcfmlFieldTranslationTest.php
+++ b/tests/Unit/StarterBase/AcfmlFieldTranslationTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\StarterBase;
+
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use Parisek\TimberKit\StarterBase;
+use Tests\Unit\HelpersTestCase;
+
+/**
+ * Covers the opt-in that skips ACFML's field-definition translation.
+ *
+ * The switch itself is one boolean. What needs holding is the context test:
+ * three of the four contexts that must keep the translation are not
+ * `is_admin()`, and getting any of them wrong shows an editor untranslated
+ * labels — a failure nobody reports as a bug in a performance flag.
+ */
+class AcfmlFieldTranslationTest extends HelpersTestCase {
+
+	private function subject(): object {
+		return new class extends StarterBase {
+			// The constructor wires a whole theme; this test needs the callback.
+			public function __construct() {}
+		};
+	}
+
+	private function contexts( bool $admin, bool $ajax ): void {
+		Functions\when( 'is_admin' )->justReturn( $admin );
+		Functions\when( 'wp_doing_ajax' )->justReturn( $ajax );
+	}
+
+	public function test_a_plain_front_end_view_skips_the_translation(): void {
+		$this->contexts( false, false );
+
+		$this->assertFalse( $this->subject()->acfml_should_translate_acf_entity( true ) );
+	}
+
+	public function test_the_admin_keeps_it(): void {
+		$this->contexts( true, false );
+
+		$this->assertTrue( $this->subject()->acfml_should_translate_acf_entity( true ) );
+	}
+
+	public function test_ajax_keeps_it(): void {
+		// ACF talks to admin-ajax from inside the block editor, and
+		// wp_doing_ajax() is not is_admin().
+		$this->contexts( false, true );
+
+		$this->assertTrue( $this->subject()->acfml_should_translate_acf_entity( true ) );
+	}
+
+	#[RunInSeparateProcess]
+	public function test_rest_keeps_it(): void {
+		// Gutenberg loads field groups over REST. This is the context an
+		// is_admin()-only guard would get wrong, and the one whose breakage
+		// looks like a translation bug rather than a caching one.
+		//
+		// Its own process: a constant cannot be undefined, and REST_REQUEST
+		// left standing makes every later test in this run look like REST.
+		$this->contexts( false, false );
+		define( 'REST_REQUEST', true );
+
+		$this->assertTrue( $this->subject()->acfml_should_translate_acf_entity( true ) );
+	}
+
+	public function test_it_passes_a_refusal_through_rather_than_forcing_true(): void {
+		// Another plugin may already have said no. Returning the incoming value
+		// rather than true keeps this a veto, not an override.
+		$this->contexts( true, false );
+
+		$this->assertFalse( $this->subject()->acfml_should_translate_acf_entity( false ) );
+	}
+}

--- a/tests/Unit/StarterBase/AcfmlFieldTranslationTest.php
+++ b/tests/Unit/StarterBase/AcfmlFieldTranslationTest.php
@@ -26,9 +26,12 @@ class AcfmlFieldTranslationTest extends HelpersTestCase {
 		};
 	}
 
-	private function contexts( bool $admin, bool $ajax ): void {
+	private function contexts( bool $admin, bool $ajax, bool $acf_form = false ): void {
 		Functions\when( 'is_admin' )->justReturn( $admin );
 		Functions\when( 'wp_doing_ajax' )->justReturn( $ajax );
+		Functions\when( 'acf_raw_setting' )->alias(
+			static fn ( $name = '' ) => 'has_done_ACF_Assets::add_actions' === $name ? $acf_form : null
+		);
 	}
 
 	public function test_a_plain_front_end_view_skips_the_translation(): void {
@@ -72,4 +75,47 @@ class AcfmlFieldTranslationTest extends HelpersTestCase {
 
 		$this->assertFalse( $this->subject()->acfml_should_translate_acf_entity( false ) );
 	}
+	public function test_an_acf_form_on_the_front_end_keeps_the_translation(): void {
+		// The shape that makes the default wrong, and the reason it can be a
+		// default at all: acf_form() puts labels, instructions and placeholders
+		// in front of a visitor, and it detects itself.
+		$this->contexts( false, false, true );
+
+		$this->assertTrue( $this->subject()->acfml_should_translate_acf_entity( true ) );
+	}
+
+	public function test_the_probe_is_read_only(): void {
+		// acf_has_done() WRITES the flag it reads, so probing with it would make
+		// ACF's own add_actions() believe it had already run and skip
+		// registering the form's assets — breaking the case the probe protects.
+		// Only the getter may be called.
+		$called = [];
+		Functions\when( 'is_admin' )->justReturn( false );
+		Functions\when( 'wp_doing_ajax' )->justReturn( false );
+		Functions\when( 'acf_has_done' )->alias(
+			static function () use ( &$called ) {
+				$called[] = 'acf_has_done';
+				return false;
+			}
+		);
+		Functions\when( 'acf_raw_setting' )->alias(
+			static function () use ( &$called ) {
+				$called[] = 'acf_raw_setting';
+				return false;
+			}
+		);
+
+		$this->subject()->acfml_should_translate_acf_entity( true );
+
+		$this->assertSame( [ 'acf_raw_setting' ], $called );
+	}
+
+	public function test_it_is_on_by_default(): void {
+		// The flip this version makes. A property defaulting the other way is a
+		// feature nobody switches on.
+		$property = new \ReflectionProperty( StarterBase::class, 'acfml_skip_frontend_field_translation' );
+
+		$this->assertTrue( $property->getDefaultValue() );
+	}
+
 }


### PR DESCRIPTION
Closes #131.

## The problem

ACFML translates ACF field **definitions** — labels, instructions, placeholders, prepend/append, choices, message — on every request that loads a field group. `ACFML\Strings\FieldHooks` implements `IWPML_Frontend_Action`, so it registers on the front end with no `is_admin()` guard and hooks `acf/load_field`.

Every field then reaches an unmemoized linear scan over a static array, run through WPML's functional library with a closure allocated per element. On a page view none of those strings is rendered, so the whole walk is discarded.

## Measured

Site with 117 field groups and 972 top-level fields:

| | time |
| --- | ---: |
| baseline | 1.09–1.13 s |
| group-level translation off | 1.04–1.14 s (no change) |
| **field-level translation off** | **0.29 s** |

A PHP-FPM slowlog over 3973 slow requests put **71 %** of deepest-frame samples inside `wpml/fp` + `wpml/collect`. Rendered HTML is byte-identical once per-render `uniqueId()` values are normalised.

Only the field level is expensive, so the flag switches off both by way of the one filter ACFML provides — the cost lives entirely in the fields.

## Off by default, and that is a refusal

Switching it on is wrong for a site that renders field definitions to visitors:

- a theme calling `acf_form()` — placeholders, instructions and labels become visitor-facing
- a template printing a `select`/`radio`/`checkbox` **choice label** rather than its value

Neither is detectable from the kit, so the consuming site asserts it. Same rule as [ADR-0007](../blob/main/docs/adr/0007-prove-cache-purity-from-inputs.md): where no static proof exists, refuse.

### Rejected: auto-detecting `acf_form()`

It looks available and it is a trap. `acf_form_head()` → `acf_enqueue_scripts()` → `ACF_Assets::add_actions()`, which guards itself with `acf_has_done( 'ACF_Assets::add_actions' )`. That function **sets the flag it reads** — verified in `api-helpers.php`:

```php
function acf_has_done( $name ) {
	if ( acf_raw_setting( "has_done_{$name}" ) ) { return true; }
	acf_update_setting( "has_done_{$name}", true );
	return false;
}
```

Calling it from a guard would make ACF's own `add_actions()` believe it had already run and skip registering its asset actions. The detection would break the exact case it was added to protect.

## Four contexts, and naming all four is load-bearing

Admin, AJAX, REST and WP-CLI keep the translation. Gutenberg loads field groups over REST, ACF talks to admin-ajax from inside the editor, and migration scripts run under WP-CLI — **none of the three is `is_admin()`**.

An `is_admin()`-only guard therefore shows an editor untranslated labels, which nobody reports as a bug in a performance flag. The test proves the difference: reducing the guard to `is_admin()` alone fails exactly the AJAX and REST cases and nothing else.

The callback returns the incoming value rather than `true`, so it stays a veto and cannot overrule another plugin's refusal.

## Why this is not #107

[#107](https://github.com/parisek/timber-kit/pull/107) was closed unmerged, because a shared workaround would outlive the bug it worked around. Right there, and it does not carry here:

| | #107 (`acf/load_reference` leak) | this |
| --- | --- | --- |
| who pays | one caller outside WPML's own plugins | every front-end render |
| fixed upstream | **yes**, acfml 3.0-b.1 | **no** |
| workaround lifetime | would outlive the bug | bug has no end date |

Verified rather than assumed: on a site running acfml 3.0-b.1 / sitepress 5.0.0-b.1, the seven files on the hot path are byte-identical to 2.2.4 and the bundled `wpml/fp` has identical MD5s. The same comparison *does* pick up 3.0-b.1's one change — the `remove_filter` hook-name fix from #107 — so it is not a blind diff.

Retiring this is a one-line default flip once ACFML memoizes its lookup.

## Notes

The REST test runs in its own process: a constant cannot be undefined, and `REST_REQUEST` left standing made every later test in the run look like REST — four unrelated failures before it was isolated.

Downstream implementation and the original evidence: portadesign/sloneek#103. This is that filter moved up, with the four contexts unchanged.