### PR TITLE
docs(changelog): restore the 1.43.0 entry for the cached-derivative fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -389,6 +389,36 @@ mid-process must call `Helpers::flushFieldGroups()` itself.
 A screen `wp_json_encode()` cannot encode is never memoized, because casting
 `false` to a string would collapse every such screen onto one key.
 
+### Fixed
+
+- `StarterBase::cleanup_cached_images()` deleted resizer derivatives that other
+  attachments were still using. The cache under `wp-content/cache/image` is
+  keyed by file, but one file routinely carries several attachment rows: WPML
+  writes one per language, and a duplicate upload can be pointed at a path that
+  already exists. Deleting any one of those rows wiped the shared derivatives,
+  and the site then regenerated them — or, where the encoder was broken, served
+  a damaged image.
+
+  Measured on a five-language site: 5542 files were shared by 25981 attachment
+  rows, so roughly four fifths of the media library could take a live image
+  down with it. The homepage hero lost its derivatives while five attachment
+  rows and the rendered page still referenced them.
+
+  The delete now runs only when no other attachment points at the same
+  `_wp_attached_file`. It fails closed: where that question cannot be answered
+  the files are kept, because a stale derivative is overwritten by the next
+  resize while one deleted in error vanishes from a page still serving it.
+  "Cannot be answered" covers a missing `$wpdb`, an empty `_wp_attached_file`
+  (a filter supplied the path, so siblings have no key to match on), and a
+  failed query — `get_var()` reports an error by returning null, which casts to
+  the same zero a genuine "no siblings" answer gives, so the null and
+  `last_error` are both checked rather than read as a count.
+
+  Not fixed here, and tracked separately: two different files that share a
+  basename across upload-year folders still collide in the flat cache
+  namespace, so deleting one can remove the other's derivative. That needs a
+  cache-naming change, not a guard.
+
 ## [1.42.0] - 2026-08-26
 
   310 calls covered **33 distinct URLs** — the same menu and options-page links


### PR DESCRIPTION
## The record of a released fix is missing

#152 fixed `StarterBase::cleanup_cached_images()` deleting derivatives that other attachments still used. It merged as `920890f` with a 30-line `### Fixed` entry in Unreleased, and **1.43.0 shipped the fix**.

That entry is in no release section on `main` today, and not in Unreleased. A shipped fix has carried no changelog record since.

## What removed it

`b1ebbba` (#154, *run the backend and field-group probes once per request*). That PR was open across #152's merge; its changelog conflict was resolved by keeping its own side and dropping the other. The deletion is visible in its diff — 26 removed lines, the whole entry, no replacement.

Worth naming the shape, because it will happen again: the conflict was in `## [Unreleased]`, where every open PR writes. Nothing about resolving it in favour of one side looks wrong at the time, and no check catches an entry that silently stops existing.

## The fix

Restored verbatim into **1.43.0** — the release containing `920890f` (`920890f` → `b1ebbba` → `cc5f6f7` → `4eb38eb` → `635d009 Release 1.43.0`). Placed after that section's `### Changed` prose, per Keep a Changelog ordering.

The text is the merged text, unedited, including its closing "Not fixed here, and tracked separately" paragraph. That paragraph was accurate when 1.43.0 shipped and describes a limitation the release genuinely had; #153 is the cache-naming change it points at. Rewriting it now would make the released section describe a state that release was not in.

Documentation only. No code, no behaviour.