### PR TITLE
test(media): close the three gaps left open on #152

### DIFF
--- a/tests/Unit/StarterBase/CleanupCachedImagesTest.php
+++ b/tests/Unit/StarterBase/CleanupCachedImagesTest.php
@@ -66,8 +66,21 @@ class CleanupCachedImagesTest extends StarterBaseTestCase {
 		$this->created = array_merge( $this->created, array_reverse( $missing ) );
 	}
 
+	/**
+	 * Create $path, and fail the test if it is already there.
+	 *
+	 * Ownership is then creation-based, not path-based: a fixture this run did
+	 * not make is never adopted, and so never removed by this run's teardown.
+	 * `x` decides that atomically, which `file_exists()` followed by a write
+	 * cannot -- a concurrent run can create the file between the two.
+	 */
 	private function seedFile( string $path ): void {
-		file_put_contents( $path, 'x' );
+		$handle = @fopen( $path, 'x' );
+		if ( false === $handle ) {
+			self::fail( "Fixture path already exists, so this run does not own it: {$path}" );
+		}
+		fwrite( $handle, 'x' );
+		fclose( $handle );
 		$this->created[] = $path;
 	}
 
@@ -152,11 +165,6 @@ class CleanupCachedImagesTest extends StarterBaseTestCase {
 	}
 
 	/**
-	 * Without a database the sibling question cannot be answered. Skipping the
-	 * delete leaves a stale file that the next resize overwrites; guessing wrong
-	 * in the other direction destroys an image that is still on the page.
-	 */
-	/**
 	 * A failed query answers nothing. `get_var()` returns null on error, and the
 	 * naive `(int) null > 0` reading of that is indistinguishable from a real
 	 * zero — which would delete the files on any transient database error.
@@ -203,6 +211,21 @@ class CleanupCachedImagesTest extends StarterBaseTestCase {
 		$wpdb = $GLOBALS['wpdb'];
 		$this->assertStringContainsString( "meta_key = '_wp_attached_file'", $wpdb->prepared_query );
 		$this->assertStringContainsString( 'post_id != %d', $wpdb->prepared_query );
+		$this->assertMatchesRegularExpression(
+			'/\bFROM\s+%i\b/i',
+			$wpdb->prepared_query,
+			'the table must be the %i placeholder, not a literal name the args then contradict'
+		);
+		// The stub hands the query back verbatim rather than substituting, so an
+		// argument list alone proves nothing about where each value lands. Pin the
+		// placeholders in order: `FROM wrong_table` would drop the `%i` and shift
+		// every remaining argument onto the wrong one.
+		preg_match_all( '/%[isd]/', $wpdb->prepared_query, $placeholders );
+		$this->assertSame(
+			[ '%i', '%s', '%d' ],
+			$placeholders[0],
+			'table, then shared path, then excluded row -- in that order'
+		);
 		$this->assertSame(
 			[ 'wp_postmeta', '2026/08/homepage-hero-desktop.webp', 59741 ],
 			$wpdb->prepare_args,
@@ -210,6 +233,11 @@ class CleanupCachedImagesTest extends StarterBaseTestCase {
 		);
 	}
 
+	/**
+	 * Without a database the sibling question cannot be answered. Skipping the
+	 * delete leaves a stale file that the next resize overwrites; guessing wrong
+	 * in the other direction destroys an image that is still on the page.
+	 */
 	public function test_keeps_derivatives_when_the_sibling_count_is_unavailable(): void {
 		$this->seedDerivatives();
 		Functions\when( 'get_attached_file' )->justReturn( '/var/www/wp-content/uploads/2026/08/homepage-hero-desktop.webp' );


### PR DESCRIPTION
Closes the three findings recorded as *Still open — deferred, not fixed* on [#152](https://github.com/parisek/timber-kit/pull/152#issuecomment-5435444714).

They were deferred because #153 was stacked on that branch and fixing them meant rebasing it. #153 is now rebased onto `main`, so the reason is gone.

**Tests and comments only. No production code.**

## 1. The SQL contract test did not pin where the table lands

It pinned the meta key, the `post_id != %d` exclusion and every argument — but the stub hands the query back verbatim instead of substituting, so an argument list proves nothing about *where* each value goes. `FROM wrong_table` passed the test while `wp_postmeta` still sat in the argument list.

Now asserts `FROM %i`, and pins the placeholder sequence `['%i', '%s', '%d']`. The sequence is the load-bearing half: dropping a placeholder shifts every remaining argument onto the wrong one, and only order catches that.

Verified by mutation — with the table written as a literal:

```
Failed asserting that 'SELECT COUNT(*) FROM wp_postmeta WHERE …'
matches PCRE pattern "/\bFROM\s+%i\b/i".
```

## 2. `seedFile()` owned paths, not files

Teardown removed only the test's own paths, but ownership was path-based rather than creation-based. A fixture a concurrent run had created was adopted by this run and then deleted by its teardown.

It now creates with `fopen($path, 'x')`, which fails atomically when the path exists. `file_exists()` followed by a write cannot close this — the other run can create the file between the two calls.

Verified by mutation. With a foreign fixture pre-planted, the test fails with

```
Fixture path already exists, so this run does not own it: …/homepage-hero-desktop.avif
```

and — the actual point — **the foreign file survives teardown**. Before this, it was deleted.

## 3. Two docblocks above one test method

PHP associates only the second with the method, so the first was dropped. The missing-database description belongs to the missing-database test and is moved there. Documentation only.

## Not addressed

The WP 6.2 floor for `%i`, which Codex suggested documenting. That is a README question about which cores are supported, not a defect in this test file, and it does not belong in the same change.

## Verification

Full suite green, PHPStan clean. Both behavioural fixes are mutation-verified above rather than asserted to work — an assertion that does not fail on the bug it targets is decoration.