### PR TITLE
chore(tests): drop calls PHP 8.5 deprecates for having no effect

### DIFF
--- a/src/Health/Image/BackendImageFormatProbe.php
+++ b/src/Health/Image/BackendImageFormatProbe.php
@@ -156,11 +156,9 @@ final class BackendImageFormatProbe implements ImageFormatProbe {
 		$source = imagecreatetruecolor( 16, 16 );
 
 		// Guarded, not assumed: under memory pressure GD returns false, and
-		// every call below is typed for GdImage. Without this the first one
-		// throws a TypeError, the finally block's imagedestroy( false ) throws
-		// a second one on the way out, and that escapes probe() and fatals the
-		// Site Health screen — a health check taking down the page that shows
-		// health.
+		// every call below is typed for GdImage, so the first one would throw
+		// a TypeError that escapes probe() and fatals the Site Health screen —
+		// a health check taking down the page that shows health.
 		if ( false === $source ) {
 			return self::VERDICT_NO_BACKEND;
 		}
@@ -191,22 +189,16 @@ final class BackendImageFormatProbe implements ImageFormatProbe {
 				return self::VERDICT_UNVERIFIED;
 			}
 
-			try {
-				imagesavealpha( $read, true );
+			imagesavealpha( $read, true );
 
-				// GD packs alpha into bits 24-30 on an inverted scale: 0 is
-				// opaque, 127 fully transparent. Normalise to opacity so both
-				// backends are judged by one threshold.
-				$packed = ( imagecolorat( $read, self::SAMPLE_X, self::SAMPLE_Y ) >> 24 ) & 0x7F;
+			// GD packs alpha into bits 24-30 on an inverted scale: 0 is
+			// opaque, 127 fully transparent. Normalise to opacity so both
+			// backends are judged by one threshold.
+			$packed = ( imagecolorat( $read, self::SAMPLE_X, self::SAMPLE_Y ) >> 24 ) & 0x7F;
 
-				return self::alphaVerdict( 1.0 - ( $packed / 127.0 ) );
-			} finally {
-				imagedestroy( $read );
-			}
+			return self::alphaVerdict( 1.0 - ( $packed / 127.0 ) );
 		} catch ( \Throwable $e ) {
 			return self::VERDICT_WRITE_FAILED;
-		} finally {
-			imagedestroy( $source );
 		}
 	}
 

--- a/src/Resizer.php
+++ b/src/Resizer.php
@@ -915,10 +915,6 @@ class Resizer {
 						// Use grid algorithm by default (better results)
 						$cropRect = $this->getEntropyCropByGridding( $edgeImage, $variant['width'], $variant['height'] );
 
-						// Clean up GD resources
-						imagedestroy( $edgeImage );
-						imagedestroy( $gdImage );
-
 						// Apply crop using Imagick with calculated coordinates
 						$imagick = new \Imagick( $source_path );
 						// Preserve transparency for PNG/GIF sources
@@ -933,7 +929,6 @@ class Resizer {
 						$imagick->destroy();
 					} else {
 						// Image is smaller than target, just resize without cropping
-						imagedestroy( $gdImage );
 						$imageGenerator->format( $target_format );
 						$imageGenerator->quality( $variant['quality'] );
 						$imageGenerator->save( $target_path );

--- a/tests/Unit/Breeze/WarmupSitemap/CuratedRecordsTest.php
+++ b/tests/Unit/Breeze/WarmupSitemap/CuratedRecordsTest.php
@@ -37,7 +37,6 @@ final class CuratedRecordsTest extends TestCase {
 	 */
 	private function append( array $records, array $manual ): array {
 		$method = new \ReflectionMethod( WarmupSitemap::class, 'appendMissingManual' );
-		$method->setAccessible( true );
 		return $method->invoke( null, $records, $manual );
 	}
 

--- a/tests/Unit/Health/Image/BackendImageFormatProbeTest.php
+++ b/tests/Unit/Health/Image/BackendImageFormatProbeTest.php
@@ -158,7 +158,6 @@ class BackendImageFormatProbeTest extends HealthTestCase {
 
 			return false;
 		} finally {
-			imagedestroy( $image );
 		}
 	}
 }

--- a/tests/Unit/Helpers/VideoCodecsHelperTest.php
+++ b/tests/Unit/Helpers/VideoCodecsHelperTest.php
@@ -18,7 +18,6 @@ class VideoCodecsHelperTest extends HelpersTestCase {
 	 */
 	private function appendVideoSources( array $row ): array {
 		$method = new \ReflectionMethod( Helpers::class, 'appendVideoSources' );
-		$method->setAccessible( true );
 
 		return $method->invoke( null, $row );
 	}

--- a/tests/Unit/Resizer/ProducedDimensionsAgainstEncoderTest.php
+++ b/tests/Unit/Resizer/ProducedDimensionsAgainstEncoderTest.php
@@ -63,7 +63,6 @@ class ProducedDimensionsAgainstEncoderTest extends TestCase {
 		$image = imagecreatetruecolor( $width, $height );
 		imagefilledrectangle( $image, 0, 0, $width, $height, imagecolorallocate( $image, 120, 90, 60 ) );
 		imagejpeg( $image, $path, 90 );
-		imagedestroy( $image );
 
 		return $path;
 	}

--- a/tests/Unit/StarterBase/BreezeWarmupPrioritySetupTest.php
+++ b/tests/Unit/StarterBase/BreezeWarmupPrioritySetupTest.php
@@ -101,7 +101,6 @@ class BreezeWarmupPrioritySetupTest extends TestCase {
 
 		$reflection      = new \ReflectionClass( WarmupSitemap::class );
 		$registeredHash  = $reflection->getProperty( 'weights_hash' );
-		$registeredHash->setAccessible( true );
 
 		$writeWouldStore = \Parisek\TimberKit\Breeze\Scorer::weightsHash( WarmupSitemap::weights() );
 

--- a/tests/Unit/StarterBase/ResizeUploadedImageTest.php
+++ b/tests/Unit/StarterBase/ResizeUploadedImageTest.php
@@ -223,7 +223,6 @@ class ResizeUploadedImageTest extends StarterBaseTestCase {
 		}
 
 		if ( PHP_VERSION_ID < 80500 ) {
-			imagedestroy( $image );
 		} else {
 			unset( $image );
 		}

--- a/tests/Unit/WpmlBlockOverride/FilterScenariosTest.php
+++ b/tests/Unit/WpmlBlockOverride/FilterScenariosTest.php
@@ -101,7 +101,6 @@ class FilterScenariosTest extends WpmlBlockOverrideTestCase {
 	/** Seed the copy-fields index so getCopyFields() resolves without ACF. */
 	private static function seedCopyFields( array $index ): void {
 		$r = new \ReflectionProperty( WpmlBlockOverride::class, 'copyFieldsIndex' );
-		$r->setAccessible( true );
 		$r->setValue( null, $index );
 	}
 

--- a/tests/Unit/WpmlBlockOverride/GetCopyFieldsIndexTest.php
+++ b/tests/Unit/WpmlBlockOverride/GetCopyFieldsIndexTest.php
@@ -67,7 +67,6 @@ class GetCopyFieldsIndexTest extends WpmlBlockOverrideTestCase {
 
 		// Confirm memo starts null (setUp already reset it).
 		$ref = new \ReflectionProperty( \Parisek\TimberKit\WpmlBlockOverride::class, 'copyFieldsIndex' );
-		$ref->setAccessible( true );
 		$this->assertNull( $ref->getValue(), 'memo starts null' );
 
 		// First call — should hit ACF functions and populate memo.
@@ -160,7 +159,6 @@ class GetCopyFieldsIndexTest extends WpmlBlockOverrideTestCase {
 
 		// Per-request memo SHOULD still be populated (avoids re-walk within one request).
 		$ref = new \ReflectionProperty( \Parisek\TimberKit\WpmlBlockOverride::class, 'copyFieldsIndex' );
-		$ref->setAccessible( true );
 		$this->assertIsArray( $ref->getValue(), 'per-request memo still populates under WP_DEBUG' );
 		$this->assertIsArray( $result );
 	}

--- a/tests/Unit/WpmlBlockOverrideTestCase.php
+++ b/tests/Unit/WpmlBlockOverrideTestCase.php
@@ -26,13 +26,11 @@ abstract class WpmlBlockOverrideTestCase extends TestCase {
 
 	private function resetMemo( string $property, mixed $value ): void {
 		$ref = new \ReflectionProperty( \Parisek\TimberKit\WpmlBlockOverride::class, $property );
-		$ref->setAccessible( true );
 		$ref->setValue( null, $value );
 	}
 
 	protected static function callPrivate( string $method, array $args ): mixed {
 		$ref = new \ReflectionMethod( \Parisek\TimberKit\WpmlBlockOverride::class, $method );
-		$ref->setAccessible( true );
 		return $ref->invoke( null, ...$args );
 	}
 }


### PR DESCRIPTION
Local PHP moved to 8.5, which deprecates two functions that have been no-ops for years. The suite reported **12 deprecations**; CI runs 8.3 and 8.4 and reports none, so this was invisible there.

The alternative was relinking the local PHP back to 8.3. That hides the warning rather than answering it, and 8.5 is worth running locally precisely because it surfaces this before CI has to.

## `setAccessible()` — 8 calls

No effect since PHP 8.1, deprecated in 8.5. The package requires `^8.3`, so nothing depended on them.

## `imagedestroy()` — 6 calls

No effect since PHP 8.0, deprecated in 8.5: GD handles are objects and are collected. Removed from `Resizer`'s smart-crop path, from `BackendImageFormatProbe`, and from three tests.

`BackendImageFormatProbe` needs a note. Its two `finally` blocks existed **only** to call `imagedestroy()`, so both are gone and the outer `catch` stays. The guard on a `false` from `imagecreatetruecolor()` also stays — the typed calls below it would still throw — but its comment no longer claims a second `TypeError` arrives from freeing `false` on the way out, because there is nothing left to free.

## Verification

1907 tests pass, PHPStan clean, **0 deprecations** on PHP 8.5.

One warning remains and is not ours: `patchwork`'s own cache directory races on `mkdir()` inside `vendor/`.