### PR TITLE
docs(starter-base): recommend a literal domain in breadcrumb labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+
+- `setup_breadcrumb_labels()` docblock now shows a **string literal** as the
+  `_x()` context and domain, and explains why. The previous example used
+  `$this->theme_name`, which resolves correctly at runtime but makes the
+  strings invisible to `wp i18n make-pot` — a variable cannot be resolved in
+  the context position, so those calls are skipped and the catalogue is written
+  without them. Nothing errors; the strings just never become translatable.
+  Measured on one theme: 11 strings extracted with the property form, 16 with
+  literals. Docblock only, no behaviour change. Reported in #165.
+
 ## [1.46.0] - 2026-08-31
 
 ### Added

--- a/src/StarterBase.php
+++ b/src/StarterBase.php
@@ -1603,13 +1603,34 @@ class StarterBase extends Site {
 	 *
 	 *     public function setup_breadcrumb_labels() {
 	 *         $this->breadcrumb_labels = array(
-	 *             'home'       => _x( 'Home', $this->theme_name, $this->theme_name ),
-	 *             '404'        => _x( 'Page not found', $this->theme_name, $this->theme_name ),
-	 *             'search'     => _x( 'Search: %s', $this->theme_name, $this->theme_name ),
-	 *             'pagination' => _x( 'Page %d', $this->theme_name, $this->theme_name ),
-	 *             'author'     => _x( 'Author: %s', $this->theme_name, $this->theme_name ),
+	 *             'home'       => _x( 'Home', 'my_theme', 'my_theme' ),
+	 *             '404'        => _x( 'Page not found', 'my_theme', 'my_theme' ),
+	 *             'search'     => _x( 'Search: %s', 'my_theme', 'my_theme' ),
+	 *             'pagination' => _x( 'Page %d', 'my_theme', 'my_theme' ),
+	 *             'author'     => _x( 'Author: %s', 'my_theme', 'my_theme' ),
 	 *         );
 	 *     }
+	 *
+	 * **Use a string literal, not `$this->theme_name`.** The property holds the
+	 * right value and resolves correctly at runtime, so the property form looks
+	 * equivalent and survives a theme rename without edits. It is not
+	 * equivalent: `wp i18n make-pot` cannot resolve a variable in the context
+	 * or domain position, so it skips those calls entirely and writes a
+	 * catalogue without them. Nothing fails — the strings simply never become
+	 * translatable, and each renders as its English source with a 200 response.
+	 *
+	 * Measured on one theme, same command, only the argument form differing:
+	 * 11 strings extracted with the property, 16 with literals, the five
+	 * missing ones being exactly this set. An explicit `--domain` does not
+	 * help; the context argument is the blocker.
+	 *
+	 * The costs are asymmetric. A literal costs a few mechanical, greppable
+	 * edits once, when a theme is renamed. The property costs hand-maintenance
+	 * of the catalogue for every string added afterwards, permanently. Prefer
+	 * the property only in a project that does not extract PHP strings at all.
+	 *
+	 * WPCS flags a non-literal here (`WordPress.WP.I18n.NonSingularStringLiteral*`),
+	 * which is the same rule pointing at the same problem from the lint side.
 	 *
 	 * Hooked to `init` (priority 1).
 	 *


### PR DESCRIPTION
Closes #165.

## Why

The `setup_breadcrumb_labels()` example passed `$this->theme_name` as the `_x()` context and domain. The property holds the right value and resolves correctly at runtime, so the form looks equivalent to a literal — with the obvious advantage of surviving a theme rename untouched.

It is not equivalent. `wp i18n make-pot` cannot resolve a variable in the context or domain position, so it skips those calls and writes a catalogue without them.

Nothing errors. The strings never become translatable, and each renders as its English source with a 200 response. A consumer following the example gets five permanently untranslated labels and no signal anywhere.

## Measurement

Same theme, same command, only the argument form differing:

| Form | Strings extracted | `Page not found` present |
| --- | --- | --- |
| `$this->theme_name` | 11 | **no** |
| `'my_theme'` literal | 16 | yes |

The five missing strings are exactly this set. An explicit `--domain` does not help — the **context** argument is the blocker.

## What

The example now uses a literal, and the docblock states the trade-off, because the asymmetry is invisible at the call site:

- a **literal** costs a few mechanical, greppable edits **once**, when a theme is renamed
- the **property** costs hand-maintenance of the catalogue for every string added afterwards, **permanently**

The property stays reasonable for a project that does not extract PHP strings at all, and the docblock says so rather than forbidding it.

Also noted in the docblock: WPCS already flags a non-literal here (`WordPress.WP.I18n.NonSingularStringLiteral*`) — the same problem seen from the lint side, which is worth connecting for a reader who hits the sniff and reaches for an exclude.

## Scope

Docblock and `CHANGELOG.md` only. No behaviour change.

`composer check` green, `composer test` green (1970 tests, 3224 assertions).
